### PR TITLE
fix(ci): use v-prefixed tag for container image

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,7 +71,7 @@ jobs:
       platforms: 'linux/amd64,linux/arm64'
       version: ${{ needs.release.outputs.new-release-version }}
       tags: |
-        ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new-release-version }}
+        ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new-release-version-v }}
         ghcr.io/${{ github.repository }}:latest
 
   # Publish Helm chart to OCI registry
@@ -86,6 +86,6 @@ jobs:
       chart-name: cloudflare-operator
       chart-path: chart
       repository: ${{ github.repository_owner }}/charts
-      version: ${{ needs.release.outputs.new-release-version }}
+      version: ${{ needs.release.outputs.new-release-version-v }}
       registry: ghcr.io
       registry-username: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary

The v0.3.0 release accidentally shipped the container image as `ghcr.io/jacaudi/cloudflare-operator:0.3.0` (bare), breaking the v-prefix convention established by the earlier hand-cut `v0.1.0` and `v0.2.0` tags.

Root cause: \`ci-cd.yml\` was passing \`new-release-version\` (bare, e.g. \`0.3.0\`) for the docker tag instead of \`new-release-version-v\` (v-prefixed, e.g. \`v0.3.0\`).

This commit switches both the docker tag and the helm chart version inputs to use \`new-release-version-v\`, matching the [nextdns-operator pattern](https://github.com/jacaudi/nextdns-operator/blob/main/.github/workflows/ci-cd.yml).

- **Container:** future releases will be tagged \`v<version>\` again. The OCI \`org.opencontainers.image.version\` label keeps the bare value per spec.
- **Helm:** no visual change — the upstream \`component-helm-publish.yml\` already normalizes to v-prefix internally — but the source is now consistent with nextdns-operator.

## Test plan

- [x] One-line workflow change, no source impact
- [ ] After merge, the v0.3.1 release pipeline pushes \`ghcr.io/jacaudi/cloudflare-operator:v0.3.1\` (not \`:0.3.1\`)
- [ ] \`:latest\` continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)