### PR TITLE
fix(controller): log zone-ref-not-ready at Info, not Error

### DIFF
--- a/internal/controller/cloudflarednsrecord_controller.go
+++ b/internal/controller/cloudflarednsrecord_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -91,7 +92,11 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 	// 3.5. Resolve zone ID
 	resolvedZoneID, err := ResolveZoneID(ctx, r.Client, &dnsRecord)
 	if err != nil {
-		logger.Error(err, "failed to resolve zone ID")
+		if stderrors.Is(err, ErrZoneRefNotReady) {
+			logger.Info("waiting for zone reference", "error", err.Error())
+		} else {
+			logger.Error(err, "failed to resolve zone ID")
+		}
 		return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
 			cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}

--- a/internal/controller/cloudflareruleset_controller.go
+++ b/internal/controller/cloudflareruleset_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -90,7 +91,11 @@ func (r *CloudflareRulesetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// 3.5. Resolve zone ID
 	resolvedZoneID, err := ResolveZoneID(ctx, r.Client, &ruleset)
 	if err != nil {
-		logger.Error(err, "failed to resolve zone ID")
+		if stderrors.Is(err, ErrZoneRefNotReady) {
+			logger.Info("waiting for zone reference", "error", err.Error())
+		} else {
+			logger.Error(err, "failed to resolve zone ID")
+		}
 		return failReconcile(ctx, r.Client, &ruleset, &ruleset.Status.Conditions,
 			cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}

--- a/internal/controller/cloudflarezoneconfig_controller.go
+++ b/internal/controller/cloudflarezoneconfig_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -92,7 +93,11 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	// 3.5. Resolve zone ID
 	resolvedZoneID, err := ResolveZoneID(ctx, r.Client, &zoneConfig)
 	if err != nil {
-		logger.Error(err, "failed to resolve zone ID")
+		if stderrors.Is(err, ErrZoneRefNotReady) {
+			logger.Info("waiting for zone reference", "error", err.Error())
+		} else {
+			logger.Error(err, "failed to resolve zone ID")
+		}
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
 			cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}

--- a/internal/controller/zoneref.go
+++ b/internal/controller/zoneref.go
@@ -17,14 +17,23 @@ limitations under the License.
 package controller
 
 import (
-	"context"
+	"errors"
 	"fmt"
+
+	"context"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 )
+
+// ErrZoneRefNotReady is returned by ResolveZoneID when the referenced
+// CloudflareZone exists but has not yet populated its status.ZoneID. Callers
+// can check with errors.Is to log this as an Info-level "waiting on
+// dependency" rather than an Error, since it resolves on its own once the
+// zone reconciles.
+var ErrZoneRefNotReady = errors.New("zone reference is not ready")
 
 // zoneReferencer is implemented by CRDs whose spec either hardcodes a Cloudflare
 // zone ID or references a CloudflareZone CR. It lets ResolveZoneID accept any of
@@ -37,7 +46,8 @@ type zoneReferencer interface {
 
 // ResolveZoneID returns the Cloudflare zone ID for obj: either its inline
 // Spec.ZoneID, or the ZoneID from the CloudflareZone it references via
-// Spec.ZoneRef (looked up in obj's namespace).
+// Spec.ZoneRef (looked up in obj's namespace). Returns ErrZoneRefNotReady
+// (wrapped) when the referenced zone exists but hasn't populated ZoneID yet.
 func ResolveZoneID(ctx context.Context, k8sClient client.Client, obj zoneReferencer) (string, error) {
 	if id := obj.GetZoneID(); id != "" {
 		return id, nil
@@ -56,7 +66,7 @@ func ResolveZoneID(ctx context.Context, k8sClient client.Client, obj zoneReferen
 	}
 
 	if zone.Status.ZoneID == "" {
-		return "", fmt.Errorf("CloudflareZone %q does not have a zone ID yet (status: %s)", ref.Name, zone.Status.Status)
+		return "", fmt.Errorf("%w: CloudflareZone %q (status: %q)", ErrZoneRefNotReady, ref.Name, zone.Status.Status)
 	}
 
 	return zone.Status.ZoneID, nil


### PR DESCRIPTION
## Problem

Operator logs like these were showing up at \`ERROR\` level:

\`\`\`
ERROR failed to resolve zone ID  err="CloudflareZone \"jacaudi-dev\" does not have a zone ID yet (status: )"
\`\`\`

That's a transient "waiting on dependency" — the referenced zone exists but hasn't populated \`status.zoneID\` yet. It resolves on its own when the zone reconciles. Logging it at ERROR creates alert noise and makes real errors harder to spot.

## Fix

- Add \`ErrZoneRefNotReady\` sentinel in \`internal/controller/zoneref.go\`. It's wrapped into the returned error only for the "zone exists, ZoneID still empty" branch — other failure modes (missing zoneRef, k8s \`Get\` failure on the zone, RBAC denial) return plain errors as before.
- DNS record, ruleset, and zone config reconcilers now \`errors.Is(err, ErrZoneRefNotReady)\` and log at \`Info\` level for that specific case. Actual errors still log at \`Error\`.

The \`Ready=False\` status condition with \`ReasonZoneRefNotReady\` stays intact, so \`kubectl describe\` still shows users exactly what's happening. No status-observability loss — just log-level hygiene.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` — all 6 packages pass
- [x] \`make lint\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)