### PR TITLE
docs: add operator documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,88 @@
 # cloudflare-operator
-// TODO(user): Add simple overview of use/purpose
 
-## Description
-// TODO(user): An in-depth paragraph about your project and overview of use
+A Kubernetes operator that manages Cloudflare resources declaratively using Custom Resources. Define DNS records, tunnels, WAF rulesets, zone settings, and zone lifecycle as Kubernetes objects with automatic drift detection and reconciliation.
 
-## Getting Started
+## Custom Resources
+
+| CRD | Description |
+|-----|-------------|
+| `CloudflareZone` | Onboard and manage domain lifecycle (create, adopt, activate, delete) |
+| `CloudflareDNSRecord` | Manage DNS records (A, AAAA, CNAME, SRV, MX, TXT, NS) with dynamic IP support |
+| `CloudflareTunnel` | Create and manage Cloudflare Tunnels with auto-generated credentials |
+| `CloudflareZoneConfig` | Declaratively configure zone settings (SSL, security, performance, network) |
+| `CloudflareRuleset` | Manage WAF rulesets and firewall rules across 14+ phases |
+
+## Quick Start
 
 ### Prerequisites
-- go version v1.24.6+
-- docker version 17.03+.
-- kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
 
-### To Deploy on the cluster
-**Build and push your image to the location specified by `IMG`:**
+- Kubernetes cluster v1.11.3+
+- kubectl configured
+- Cloudflare API token with appropriate permissions
 
-```sh
-make docker-build docker-push IMG=<some-registry>/cloudflare-operator:tag
-```
-
-**NOTE:** This image ought to be published in the personal registry you specified.
-And it is required to have access to pull the image from the working environment.
-Make sure you have the proper permission to the registry if the above commands don’t work.
-
-**Install the CRDs into the cluster:**
+### Install
 
 ```sh
+# Install CRDs
 make install
+
+# Deploy the operator
+make deploy IMG=<your-registry>/cloudflare-operator:latest
 ```
 
-**Deploy the Manager to the cluster with the image specified by `IMG`:**
+### Create a Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-token
+type: Opaque
+stringData:
+  apiToken: "<your-cloudflare-api-token>"
+```
+
+### Create a DNS Record
+
+```yaml
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareDNSRecord
+metadata:
+  name: my-record
+spec:
+  zoneID: "<zone-id>"
+  name: "app.example.com"
+  type: A
+  dynamicIP: true
+  proxied: true
+  ttl: 1
+  interval: 5m
+  secretRef:
+    name: cloudflare-api-token
+```
+
+### Verify
 
 ```sh
-make deploy IMG=<some-registry>/cloudflare-operator:tag
+kubectl get cloudflarednsrecords
+kubectl get cloudflarezones
+kubectl get cloudflaretunnels
+kubectl get cloudflarerulesets
+kubectl get cloudflarezoneconfigs
 ```
 
-> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin.
-
-**Create instances of your solution**
-You can apply the samples (examples) from the config/sample:
+## Uninstall
 
 ```sh
