### PR TITLE
feat(logging)!: migrate from zap to log/slog

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   # Lint YAML and Go code
   lint:
-    uses: jacaudi/github-actions/.github/workflows/lint.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
     permissions:
       contents: read
     with:
@@ -32,7 +32,7 @@ jobs:
 
   # Run Go tests with coverage
   test:
-    uses: jacaudi/github-actions/.github/workflows/test.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.1
     permissions:
       contents: read
     with:
@@ -46,7 +46,7 @@ jobs:
   release:
     needs: [lint, test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: jacaudi/github-actions/.github/workflows/semantic-release.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-semantic-release.yml@v0.20.1
     permissions:
       contents: write
       issues: write
@@ -62,7 +62,7 @@ jobs:
   docker:
     needs: [release]
     if: needs.release.outputs.new-release-published == 'true'
-    uses: jacaudi/github-actions/.github/workflows/docker-build.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.1
     permissions:
       contents: read
       packages: write
@@ -78,7 +78,7 @@ jobs:
   helm:
     needs: [release, docker]
     if: needs.release.outputs.new-release-published == 'true'
-    uses: jacaudi/github-actions/.github/workflows/helm-publish.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-helm-publish.yml@v0.20.1
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
       pull-requests: write
     with:
       use-github-app: true
-      allow-initial-development-versions: true
+      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec'
     secrets:
       app-id: ${{ secrets.APP_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   lint:
     name: Lint Code
-    uses: jacaudi/github-actions/.github/workflows/lint.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-lint.yml@v0.20.1
     with:
       yaml: true
       go: true
@@ -25,7 +25,7 @@ jobs:
 
   test:
     name: Run Tests
-    uses: jacaudi/github-actions/.github/workflows/test.yml@v0.20.1
+    uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.1
     with:
       test-framework: 'go'
       go-version: '1.25'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,53 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "breaking": true, "release": "minor" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "scope": "deps", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "refactor", "section": "Refactors" },
+            { "type": "chore", "scope": "deps", "section": "Dependencies" }
+          ]
+        },
+        "writerOpts": {
+          "headerPartial": "## {{#if @root.linkCompare~}}[{{version}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{~else}}{{~version}}{{~/if}} ({{date}})"
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "if [ -f chart/Chart.yaml ]; then sed -i 's/^version:.*/version: ${nextRelease.version}/' chart/Chart.yaml && sed -i 's/^appVersion:.*/appVersion: \"${nextRelease.version}\"/' chart/Chart.yaml; fi"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "chart/Chart.yaml"],
+        "message": "release: v${nextRelease.version} [skip ci]"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"flag"
+	"log/slog"
 	"os"
+	"strings"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -145,4 +147,37 @@ func main() {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)
 	}
+}
+
+// lookupEnvOrString returns the value of the named environment variable,
+// falling back to defaultVal when the variable is unset.
+func lookupEnvOrString(key, defaultVal string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	}
+	return defaultVal
+}
+
+// setupLogger builds an slog.Logger for the given level and format strings.
+// Unknown level → info. Unknown format → json. Inputs are case-insensitive.
+func setupLogger(level, format string) *slog.Logger {
+	var slogLevel slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		slogLevel = slog.LevelDebug
+	case "warn":
+		slogLevel = slog.LevelWarn
+	case "error":
+		slogLevel = slog.LevelError
+	default:
+		slogLevel = slog.LevelInfo
+	}
+
+	var handler slog.Handler
+	if strings.ToLower(format) == "text" {
+		handler = slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slogLevel})
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slogLevel})
+	}
+	return slog.New(handler)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,12 +24,13 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
@@ -62,11 +63,17 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager.")
 
