### PR TITLE
feat!: account ID to secret + pipeline alignment with nextdns-operator

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,7 +59,7 @@ jobs:
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
   # Build multi-arch container images
-  docker:
+  container:
     needs: [release]
     if: needs.release.outputs.new-release-published == 'true'
     uses: jacaudi/github-actions/.github/workflows/component-container-build.yml@v0.20.1
@@ -74,9 +74,9 @@ jobs:
         ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new-release-version-v }}
         ghcr.io/${{ github.repository }}:latest
 
-  # Publish Helm chart to OCI registry
+  # Publish Helm chart to OCI registry (runs in parallel with container build)
   helm:
-    needs: [release, docker]
+    needs: [release]
     if: needs.release.outputs.new-release-published == 'true'
     uses: jacaudi/github-actions/.github/workflows/component-helm-publish.yml@v0.20.1
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,7 @@ jobs:
           echo "Helm chart CRDs are in sync"
 
   # Build multi-arch container images natively (no push)
-  docker-amd64:
+  container-amd64:
     name: Build Container (amd64)
     needs: [lint, test, verify-helm-rbac, verify-helm-crds]
     runs-on: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=amd64
 
 
-  docker-arm64:
+  container-arm64:
     name: Build Container (arm64)
     needs: [lint, test, verify-helm-rbac, verify-helm-crds]
     runs-on: ubuntu-24.04-arm

--- a/README.md
+++ b/README.md
@@ -48,15 +48,16 @@ metrics:
     enabled: false      # set true if you run the Prometheus Operator
 ```
 
-### 2. Create the API token Secret
+### 2. Create the credentials Secret
 
 ```sh
 kubectl create secret generic cloudflare-api-token \
   --namespace cloudflare-operator \