-kubectl apply -k config/samples/
+kubectl delete -k config/samples/   # Remove CRs
+make uninstall                       # Remove CRDs
+make undeploy                        # Remove operator
 ```
 
->**NOTE**: Ensure that the samples has default values to test it out.
+## Documentation
 
-### To Uninstall
-**Delete the instances (CRs) from the cluster:**
-
-```sh
-kubectl delete -k config/samples/
-```
-
-**Delete the APIs(CRDs) from the cluster:**
-
-```sh
-make uninstall
-```
-
-**UnDeploy the controller from the cluster:**
-
-```sh
-make undeploy
-```
-
-## Project Distribution
-
-Following the options to release and provide this solution to the users.
-
-### By providing a bundle with all YAML files
-
-1. Build the installer for the image built and published in the registry:
-
-```sh
-make build-installer IMG=<some-registry>/cloudflare-operator:tag
-```
-
-**NOTE:** The makefile target mentioned above generates an 'install.yaml'
-file in the dist directory. This file contains all the resources built
-with Kustomize, which are necessary to install this project without its
-dependencies.
-
-2. Using the installer
-
-Users can just run 'kubectl apply -f <URL for YAML BUNDLE>' to install
-the project, i.e.:
-
-```sh
-kubectl apply -f https://raw.githubusercontent.com/<org>/cloudflare-operator/<tag or branch>/dist/install.yaml
-```
-
-### By providing a Helm Chart
-
-1. Build the chart using the optional helm plugin
-
-```sh
-kubebuilder edit --plugins=helm/v2-alpha
-```
-
-2. See that a chart was generated under 'dist/chart', and users
-can obtain this solution from there.
-
-**NOTE:** If you change the project, you need to update the Helm Chart
-using the same command above to sync the latest changes. Furthermore,
-if you create webhooks, you need to use the above command with
-the '--force' flag and manually ensure that any custom configuration
-previously added to 'dist/chart/values.yaml' or 'dist/chart/manager/manager.yaml'
-is manually re-applied afterwards.
-
-## Contributing
-// TODO(user): Add detailed information on how you would like others to contribute to this project
-
-**NOTE:** Run `make help` for more information on all potential `make` targets
-
-More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
+Full documentation including all CRD specifications, configuration options, and examples is available at [docs/README.md](docs/README.md).
 
 ## License
 
-Copyright 2026.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
+Copyright 2026. Licensed under the Apache License, Version 2.0. See [LICENSE](http://www.apache.org/licenses/LICENSE-2.0) for details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,500 @@
+# cloudflare-operator Documentation
+
+A Kubernetes operator for managing Cloudflare resources declaratively. All resources use the API group `cloudflare.io/v1alpha1`.
+
+## Table of Contents
+
+- [Authentication](#authentication)
+- [CloudflareZone](#cloudflarezone)
+- [CloudflareDNSRecord](#cloudflarednsrecord)
+- [CloudflareTunnel](#cloudflaretunnel)
+- [CloudflareZoneConfig](#cloudflarezoneconfig)
+- [CloudflareRuleset](#cloudflareruleset)
+- [Common Patterns](#common-patterns)
+
+---
+
+## Authentication
+
+All resources reference a Kubernetes Secret containing a Cloudflare API token:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-token
+type: Opaque
+stringData:
+  apiToken: "<your-cloudflare-api-token>"
+```
+
+Reference this secret in any resource via `secretRef`:
+
+```yaml
+secretRef:
+  name: cloudflare-api-token
+```
+
+### Required API Token Permissions
+
+| Resource | Permissions |
+|----------|-------------|
+| `CloudflareZone` | Zone:Edit, Zone:Read |
+| `CloudflareDNSRecord` | DNS:Edit, Zone:Read |
+| `CloudflareTunnel` | Argo Tunnel:Edit, Account Settings:Read |
+| `CloudflareZoneConfig` | Zone Settings:Edit, Zone:Read |
+| `CloudflareRuleset` | Zone WAF:Edit, Zone:Read |
+
+---
+
+## CloudflareZone
+
+Manages domain lifecycle in Cloudflare: onboarding new domains, adopting existing ones, tracking activation status, and optional deletion.
+
+### Spec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | | Domain name (e.g., `example.com`) |
+| `accountID` | string | Yes | | Cloudflare Account ID |
+| `type` | enum | No | `full` | Zone type: `full`, `partial`, `secondary` |
+| `paused` | bool | No | | Pause zone (stop serving traffic through Cloudflare) |
+| `deletionPolicy` | enum | No | `Retain` | `Retain` leaves zone in CF on CR deletion; `Delete` removes it |
+| `secretRef` | object | Yes | | Reference to API token Secret |
+| `interval` | duration | No | `30m` | Reconciliation interval |
+
+### Status
+
+| Field | Description |
+|-------|-------------|
+| `zoneID` | Cloudflare Zone ID |
+| `status` | Zone status: `initializing`, `pending`, `active`, `moved` |
+| `nameServers` | Cloudflare-assigned nameservers |
+| `originalNameServers` | Nameservers before migration |
+| `originalRegistrar` | Registrar at onboarding time |
+| `activatedOn` | Timestamp when zone became active |
+
+### Behavior
+
+- **Adoption**: If a zone with the same domain already exists in the account, the operator adopts it rather than creating a duplicate.
+- **Activation polling**: While `pending`, the operator triggers activation checks and requeues every 5 minutes for faster detection.
+- **Ready condition**: `Ready=True` only when zone status is `active`. While `pending`, the condition message includes the nameservers to configure at your registrar.
+- **Deletion policy**: `Retain` (default) removes the finalizer without touching Cloudflare. `Delete` actively removes the zone.
+
+### Example
+
+```yaml
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareZone
+metadata:
+  name: my-domain
+spec:
+  name: "example.com"
+  accountID: "<account-id>"
+  type: "full"
+  deletionPolicy: Retain
+  interval: 30m
+  secretRef:
+    name: cloudflare-api-token
+```
+
+### Print Columns
+
+```
+NAME        DOMAIN        ZONE ID       STATUS    READY   AGE
+my-domain   example.com   abc123...     active    True    5d
+```
+
+---
+
+## CloudflareDNSRecord
+
+Manages DNS records with support for dynamic IP resolution, SRV records, and automatic drift detection.
+
+### Spec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `zoneID` | string | Yes | | Cloudflare Zone ID |
+| `name` | string | Yes | | Record name (e.g., `sub.example.com`) |
+| `type` | enum | Yes | | `A`, `AAAA`, `CNAME`, `SRV`, `MX`, `TXT`, `NS` |
+| `content` | string | No | | Record content. Mutually exclusive with `dynamicIP` |
+| `dynamicIP` | bool | No | `false` | Auto-resolve external IP (type A only). Mutually exclusive with `content` |
+| `ttl` | int | No | `1` | TTL in seconds. `1` = automatic |
+| `proxied` | bool | No | | Whether to proxy through Cloudflare |
+| `priority` | int | No | | Record priority (MX and SRV) |
+| `srvData` | object | No | | SRV-specific data (required when type is SRV) |
+| `secretRef` | object | Yes | | Reference to API token Secret |
+| `interval` | duration | No | `5m` | Reconciliation interval for drift detection |
+
+### SRV Data
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `service` | string | Yes | Service name (e.g., `_satisfactory`) |
+| `proto` | enum | Yes | Protocol: `_tcp`, `_udp`, `_tls` |
+| `priority` | int | Yes | SRV priority (0-65535) |
+| `weight` | int | Yes | SRV weight (0-65535) |
+| `port` | int | Yes | Target port (0-65535) |
+| `target` | string | Yes | Target hostname |
+
+### Status
+
+| Field | Description |
+|-------|-------------|
+| `recordID` | Cloudflare DNS Record ID |
+| `currentContent` | Current value of the record in Cloudflare |
+
+### Behavior
+
+- **Dynamic IP**: When `dynamicIP: true`, the operator resolves your external IP automatically and keeps the A record updated. Useful for home labs or environments with changing public IPs.
+- **Drift detection**: On each reconciliation interval, the operator compares the desired state with Cloudflare and corrects any drift.
+- **Record matching**: Finds existing records by name and type to avoid duplicates.
+
+### Examples
+
+```yaml
+# Dynamic IP A record
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareDNSRecord
+metadata:
+  name: root-a-record
+spec:
+  zoneID: "<zone-id>"
+  name: "example.com"
+  type: A
+  dynamicIP: true
+  proxied: true
+  ttl: 1
+  interval: 5m
+  secretRef:
+    name: cloudflare-api-token
+---
+# CNAME record
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareDNSRecord
+metadata:
+  name: app-cname
+spec:
+  zoneID: "<zone-id>"
+  name: "app.example.com"
+  type: CNAME
+  content: "example.com"
+  proxied: true
+  ttl: 1
+  secretRef:
+    name: cloudflare-api-token
+---
+# SRV record for game server
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareDNSRecord
+metadata:
+  name: game-srv
+spec:
+  zoneID: "<zone-id>"
+  name: "_game._udp.example.com"
+  type: SRV
+  srvData:
+    service: "_game"
+    proto: "_udp"
+    priority: 10
+    weight: 1
+    port: 7777
+    target: "game.example.com"
+  ttl: 1
+  secretRef:
+    name: cloudflare-api-token
+```
+
+### Print Columns
+
+```
+NAME           RECORD NAME       TYPE    CONTENT        PROXIED   READY   AGE
+root-a-record  example.com       A       203.0.113.1    true      True    5d
+app-cname      app.example.com   CNAME   example.com    true      True    5d
+```
+
+---
+
+## CloudflareTunnel
+
+Manages Cloudflare Tunnel lifecycle and auto-generates a credentials Secret for use with `cloudflared`.
+
+### Spec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | | Tunnel name in Cloudflare |
+| `accountID` | string | Yes | | Cloudflare Account ID |
+| `generatedSecretName` | string | Yes | | Name of the Secret to create with tunnel credentials |
+| `secretRef` | object | Yes | | Reference to API token Secret |
+| `interval` | duration | No | `30m` | Reconciliation interval |
+
+### Status
+
+| Field | Description |
+|-------|-------------|
+| `tunnelID` | Cloudflare Tunnel ID |
+| `tunnelCNAME` | Tunnel CNAME (`<tunnelID>.cfargotunnel.com`) |
+| `credentialsSecretName` | Name of the generated credentials Secret |
+
+### Behavior
+
+- **Credential generation**: Automatically creates a Kubernetes Secret containing `credentials.json` with the tunnel token. Use this Secret to configure `cloudflared` deployments.
+- **Tunnel CNAME**: The status exposes the tunnel CNAME, which you can use in DNS CNAME records to route traffic through the tunnel.
+- **Adoption**: If a tunnel with the same name exists, the operator adopts it.
+
+### Example
+
+```yaml
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareTunnel
+metadata:
+  name: k8s-tunnel
+spec:
+  name: k8s-external-ingress
+  accountID: "<account-id>"
+  generatedSecretName: cloudflare-tunnel-credentials
+  interval: 30m
+  secretRef:
+    name: cloudflare-api-token
+```
+
+### Print Columns
+
+```
+NAME         TUNNEL NAME           TUNNEL ID     CNAME                                   READY   AGE
+k8s-tunnel   k8s-external-ingress  abc123...     abc123.cfargotunnel.com                 True    5d
+```
+
+---
+
+## CloudflareZoneConfig
+
+Declaratively manages zone-level settings: SSL/TLS, security, performance, network, and bot management.
+
+### Spec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `zoneID` | string | Yes | | Cloudflare Zone ID |
+| `secretRef` | object | Yes | | Reference to API token Secret |
+| `interval` | duration | No | `30m` | Reconciliation interval |
+| `ssl` | object | No | | SSL/TLS settings |
+| `security` | object | No | | Security settings |
+| `performance` | object | No | | Performance settings |
+| `network` | object | No | | Network settings |
+| `botManagement` | object | No | | Bot management settings |
+
+### SSL Settings
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `mode` | `off`, `flexible`, `full`, `strict` | SSL mode |
+| `minTLSVersion` | `1.0`, `1.1`, `1.2`, `1.3` | Minimum TLS version |
+| `tls13` | `on`, `off`, `zrt` | TLS 1.3 setting |
+| `alwaysUseHTTPS` | `on`, `off` | Redirect HTTP to HTTPS |
+| `automaticHTTPSRewrites` | `on`, `off` | Rewrite HTTP URLs in content |
+| `opportunisticEncryption` | `on`, `off` | Opportunistic encryption |
+
+### Security Settings
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `securityLevel` | `essentially_off`, `low`, `medium`, `high`, `under_attack` | Security level |
+| `challengeTTL` | `300`-`86400` | Challenge TTL in seconds |
+| `browserCheck` | `on`, `off` | Browser integrity check |
+| `emailObfuscation` | `on`, `off` | Email address obfuscation |
+
+### Performance Settings
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `cacheLevel` | `aggressive`, `basic`, `simplified` | Cache level |
+| `browserCacheTTL` | int (0 = respect headers) | Browser cache TTL in seconds |
+| `brotli` | `on`, `off` | Brotli compression |
+| `earlyHints` | `on`, `off` | Early hints |
+| `http2` | `on`, `off` | HTTP/2 |
+| `http3` | `on`, `off` | HTTP/3 |
+| `polish` | `off`, `lossless`, `lossy` | Image optimization |
+| `minify.css` | `on`, `off` | CSS minification |
+| `minify.html` | `on`, `off` | HTML minification |
+| `minify.js` | `on`, `off` | JavaScript minification |
+
+### Network Settings
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `ipv6` | `on`, `off` | IPv6 support |
+| `websockets` | `on`, `off` | WebSocket support |
+| `pseudoIPv4` | `off`, `add_header`, `overwrite_header` | Pseudo IPv4 |
+| `ipGeolocation` | `on`, `off` | IP geolocation headers |
+| `opportunisticOnion` | `on`, `off` | Onion routing |
+
+### Bot Management Settings
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enableJS` | bool | JavaScript-based detection |
+| `fightMode` | bool | Bot fight mode |
+
+### Status
+
+| Field | Description |
+|-------|-------------|
+| `appliedSettings` | Count of settings applied |
+
+### Example
+
+```yaml
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareZoneConfig
+metadata:
+  name: zone-settings
+spec:
+  zoneID: "<zone-id>"
+  interval: 30m
+  secretRef:
+    name: cloudflare-api-token
+  ssl:
+    mode: "full"
+    minTLSVersion: "1.2"
+    alwaysUseHTTPS: "on"
+  security:
+    securityLevel: "medium"
+    browserCheck: "on"
+  performance:
+    cacheLevel: "aggressive"
+    brotli: "on"
+    http2: "on"
+    http3: "on"
+  network:
+    ipv6: "on"
+    websockets: "on"
+  botManagement:
+    fightMode: true
+```
+
+### Print Columns
+
+```
+NAME            ZONE ID       SETTINGS   READY   AGE
+zone-settings   abc123...     18         True    5d
+```
+
+---
+
+## CloudflareRuleset
+
+Manages Cloudflare WAF rulesets with support for 14+ phases and free-form action parameters.
+
+### Spec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `zoneID` | string | Yes | | Cloudflare Zone ID |
+| `name` | string | Yes | | Human-readable ruleset name |
+| `description` | string | No | | Ruleset description |
+| `phase` | enum | Yes | | Ruleset phase (see below) |
+| `rules` | array | Yes | | List of rules (min 1) |
+| `secretRef` | object | Yes | | Reference to API token Secret |
+| `interval` | duration | No | `30m` | Reconciliation interval |
+
+### Phases
+
+| Phase | Description |
+|-------|-------------|
+| `http_request_firewall_custom` | Custom firewall rules |
+| `http_request_firewall_managed` | Managed firewall rules |
+| `http_request_late_transform` | Late request transforms |
+| `http_request_redirect` | Redirects |
+| `http_request_transform` | Request transforms |
+| `http_response_headers_transform` | Response header transforms |
+| `http_response_firewall_managed` | Response firewall rules |
+| `http_config_settings` | Config settings |
+| `http_custom_errors` | Custom error pages |
+| `http_ratelimit` | Rate limiting |
+| `http_request_cache_settings` | Cache settings |
+| `http_request_origin` | Origin rules |
+| `http_request_dynamic_redirect` | Dynamic redirects |
+| `http_response_compression` | Response compression |
+
+### Rule Spec
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `action` | enum | Yes | | Action: `block`, `challenge`, `js_challenge`, `managed_challenge`, `log`, `skip`, `execute`, `redirect`, `rewrite`, `route`, `score`, `serve_error`, `set_cache_settings`, `set_config`, `compress_response`, `force_connection_close` |
+| `expression` | string | Yes | | Wirefilter expression |
+| `description` | string | No | | Rule description |
+| `enabled` | bool | No | `true` | Whether rule is active |
+| `actionParameters` | object | No | | Free-form action parameters (JSON) |
+
+### Status
+
+| Field | Description |
+|-------|-------------|
+| `rulesetID` | Cloudflare Ruleset ID |
+| `ruleCount` | Number of rules in the ruleset |
+
+### Example
+
+```yaml
+apiVersion: cloudflare.io/v1alpha1
+kind: CloudflareRuleset
+metadata:
+  name: waf-custom-rules
+spec:
+  zoneID: "<zone-id>"
+  name: "Custom WAF Rules"
+  description: "Custom WAF rules for zone protection"
+  phase: "http_request_firewall_custom"
+  interval: 30m
+  secretRef:
+    name: cloudflare-api-token
+  rules:
+    - action: block
+      expression: '(cf.client.bot) or (cf.threat_score gt 14)'
+      description: "Block bots and high threat scores"
+      enabled: true
+    - action: block
+      expression: '(not ip.geoip.country in {"CA" "US" "GB"})'
+      description: "Block non-allowed countries"
+      enabled: true
+```
+
+### Print Columns
+
+```
+NAME              RULESET NAME       PHASE                             RULES   READY   AGE
+waf-custom-rules  Custom WAF Rules   http_request_firewall_custom      2       True    5d
+```
+
+---
+
+## Common Patterns
+
+### All Resources Share
+
+- **`secretRef`**: Reference to a Kubernetes Secret with an `apiToken` key
+- **`interval`**: Reconciliation interval for drift detection
+- **`Ready` condition**: Standard Kubernetes condition indicating sync status
+- **`lastSyncedAt`**: Timestamp of last successful reconciliation
+- **`observedGeneration`**: Tracks spec changes for efficient reconciliation
+
+### Drift Detection
+
+All resources periodically compare desired state (spec) with actual Cloudflare state and correct any differences. The `interval` field controls how frequently this check occurs.
+
+### Status Conditions
+
+Every resource reports standard Kubernetes conditions:
+
+| Condition | Meaning |
+|-----------|---------|
+| `Ready=True` | Resource is synced and healthy |
+| `Ready=False` | Resource has an error or is pending |
+| `Synced=True` | Last reconciliation succeeded |
+
+### Events
+
+The operator emits Kubernetes events for key actions: resource creation, updates, sync failures, and deletion. View with `kubectl describe <resource>`.


### PR DESCRIPTION
## Summary
- Replace Kubebuilder boilerplate README with concise overview (88 lines), quick start guide, and link to full docs
- Add comprehensive `docs/README.md` covering all 5 CRDs (CloudflareZone, CloudflareDNSRecord, CloudflareTunnel, CloudflareZoneConfig, CloudflareRuleset) with specs, status fields, behaviors, and examples

## Test plan
- [x] All tests pass (`make test`)
- [ ] Review README renders correctly on GitHub
- [ ] Verify docs/README.md table of contents links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)