-	opts := zap.Options{Development: true}
-	opts.BindFlags(flag.CommandLine)
+	var logLevel, logFormat string
+	flag.StringVar(&logLevel, "log-level", lookupEnvOrString("LOG_LEVEL", "info"),
+		"Log level (debug, info, warn, error). Can also be set via LOG_LEVEL.")
+	flag.StringVar(&logFormat, "log-format", lookupEnvOrString("LOG_FORMAT", "json"),
+		"Log format (json, text). Can also be set via LOG_FORMAT.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	slogLogger := setupLogger(logLevel, logFormat)
+	slog.SetDefault(slogLogger)
+	ctrl.SetLogger(logr.FromSlogHandler(slogLogger.Handler()))
+	klog.SetSlogLogger(slogLogger)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestSetupLogger_DefaultLevel(t *testing.T) {
+	logger := setupLogger("info", "json")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if _, ok := logger.Handler().(*slog.JSONHandler); !ok {
+		t.Errorf("expected JSONHandler for format=json, got %T", logger.Handler())
+	}
+}
+
+func TestSetupLogger_DebugLevel(t *testing.T) {
+	logger := setupLogger("debug", "json")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if !logger.Handler().Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("expected debug level enabled")
+	}
+}
+
+func TestSetupLogger_WarnLevel(t *testing.T) {
+	logger := setupLogger("warn", "json")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	ctx := context.Background()
+	if logger.Handler().Enabled(ctx, slog.LevelInfo) {
+		t.Error("expected info level disabled")
+	}
+	if !logger.Handler().Enabled(ctx, slog.LevelWarn) {
+		t.Error("expected warn level enabled")
+	}
+}
+
+func TestSetupLogger_ErrorLevel(t *testing.T) {
+	logger := setupLogger("error", "json")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	ctx := context.Background()
+	if logger.Handler().Enabled(ctx, slog.LevelWarn) {
+		t.Error("expected warn level disabled")
+	}
+	if !logger.Handler().Enabled(ctx, slog.LevelError) {
+		t.Error("expected error level enabled")
+	}
+}
+
+func TestSetupLogger_UnknownLevelDefaultsToInfo(t *testing.T) {
+	logger := setupLogger("garbage", "json")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	ctx := context.Background()
+	if !logger.Handler().Enabled(ctx, slog.LevelInfo) {
+		t.Error("expected info level enabled")
+	}
+	if logger.Handler().Enabled(ctx, slog.LevelDebug) {
+		t.Error("expected debug level disabled")
+	}
+}
+
+func TestSetupLogger_TextFormat(t *testing.T) {
+	logger := setupLogger("info", "text")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if _, ok := logger.Handler().(*slog.TextHandler); !ok {
+		t.Errorf("expected TextHandler for format=text, got %T", logger.Handler())
+	}
+}
+
+func TestSetupLogger_UnknownFormatDefaultsToJSON(t *testing.T) {
+	logger := setupLogger("info", "garbage")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if _, ok := logger.Handler().(*slog.JSONHandler); !ok {
+		t.Errorf("expected JSONHandler for unknown format, got %T", logger.Handler())
+	}
+}
+
+func TestSetupLogger_CaseInsensitiveLevel(t *testing.T) {
+	logger := setupLogger("DEBUG", "json")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if !logger.Handler().Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("expected debug level enabled (uppercase input)")
+	}
+}
+
+func TestSetupLogger_CaseInsensitiveFormat(t *testing.T) {
+	logger := setupLogger("info", "TEXT")
+	if logger == nil {
+		t.Fatal("logger is nil")
+	}
+	if _, ok := logger.Handler().(*slog.TextHandler); !ok {
+		t.Errorf("expected TextHandler for format=TEXT (uppercase), got %T", logger.Handler())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.25.3
 
 require (
 	github.com/cloudflare/cloudflare-go/v6 v6.9.0
+	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	k8s.io/api v0.35.4
 	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
+	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
@@ -22,8 +24,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
-	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -50,8 +50,6 @@ require (
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect
@@ -68,7 +66,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect


### PR DESCRIPTION
Closes #19

## Summary

- Replace controller-runtime's zap logger setup in `cmd/main.go` with Go's stdlib `log/slog`
- Route klog (used by client-go leader election) through the same slog handler so all output is structurally consistent
- Add `setupLogger` helper with 9 stdlib unit tests covering levels, formats, unknown-input fallbacks, and case-insensitivity
- Drop `go.uber.org/zap` direct dep; promote `github.com/go-logr/logr` and `k8s.io/klog/v2` to direct (they were already transitive)

## Breaking change

Removes 5 CLI flags inherited from `zap.Options.BindFlags`:

- `--zap-devel`
- `--zap-encoder`
- `--zap-log-level`
- `--zap-stacktrace-level`
- `--zap-time-encoding`

Replacement surface:

- `--log-level` (or `LOG_LEVEL` env var) — `debug` / `info` / `warn` / `error` (default `info`)
- `--log-format` (or `LOG_FORMAT` env var) — `json` / `text` (default `json`)

The `feat!:` prefix on the implementation commit signals the breaking change to go-semantic-release. With the new `.releaserc.json` (see CI commits below), breaking changes map to a **minor** bump while the project is still in 0.x — so this PR cuts `v0.1.0 → v0.2.0`.

## CI fixes (added during merge attempt)

The first CI run after pushing this PR failed at workflow-resolution time (`workflow file issue` in 0s). Root cause: a Renovate bump in commit `622078a` updated `jacaudi/github-actions/.github/workflows/*.yml@v0.14.0 → @v0.20.1`, but the upstream renamed all reusable workflows to `component-*` paths. Every push to main since `622078a` has been failing for the same reason.

Two follow-up commits on this branch fix the gate:

1. `ci: rename reusable workflow refs to component-* paths` — updates `pr.yml` and `ci-cd.yml` references (`lint.yml → component-lint.yml`, `test.yml → component-test.yml`, `semantic-release.yml → component-semantic-release.yml`, `docker-build.yml → component-container-build.yml`, `helm-publish.yml → component-helm-publish.yml`).
2. `ci: migrate semantic-release config to .releaserc.json` — `component-semantic-release.yml@v0.20.x` requires `.releaserc.json` instead of inline workflow inputs. Adds a config mirroring nextdns-operator (the reference operator), preserves 0.x semantics by mapping `breaking → minor`, removes the now-removed `allow-initial-development-versions` input from `ci-cd.yml`, and adds `@semantic-release/exec` to `extra-plugins` so the `chart/Chart.yaml` version sync can run.

## Test plan

- [x] `go test ./...` — all 6 packages pass, including 9/9 new `setupLogger` unit tests
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go run ./cmd --help` shows `-log-format` and `-log-level`, no `-zap-*` flags
- [x] Verified no consumers of removed `--zap-*` flags in repo (manifests, Helm chart, CI workflows, Dockerfile, README)
- [x] `.releaserc.json` validates with `jq`
- [ ] PR Validation passes after the CI fix commits
- [ ] Merge with **rebase** or **merge commit** (not squash) to preserve the `BREAKING CHANGE:` footer for go-semantic-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)