### PR TITLE
chore(renovate): set recreateWhen=always on grouped package rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,17 +9,20 @@
     {
       "description": "Group Kubernetes client libraries (local override of upstream preset which uses deprecated matchPackagePatterns)",
       "matchPackageNames": ["/^k8s\\.io//", "sigs.k8s.io/controller-runtime"],
-      "groupName": "kubernetes-client-libraries"
+      "groupName": "kubernetes-client-libraries",
+      "recreateWhen": "always"
     },
     {
       "description": "Group Ginkgo and Gomega test framework bumps together",
       "matchPackageNames": ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
-      "groupName": "test-libraries"
+      "groupName": "test-libraries",
+      "recreateWhen": "always"
     },
     {
       "description": "Group Go toolchain bumps (go.mod directive, golang Docker image, setup-go version)",
       "matchPackageNames": ["go", "golang"],
-      "groupName": "go-toolchain"
+      "groupName": "go-toolchain",
+      "recreateWhen": "always"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

- Adds `recreateWhen: always` to the three grouped package rules (k8s client libs, test libs, go toolchain).
- Fixes Renovate skipping the regrouped k8s/ginkgo/build-push-action/go-toolchain bumps after #9–#18 were closed without merging.
- Without this, Renovate treats closed-without-merge PRs as user rejections and won't recreate the same version updates — even under a new groupName.

## Test plan

- [ ] CI passes
- [ ] After merge, Renovate's next run produces grouped PRs for k8s, test libs, and go-toolchain