-  --from-literal=apiToken=<your-cloudflare-api-token>
+  --from-literal=apiToken=<your-cloudflare-api-token> \
+  --from-literal=accountID=<your-cloudflare-account-id>
 ```
 
-Every CR references this Secret via `secretRef.name`. Place the Secret in the same namespace as the CRs that use it.
+Every CR references this Secret via `secretRef.name`. Place the Secret in the same namespace as the CRs that use it. `accountID` is required for `CloudflareZone` and `CloudflareTunnel`; other CRs only read `apiToken`.
 
 ### 3. Onboard your zone
 
@@ -70,7 +71,6 @@ metadata:
   namespace: cloudflare-operator
 spec:
   name: "example.com"
-  accountID: "<your-account-id>"
   deletionPolicy: Retain   # leaves the zone in Cloudflare on CR delete
   secretRef:
     name: cloudflare-api-token

--- a/api/v1alpha1/cloudflaretunnel_types.go
+++ b/api/v1alpha1/cloudflaretunnel_types.go
@@ -27,11 +27,6 @@ type CloudflareTunnelSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
-	// AccountID is the Cloudflare Account ID.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
-	AccountID string `json:"accountID"`
-
 	// SecretRef references a Secret containing Cloudflare API credentials.
 	// +kubebuilder:validation:Required
 	SecretRef SecretReference `json:"secretRef"`

--- a/api/v1alpha1/cloudflarezone_types.go
+++ b/api/v1alpha1/cloudflarezone_types.go
@@ -27,11 +27,6 @@ type CloudflareZoneSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
-	// AccountID is the Cloudflare Account ID.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
-	AccountID string `json:"accountID"`
-
 	// Type is the zone type. "full" means Cloudflare is the authoritative DNS.
 	// "partial" is a CNAME setup. Immutable after creation.
 	// +kubebuilder:validation:Enum=full;partial;secondary

--- a/chart/crds/cloudflare.io_cloudflaretunnels.yaml
+++ b/chart/crds/cloudflare.io_cloudflaretunnels.yaml
@@ -55,10 +55,6 @@ spec:
           spec:
             description: spec defines the desired state of CloudflareTunnel
             properties:
-              accountID:
-                description: AccountID is the Cloudflare Account ID.
-                minLength: 1
-                type: string
               generatedSecretName:
                 description: |-
                   GeneratedSecretName is the name of the Secret to create with tunnel credentials.
@@ -85,7 +81,6 @@ spec:
                 - name
                 type: object
             required:
-            - accountID
             - generatedSecretName
             - name
             - secretRef

--- a/chart/crds/cloudflare.io_cloudflarezones.yaml
+++ b/chart/crds/cloudflare.io_cloudflarezones.yaml
@@ -55,10 +55,6 @@ spec:
           spec:
             description: spec defines the desired state of CloudflareZone
             properties:
-              accountID:
-                description: AccountID is the Cloudflare Account ID.
-                minLength: 1
-                type: string
               deletionPolicy:
                 default: Retain
                 description: |-
@@ -103,7 +99,6 @@ spec:
                 - secondary
                 type: string
             required:
-            - accountID
             - name
             - secretRef
             type: object

--- a/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
@@ -55,10 +55,6 @@ spec:
           spec:
             description: spec defines the desired state of CloudflareTunnel
             properties:
-              accountID:
-                description: AccountID is the Cloudflare Account ID.
-                minLength: 1
-                type: string
               generatedSecretName:
                 description: |-
                   GeneratedSecretName is the name of the Secret to create with tunnel credentials.
@@ -85,7 +81,6 @@ spec:
                 - name
                 type: object
             required:
-            - accountID
             - generatedSecretName
             - name
             - secretRef

--- a/config/crd/bases/cloudflare.io_cloudflarezones.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarezones.yaml
@@ -55,10 +55,6 @@ spec:
           spec:
             description: spec defines the desired state of CloudflareZone
             properties:
-              accountID:
-                description: AccountID is the Cloudflare Account ID.
-                minLength: 1
-                type: string
               deletionPolicy:
                 default: Retain
                 description: |-
@@ -103,7 +99,6 @@ spec:
                 - secondary
                 type: string
             required:
-            - accountID
             - name
             - secretRef
             type: object

--- a/config/samples/cloudflare_v1alpha1_cloudflaretunnel.yaml
+++ b/config/samples/cloudflare_v1alpha1_cloudflaretunnel.yaml
@@ -4,8 +4,8 @@ metadata:
   name: k8s-external-ingress
 spec:
   name: k8s-external-ingress
-  accountID: "<account-id>"
   generatedSecretName: cloudflare-tunnel-credentials
   interval: 30m
+  # The referenced Secret must include both `apiToken` and `accountID` keys.
   secretRef:
     name: cloudflare-api-token

--- a/config/samples/cloudflare_v1alpha1_cloudflarezone.yaml
+++ b/config/samples/cloudflare_v1alpha1_cloudflarezone.yaml
@@ -5,9 +5,9 @@ metadata:
   name: example-zone
 spec:
   name: "example.com"
-  accountID: "<account-id>"
   type: "full"
   deletionPolicy: Retain
   interval: 30m
+  # The referenced Secret must include both `apiToken` and `accountID` keys.
   secretRef:
     name: cloudflare-api-token

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ A Kubernetes operator for managing Cloudflare resources declaratively. All resou
 
 ## Authentication
 
-All resources reference a Kubernetes Secret containing a Cloudflare API token:
+All resources reference a Kubernetes Secret containing a Cloudflare API token. `CloudflareZone` and `CloudflareTunnel` additionally require the Cloudflare Account ID to be stored in the same Secret (keeps account identifiers out of your CR manifests):
 
 ```yaml
 apiVersion: v1
@@ -26,6 +26,8 @@ metadata:
 type: Opaque
 stringData:
   apiToken: "<your-cloudflare-api-token>"
