### PR TITLE
ci(lint): silence chart/crds yamllint and GetEventRecorderFor SA1019

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -11,3 +11,4 @@ rules:
 ignore: |
   config/
   chart/templates/
+  chart/crds/

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,9 +93,10 @@ func main() {
 	ipResolver := ipresolver.NewResolver()
 
 	if err := (&controller.CloudflareDNSRecordReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("cloudflarednsrecord-controller"),
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor( //nolint:staticcheck // TODO: migrate to events.EventRecorder
+			"cloudflarednsrecord-controller"),
 		ClientFactory: clientFactory,
 		IPResolver:    ipResolver,
 	}).SetupWithManager(mgr); err != nil {
@@ -103,36 +104,40 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.CloudflareTunnelReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("cloudflaretunnel-controller"),
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor( //nolint:staticcheck // TODO: migrate to events.EventRecorder
+			"cloudflaretunnel-controller"),
 		ClientFactory: clientFactory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "CloudflareTunnel")
 		os.Exit(1)
 	}
 	if err := (&controller.CloudflareRulesetReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("cloudflareruleset-controller"),
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor( //nolint:staticcheck // TODO: migrate to events.EventRecorder
+			"cloudflareruleset-controller"),
 		ClientFactory: clientFactory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "CloudflareRuleset")
 		os.Exit(1)
 	}
 	if err := (&controller.CloudflareZoneConfigReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("cloudflarezoneconfig-controller"),
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor( //nolint:staticcheck // TODO: migrate to events.EventRecorder
+			"cloudflarezoneconfig-controller"),
 		ClientFactory: clientFactory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "CloudflareZoneConfig")
 		os.Exit(1)
 	}
 	if err := (&controller.CloudflareZoneReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("cloudflarezone-controller"),
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor( //nolint:staticcheck // TODO: migrate to events.EventRecorder
+			"cloudflarezone-controller"),
 		ClientFactory: clientFactory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "CloudflareZone")


### PR DESCRIPTION
Two additional CI annotations surfaced on PR #38 — neither a real defect, both fixable at the config/suppression level. Splitting out to its own PR so #38 stays focused on the account-ID migration.

## Fixes

### 10 yamllint errors in `chart/crds/cloudflare.io_cloudflarezoneconfigs.yaml`

These CRD files are generated by controller-gen and use its own indentation style. Hand-fixing gets clobbered on every \`make sync-helm-crds\`. Add \`chart/crds/\` to \`.yamllint\`'s ignore list, alongside the already-ignored \`config/\` and \`chart/templates/\`.

### 3 staticcheck `SA1019` deprecations in `cmd/main.go`

\`mgr.GetEventRecorderFor\` is deprecated in controller-runtime. Local \`make lint\` doesn't flag these (older staticcheck), but CI's stricter version does.

The migration isn't trivial: the replacement (\`GetEventRecorder\` returning \`k8s.io/client-go/tools/events.EventRecorder\`) has a different method shape — \`.Eventf(regarding, related, eventtype, reason, action, note, args...)\` instead of the old \`.Event(obj, eventtype, reason, msg)\`. Migrating requires changing the \`Recorder\` field type in all 5 controllers and updating every event-emission site to include a new \`action\` string.

Suppressing with \`//nolint:staticcheck\` and a TODO comment on all 5 recorder sites (the 3 CI flagged plus the other 2 for consistency). Proper migration belongs in its own PR where the action-name semantics can be decided deliberately.

## Warnings not addressed (upstream)

- **Node.js 20 actions are deprecated** — comes from the reusable \`jacaudi/github-actions\` workflow, not our code
- **golangci-lint version mismatch** — \`.custom-gcl.yml\` pins v2.8.0; the component-lint action uses something else. Our repo's lint runs via \`make lint\` always use the custom build, so this is a CI-runner inconsistency to resolve upstream

## Test plan

- [x] \`make lint\` — still 0 issues locally
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 6 packages pass (no test changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)