### PR TITLE
chore(renovate): remove empty stub renovate.json shadowing the real config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
-}


### PR DESCRIPTION
## Summary

- Removes the empty \`renovate.json\` stub at repo root.
- Renovate's [\`configFileNames\`](https://docs.renovatebot.com/configuration-options/#configfilenames) checks \`renovate.json\` before \`.github/renovate.json\`, so the stub has been shadowing the real config in \`.github/renovate.json\` — including the grouping rules from #20 and the \`recreateWhen: always\` from #23.
- Once removed, Renovate will read \`.github/renovate.json\` on its next run and the grouped PRs (k8s, test-libs, go-toolchain) should finally appear.

## Test plan

- [ ] CI passes
- [ ] After merge + next Renovate run, grouped PRs appear with correct groupName-derived branch names (\`renovate/kubernetes-client-libraries\`, \`renovate/test-libraries\`, \`renovate/go-toolchain\`)