+  # Required for CloudflareZone and CloudflareTunnel; optional for others.
+  accountID: "<your-cloudflare-account-id>"
 ```
 
 Reference this secret in any resource via `secretRef`:
@@ -56,7 +58,6 @@ Manages domain lifecycle in Cloudflare: onboarding new domains, adopting existin
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | Yes | | Domain name (e.g., `example.com`) |
-| `accountID` | string | Yes | | Cloudflare Account ID |
 | `type` | enum | No | `full` | Zone type: `full`, `partial`, `secondary` |
 | `paused` | bool | No | | Pause zone (stop serving traffic through Cloudflare) |
 | `deletionPolicy` | enum | No | `Retain` | `Retain` leaves zone in CF on CR deletion; `Delete` removes it |
@@ -90,7 +91,6 @@ metadata:
   name: my-domain
 spec:
   name: "example.com"
-  accountID: "<account-id>"
   type: "full"
   deletionPolicy: Retain
   interval: 30m
@@ -226,9 +226,8 @@ Manages Cloudflare Tunnel lifecycle and auto-generates a credentials Secret for 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `name` | string | Yes | | Tunnel name in Cloudflare |
-| `accountID` | string | Yes | | Cloudflare Account ID |
 | `generatedSecretName` | string | Yes | | Name of the Secret to create with tunnel credentials |
-| `secretRef` | object | Yes | | Reference to API token Secret |
+| `secretRef` | object | Yes | | Reference to API token + Account ID Secret |
 | `interval` | duration | No | `30m` | Reconciliation interval |
 
 ### Status
@@ -254,7 +253,6 @@ metadata:
   name: k8s-tunnel
 spec:
   name: k8s-external-ingress
-  accountID: "<account-id>"
   generatedSecretName: cloudflare-tunnel-credentials
   interval: 30m
   secretRef:

--- a/internal/cloudflare/client.go
+++ b/internal/cloudflare/client.go
@@ -12,8 +12,11 @@ import (
 	"github.com/cloudflare/cloudflare-go/v6/option"
 )
 
-// SecretKeyAPIToken is the Secret data key where the Cloudflare API token is expected.
-const SecretKeyAPIToken = "apiToken"
+// Secret data keys where Cloudflare credentials are expected.
+const (
+	SecretKeyAPIToken  = "apiToken"
+	SecretKeyAccountID = "accountID"
+)
 
 // ClientFactory creates Cloudflare API clients from Kubernetes Secrets.
 type ClientFactory struct {
@@ -25,23 +28,44 @@ func NewClientFactory(k8sClient client.Client) *ClientFactory {
 	return &ClientFactory{k8sClient: k8sClient}
 }
 
+// Credentials holds the Cloudflare API token and, optionally, the Account ID
+// read from a single Kubernetes Secret.
+type Credentials struct {
+	APIToken  string
+	AccountID string
+}
+
 // GetAPIToken reads a Cloudflare API token from a Kubernetes Secret.
 func (f *ClientFactory) GetAPIToken(ctx context.Context, secretName, namespace string) (string, error) {
+	creds, err := f.GetCredentials(ctx, secretName, namespace)
+	if err != nil {
+		return "", err
+	}
+	return creds.APIToken, nil
+}
+
+// GetCredentials reads the Cloudflare API token (required) and Account ID
+// (optional, empty string if not set) from a single Kubernetes Secret.
+// Controllers that need both call this to avoid two Secret reads.
+func (f *ClientFactory) GetCredentials(ctx context.Context, secretName, namespace string) (Credentials, error) {
 	secret := &corev1.Secret{}
 	err := f.k8sClient.Get(ctx, types.NamespacedName{
 		Name:      secretName,
 		Namespace: namespace,
 	}, secret)
 	if err != nil {
-		return "", fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
+		return Credentials{}, fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
 	}
 
 	token, ok := secret.Data[SecretKeyAPIToken]
 	if !ok {
-		return "", fmt.Errorf("secret %s/%s does not contain %q key", namespace, secretName, SecretKeyAPIToken)
+		return Credentials{}, fmt.Errorf("secret %s/%s does not contain %q key", namespace, secretName, SecretKeyAPIToken)
 	}
 
-	return string(token), nil
+	return Credentials{
+		APIToken:  string(token),
+		AccountID: string(secret.Data[SecretKeyAccountID]),
+	}, nil
 }
 
 // NewCloudflareClient creates a new Cloudflare API client from an API token.

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -147,7 +147,7 @@ func newTestDNSRecord(name, namespace string) *cloudflarev1alpha1.CloudflareDNSR
 	}
 }
 
-// Helper to create the Cloudflare API token secret.
+// Helper to create the Cloudflare API token + Account ID secret.
 func newTestSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +155,8 @@ func newTestSecret(namespace string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"apiToken": []byte("test-token"),
+			"apiToken":  []byte("test-token"),
+			"accountID": []byte("acct-123"),
 		},
 	}
 }
@@ -542,7 +543,6 @@ func TestDNSReconcile_ZoneRefResolvesFromCloudflareZone(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "example.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}
@@ -613,7 +613,6 @@ func TestDNSReconcile_ZoneRefNotReady(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "pending.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}
@@ -691,7 +690,6 @@ func TestDNSReconcile_ZoneRefDeleteWithResolvedZone(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "example.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}

--- a/internal/controller/cloudflareruleset_controller_test.go
+++ b/internal/controller/cloudflareruleset_controller_test.go
@@ -426,7 +426,6 @@ func TestRulesetReconcile_ZoneRefResolvesFromCloudflareZone(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "example.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}
@@ -516,7 +515,6 @@ func TestRulesetReconcile_ZoneRefNotReady(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "pending.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}
@@ -612,7 +610,6 @@ func TestRulesetReconcile_ZoneRefDeleteWithResolvedZone(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "example.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -89,16 +89,23 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
-	// 4. Get API token
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, tunnel.Spec.SecretRef.Name, tunnel.Namespace)
+	// 4. Get Cloudflare credentials (API token + Account ID)
+	creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, tunnel.Namespace)
 	if err != nil {
-		logger.Error(err, "failed to get API token")
+		logger.Error(err, "failed to get credentials")
+		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
+			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+	}
+	if creds.AccountID == "" {
+		err := fmt.Errorf("secret %s/%s does not contain %q key",
+			tunnel.Namespace, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
+		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
 			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
 	}
 
 	// 5. Reconcile the tunnel
-	result, err := r.reconcileTunnel(ctx, &tunnel, r.tunnelClient(apiToken))
+	result, err := r.reconcileTunnel(ctx, &tunnel, r.tunnelClient(creds.APIToken), creds.AccountID)
 	if err != nil {
 		logger.Error(err, "reconciliation failed")
 		r.Recorder.Event(&tunnel, corev1.EventTypeWarning, "SyncFailed", err.Error())
@@ -121,14 +128,14 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return result, nil
 }
 
-func (r *CloudflareTunnelReconciler) reconcileTunnel(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel, tunnelClient cfclient.TunnelClient) (ctrl.Result, error) {
+func (r *CloudflareTunnelReconciler) reconcileTunnel(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel, tunnelClient cfclient.TunnelClient, accountID string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Check if tunnel exists by ID
 	var existing *cfclient.Tunnel
 	var err error
 	if tunnel.Status.TunnelID != "" {
-		existing, err = tunnelClient.GetTunnel(ctx, tunnel.Spec.AccountID, tunnel.Status.TunnelID)
+		existing, err = tunnelClient.GetTunnel(ctx, accountID, tunnel.Status.TunnelID)
 		if err != nil {
 			logger.Info("could not fetch tunnel by ID, will search by name", "tunnelID", tunnel.Status.TunnelID)
 			tunnel.Status.TunnelID = ""
@@ -138,7 +145,7 @@ func (r *CloudflareTunnelReconciler) reconcileTunnel(ctx context.Context, tunnel
 
 	// Search by name (adopt existing)
 	if existing == nil {
-		tunnels, err := tunnelClient.ListTunnelsByName(ctx, tunnel.Spec.AccountID, tunnel.Spec.Name)
+		tunnels, err := tunnelClient.ListTunnelsByName(ctx, accountID, tunnel.Spec.Name)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("list tunnels: %w", err)
 		}
@@ -164,7 +171,7 @@ func (r *CloudflareTunnelReconciler) reconcileTunnel(ctx context.Context, tunnel
 		}
 
 		// Create new tunnel
-		created, err := tunnelClient.CreateTunnel(ctx, tunnel.Spec.AccountID, cfclient.TunnelParams{
+		created, err := tunnelClient.CreateTunnel(ctx, accountID, cfclient.TunnelParams{
 			Name:         tunnel.Spec.Name,
 			TunnelSecret: tunnelSecret,
 		})
@@ -177,12 +184,12 @@ func (r *CloudflareTunnelReconciler) reconcileTunnel(ctx context.Context, tunnel
 			fmt.Sprintf("Created tunnel %s with ID %s", tunnel.Spec.Name, created.ID))
 
 		// Create credentials Secret with the generated secret
-		if err := r.ensureCredentialsSecret(ctx, tunnel, tunnelSecret); err != nil {
+		if err := r.ensureCredentialsSecret(ctx, tunnel, accountID, tunnelSecret); err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensure credentials secret: %w", err)
 		}
 	} else {
 		// For existing/adopted tunnels, ensure credentials Secret exists but don't regenerate secret
-		if err := r.ensureCredentialsSecretExists(ctx, tunnel); err != nil {
+		if err := r.ensureCredentialsSecretExists(ctx, tunnel, accountID); err != nil {
 			return ctrl.Result{}, fmt.Errorf("ensure credentials secret: %w", err)
 		}
 	}
@@ -194,9 +201,9 @@ func (r *CloudflareTunnelReconciler) reconcileTunnel(ctx context.Context, tunnel
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
-func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel, tunnelSecret string) error {
+func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel, accountID, tunnelSecret string) error {
 	creds := map[string]string{
-		"AccountTag":   tunnel.Spec.AccountID,
+		"AccountTag":   accountID,
 		"TunnelSecret": tunnelSecret,
 		"TunnelID":     tunnel.Status.TunnelID,
 	}
@@ -230,7 +237,7 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context
 // adoption, so the Secret is created with an empty TunnelSecret and the user
 // must fill it in manually. If a Secret already exists with a matching TunnelID
 // it is preserved; otherwise it is (over)written with the empty template.
-func (r *CloudflareTunnelReconciler) ensureCredentialsSecretExists(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel) error {
+func (r *CloudflareTunnelReconciler) ensureCredentialsSecretExists(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel, accountID string) error {
 	logger := log.FromContext(ctx)
 
 	var existing corev1.Secret
@@ -248,7 +255,7 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecretExists(ctx context.C
 			"secretName", tunnel.Spec.GeneratedSecretName, "tunnelID", tunnel.Status.TunnelID)
 	}
 
-	return r.ensureCredentialsSecret(ctx, tunnel, "")
+	return r.ensureCredentialsSecret(ctx, tunnel, accountID, "")
 }
 
 // secretMatchesTunnel reports whether secret's credentials.json is parseable
@@ -277,14 +284,21 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 	logger := log.FromContext(ctx)
 
 	if tunnel.Status.TunnelID != "" {
-		apiToken, err := r.ClientFactory.GetAPIToken(ctx, tunnel.Spec.SecretRef.Name, tunnel.Namespace)
+		creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, tunnel.Namespace)
 		if err != nil {
-			logger.Error(err, "failed to get API token during deletion, will retry; remove the finalizer manually to force deletion")
+			logger.Error(err, "failed to get credentials during deletion, will retry; remove the finalizer manually to force deletion")
+			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
+				cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
+		}
+		if creds.AccountID == "" {
+			err := fmt.Errorf("secret %s/%s does not contain %q key",
+				tunnel.Namespace, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
+			logger.Error(err, "missing Account ID during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
 				cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
 		}
 
-		if err := r.tunnelClient(apiToken).DeleteTunnel(ctx, tunnel.Spec.AccountID, tunnel.Status.TunnelID); err != nil {
+		if err := r.tunnelClient(creds.APIToken).DeleteTunnel(ctx, creds.AccountID, tunnel.Status.TunnelID); err != nil {
 			logger.Error(err, "failed to delete tunnel from Cloudflare")
 			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
 				cloudflarev1alpha1.ReasonCloudflareError, err, 30*time.Second)

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -94,7 +94,6 @@ func newTestTunnel(name, namespace string) *cloudflarev1alpha1.CloudflareTunnel 
 		},
 		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
 			Name:                "my-tunnel",
-			AccountID:           "acct-123",
 			GeneratedSecretName: "tunnel-creds",
 			SecretRef: cloudflarev1alpha1.SecretReference{
 				Name: "cf-secret",

--- a/internal/controller/cloudflarezone_controller.go
+++ b/internal/controller/cloudflarezone_controller.go
@@ -84,16 +84,23 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
-	// 4. Get API token
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, zone.Spec.SecretRef.Name, zone.Namespace)
+	// 4. Get Cloudflare credentials (API token + Account ID)
+	creds, err := r.ClientFactory.GetCredentials(ctx, zone.Spec.SecretRef.Name, zone.Namespace)
 	if err != nil {
-		logger.Error(err, "failed to get API token")
+		logger.Error(err, "failed to get credentials")
+		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
+			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+	}
+	if creds.AccountID == "" {
+		err := fmt.Errorf("secret %s/%s does not contain %q key",
+			zone.Namespace, zone.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
+		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
 			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
 	}
 
 	// 5. Reconcile the zone
-	result, err := r.reconcileZone(ctx, &zone, r.zoneLifecycleClient(apiToken))
+	result, err := r.reconcileZone(ctx, &zone, r.zoneLifecycleClient(creds.APIToken), creds.AccountID)
 	if err != nil {
 		logger.Error(err, "reconciliation failed")
 		r.Recorder.Event(&zone, corev1.EventTypeWarning, "SyncFailed", err.Error())
@@ -117,7 +124,7 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return result, nil
 }
 
-func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *cloudflarev1alpha1.CloudflareZone, zoneClient cfclient.ZoneLifecycleClient) (ctrl.Result, error) {
+func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *cloudflarev1alpha1.CloudflareZone, zoneClient cfclient.ZoneLifecycleClient, accountID string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Try to find zone by stored ID
@@ -138,7 +145,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 
 	// Search by name (adopt existing)
 	if existing == nil {
-		zones, err := zoneClient.ListZonesByName(ctx, zone.Spec.AccountID, zone.Spec.Name)
+		zones, err := zoneClient.ListZonesByName(ctx, accountID, zone.Spec.Name)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("list zones: %w", err)
 		}
@@ -153,7 +160,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 
 	// Create if not found
 	if existing == nil {
-		created, err := zoneClient.CreateZone(ctx, zone.Spec.AccountID, cfclient.ZoneLifecycleParams{
+		created, err := zoneClient.CreateZone(ctx, accountID, cfclient.ZoneLifecycleParams{
 			Name: zone.Spec.Name,
 			Type: zone.Spec.Type,
 		})

--- a/internal/controller/cloudflarezone_controller_test.go
+++ b/internal/controller/cloudflarezone_controller_test.go
@@ -118,7 +118,6 @@ func newTestCloudflareZone(name, namespace string) *cloudflarev1alpha1.Cloudflar
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:           "example.com",
-			AccountID:      "acct-123",
 			Type:           "full",
 			DeletionPolicy: "Retain",
 			SecretRef: cloudflarev1alpha1.SecretReference{

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -443,7 +443,6 @@ func TestZoneConfigReconcile_ZoneRefResolvesFromCloudflareZone(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "example.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}
@@ -514,7 +513,6 @@ func TestZoneConfigReconcile_ZoneRefNotReady(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "pending.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 	}

--- a/internal/controller/zoneref_test.go
+++ b/internal/controller/zoneref_test.go
@@ -53,7 +53,6 @@ func TestResolveZoneID_ZoneRefResolvesFromStatus(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "example.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 		Status: cloudflarev1alpha1.CloudflareZoneStatus{
@@ -95,7 +94,6 @@ func TestResolveZoneID_ZoneRefNoStatusZoneID(t *testing.T) {
 		},
 		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
 			Name:      "pending.com",
-			AccountID: "acct-1",
 			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
 		},
 		Status: cloudflarev1alpha1.CloudflareZoneStatus{


### PR DESCRIPTION
Two logically-separate changes in one branch, one commit each.

## Commit 1: `ci: align pipelines with nextdns-operator`

Small cosmetic + structural alignment with the nextdns-operator CI/CD:

- Rename the container-build job from `docker` to `container` (both `ci-cd.yml` and `pr.yml`)
- In `ci-cd.yml`, stop serializing the Helm publish behind the container build — `helm` now only depends on `release` and runs in parallel with `container`

**Not adopted from nextdns**:
- Its release approval gate (`environment: release` job) — out per request
- `cancel-in-progress: true` stays `false` so runs queue in submission order

## Commit 2: `feat!: move Cloudflare Account ID from spec to secret`

**Breaking CRD change.** Cloudflare Account IDs were previously required plain-text fields on `CloudflareZone.Spec.AccountID` and `CloudflareTunnel.Spec.AccountID`, visible to anyone with \`kubectl get\`. This moves them into the same Secret that already holds the API token.

### API changes

- Remove \`spec.accountID\` from CloudflareZone and CloudflareTunnel
- Add a new Secret data key \`accountID\` alongside \`apiToken\` — required for Zone/Tunnel reconciliation, unused by DNSRecord/Ruleset/ZoneConfig

### Implementation

- New \`Credentials\` struct + \`ClientFactory.GetCredentials\` reads both keys from a single Secret fetch
- \`GetAPIToken\` still works (delegates to GetCredentials) so existing callers are unchanged
- Zone + Tunnel controllers switch to GetCredentials; missing \`accountID\` surfaces \`Ready=False\` with \`SecretNotFound\` reason
- Tunnel credentials JSON still emits AccountTag, now sourced from the Secret
- CRDs regenerated in both \`config/crd/bases/\` and \`chart/crds/\`
- Updated top-level README, \`docs/README.md\`, and \`config/samples/\`

### Upgrade path

\`\`\`sh
# 1. Patch existing Secret
kubectl patch secret cloudflare-api-token \\
  -p '{"stringData":{"accountID":"<your-account-id>"}}'
\`\`\`

\`\`\`sh
# 2. Edit each CloudflareZone / CloudflareTunnel CR to drop spec.accountID
\`\`\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — 6 packages, all pass
- [x] \`make lint\` — 0 issues
- [x] CRD manifests regenerated for both \`config/crd/bases/\` and \`chart/crds/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)