### PR TITLE
chore(deps): group renovate updates for k8s, test libs, and go toolchain

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,23 @@
     "github>jacaudi/renovate-config:go",
     "github>jacaudi/renovate-config:kubernetes"
   ],
+  "packageRules": [
+    {
+      "description": "Group Kubernetes client libraries (local override of upstream preset which uses deprecated matchPackagePatterns)",
+      "matchPackageNames": ["/^k8s\\.io//", "sigs.k8s.io/controller-runtime"],
+      "groupName": "kubernetes-client-libraries"
+    },
+    {
+      "description": "Group Ginkgo and Gomega test framework bumps together",
+      "matchPackageNames": ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
+      "groupName": "test-libraries"
+    },
+    {
+      "description": "Group Go toolchain bumps (go.mod directive, golang Docker image, setup-go version)",
+      "matchPackageNames": ["go", "golang"],
+      "groupName": "go-toolchain"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Consolidates Renovate PRs for related dependency bumps:

- **kubernetes-client-libraries** — `k8s.io/*` + `sigs.k8s.io/controller-runtime` (one PR for the whole client stack)
- **test-libraries** — `ginkgo` + `gomega` (release pair)
- **go-toolchain** — gomod `go` directive + `golang` Docker image + `actions/setup-go` `go-version` field

## Motivation

Triaging open Renovate PRs surfaced:

- 4 separate PRs (#9, #10, #11, #12) for the same `k8s.io v0.35.0 → v0.35.4` bump — only #10 bundled all four; the others were singletons
- 2 conflicting PRs (#16, #17) bumping ginkgo+gomega to *different* version pairs
- 2 PRs (#14, #15) splitting the Go 1.26 bump across go.mod / Dockerfile / workflow

The upstream preset `jacaudi/renovate-config:kubernetes` already declares the kubernetes-client-libraries group, but uses the deprecated `matchPackagePatterns` field which is silently ignored on newer Renovate versions. This PR re-declares the group locally with the new `matchPackageNames` syntax. Upstream tracking issue: jacaudi/renovate-config#2.

## Test plan

- [ ] Renovate config validates (JSON schema)
- [ ] After merge, close existing 10 stale Renovate PRs
- [ ] Trigger Renovate via dashboard checkbox; confirm new PRs are grouped (~3 instead of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)