### PR TITLE
fix(zoneconfig): apply settings groups independently (closes #51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `CloudflareZoneConfig`: a permission/plan failure on one settings group (most commonly `bot_management` on Free zones, or a token without `Zone:Bot Management:Edit`) no longer blocks the rest of the spec from being applied. Each group now records its own `<Group>Applied` status condition with reason `Applied`, `NotConfigured`, `PermissionDenied`, or `CloudflareAPIError`. The resource's `Ready` condition is `False` with `Reason=PartialApply` until every configured group succeeds. ([#51](https://github.com/jacaudi/cloudflare-operator/issues/51))
+
 ## [0.6.0](https://github.com/jacaudi/cloudflare-operator/compare/v0.5.1...v0.6.0) (2026-04-26)
 
 ### Features

--- a/api/v1alpha1/cloudflarezoneconfig_types.go
+++ b/api/v1alpha1/cloudflarezoneconfig_types.go
@@ -165,6 +165,13 @@ type NetworkSettings struct {
 }
 
 // BotManagementSettings defines bot management settings for a Cloudflare zone.
+//
+// Configuring this section requires the Zone:Bot Management:Edit scope on the
+// API token and a Cloudflare plan that supports bot management. On Free plans
+// this section's API call returns 403; the controller will surface that on
+// the BotManagementApplied condition with reason=PermissionDenied without
+// preventing other groups (ssl / security / performance / network) from
+// being applied.
 type BotManagementSettings struct {
 	// EnableJS enables JavaScript detections.
 	// +optional

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -32,12 +32,17 @@ type TunnelReference struct {
 
 // Condition type constants used across all CRDs.
 const (
-	ConditionTypeReady             = "Ready"
-	ConditionTypeValid             = "Valid"
-	ConditionTypeTunnelAccepted    = "TunnelAccepted"
-	ConditionTypeConflict          = "Conflict"
-	ConditionTypeConnectorReady    = "ConnectorReady"
-	ConditionTypeIngressConfigured = "IngressConfigured"
+	ConditionTypeReady                = "Ready"
+	ConditionTypeValid                = "Valid"
+	ConditionTypeTunnelAccepted       = "TunnelAccepted"
+	ConditionTypeConflict             = "Conflict"
+	ConditionTypeConnectorReady       = "ConnectorReady"
+	ConditionTypeIngressConfigured    = "IngressConfigured"
+	ConditionTypeSSLApplied           = "SSLApplied"
+	ConditionTypeSecurityApplied      = "SecurityApplied"
+	ConditionTypePerformanceApplied   = "PerformanceApplied"
+	ConditionTypeNetworkApplied       = "NetworkApplied"
+	ConditionTypeBotManagementApplied = "BotManagementApplied"
 )
 
 // Condition reason constants.
@@ -69,6 +74,10 @@ const (
 	ReasonRecordAdopted     = "RecordAdopted"
 	ReasonDNSReconciled     = "DNSReconciled"
 	ReasonDuplicateHostname = "DuplicateHostname"
+	ReasonApplied           = "Applied"
+	ReasonNotConfigured     = "NotConfigured"
+	ReasonPermissionDenied  = "PermissionDenied"
+	ReasonPartialApply      = "PartialApply"
 )
 
 // FinalizerName is the finalizer used by all cloudflare-operator controllers.

--- a/api/v1alpha1/common_types_test.go
+++ b/api/v1alpha1/common_types_test.go
@@ -21,10 +21,29 @@ func TestReasonConstants(t *testing.T) {
 		ReasonInvalidSpec,
 		ReasonDeletingResource,
 		ReasonIPResolutionError,
+		ReasonApplied,
+		ReasonNotConfigured,
+		ReasonPermissionDenied,
+		ReasonPartialApply,
 	}
 	for _, r := range reasons {
 		if r == "" {
 			t.Error("reason constant should not be empty")
+		}
+	}
+}
+
+func TestConditionTypeConstants(t *testing.T) {
+	conditionTypes := []string{
+		ConditionTypeSSLApplied,
+		ConditionTypeSecurityApplied,
+		ConditionTypePerformanceApplied,
+		ConditionTypeNetworkApplied,
+		ConditionTypeBotManagementApplied,
+	}
+	for _, c := range conditionTypes {
+		if c == "" {
+			t.Errorf("condition type constant should not be empty")
 		}
 	}
 }

--- a/config/samples/cloudflare_v1alpha1_cloudflarezoneconfig.yaml
+++ b/config/samples/cloudflare_v1alpha1_cloudflarezoneconfig.yaml
@@ -1,3 +1,10 @@
+# Required token scopes per group:
+#   ssl / security / performance / network: Zone:Zone Settings:Edit
+#   botManagement:                           Zone:Bot Management:Edit (paid plan)
+#
+# Groups you don't configure won't be touched. A failure on one group
+# (e.g., a 403 on botManagement) won't block the others — see
+# .status.conditions for per-group state.
 apiVersion: cloudflare.io/v1alpha1
 kind: CloudflareZoneConfig
 metadata:

--- a/docs/README.md
+++ b/docs/README.md
@@ -377,6 +377,20 @@ spec:
     fightMode: true
 ```
 
+#### Required token scopes per group
+
+`CloudflareZoneConfig` calls Cloudflare APIs only for the groups you configure. Your API token must include the matching scopes:
+
+| Group           | Required token scope                          |
+| --------------- | --------------------------------------------- |
+| `ssl`           | Zone:Zone Settings:Edit                       |
+| `security`      | Zone:Zone Settings:Edit                       |
+| `performance`   | Zone:Zone Settings:Edit                       |
+| `network`       | Zone:Zone Settings:Edit                       |
+| `botManagement` | Zone:Bot Management:Edit (and a paid plan that supports bot management) |
+
+If a group fails to apply (e.g., a 403 on `botManagement` because the token lacks scope or the zone is on Free), other groups are still applied and a per-group condition (`BotManagementApplied=False, Reason=PermissionDenied`) surfaces the failure. The resource's `Ready` condition is `False` with `Reason=PartialApply` until every configured group succeeds.
+
 ### Print Columns
 
 ```

--- a/internal/cloudflare/errors.go
+++ b/internal/cloudflare/errors.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package cloudflare
+
+import (
+	"errors"
+	"net/http"
+
+	cfgo "github.com/cloudflare/cloudflare-go/v6"
+)
+
+// IsPermissionDenied reports whether err originated from a Cloudflare API
+// 403 response. The most common cause is a missing token scope (e.g.,
+// Zone:Bot Management Write) or a plan that does not permit the requested
+// setting (e.g., bot_management on a Free zone). Wrapped errors are
+// unwrapped via errors.As.
+func IsPermissionDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *cfgo.Error
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusForbidden
+}

--- a/internal/cloudflare/errors_test.go
+++ b/internal/cloudflare/errors_test.go
@@ -1,0 +1,43 @@
+package cloudflare
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	cfgo "github.com/cloudflare/cloudflare-go/v6"
+)
+
+func TestIsPermissionDenied(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"403 cfgo.Error", &cfgo.Error{StatusCode: http.StatusForbidden}, true},
+		{"401 cfgo.Error", &cfgo.Error{StatusCode: http.StatusUnauthorized}, false},
+		{"404 cfgo.Error", &cfgo.Error{StatusCode: http.StatusNotFound}, false},
+		{"500 cfgo.Error", &cfgo.Error{StatusCode: http.StatusInternalServerError}, false},
+		{
+			"wrapped 403",
+			fmt.Errorf("update bot management: %w", &cfgo.Error{StatusCode: http.StatusForbidden}),
+			true,
+		},
+		{
+			"double-wrapped 403",
+			fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &cfgo.Error{StatusCode: http.StatusForbidden})),
+			true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPermissionDenied(tc.err); got != tc.want {
+				t.Errorf("IsPermissionDenied(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/cloudflarezoneconfig_controller.go
+++ b/internal/controller/cloudflarezoneconfig_controller.go
@@ -111,11 +111,13 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
 	}
 
-	// 5. Reconcile the zone config
+	// 5. Reconcile the zone config.
+	// Per-group conditions set inside reconcileZoneConfig (via status.SetCondition)
+	// survive failReconcile because failReconcile only mutates the Ready slot via
+	// status.SetReady. Both go through the same Status().Update call.
 	result, err := r.reconcileZoneConfig(ctx, &zoneConfig, r.zoneClient(apiToken), resolvedZoneID)
 	if err != nil {
 		logger.Error(err, "reconciliation failed")
-		r.Recorder.Event(&zoneConfig, corev1.EventTypeWarning, "SyncFailed", err.Error())
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
 			cloudflarev1alpha1.ReasonPartialApply, err, time.Minute)
 	}
@@ -310,13 +312,6 @@ func (r *CloudflareZoneConfigReconciler) reconcileZoneConfig(ctx context.Context
 	// All configured groups succeeded.
 	zoneConfig.Status.AppliedSpecHash = desiredHash
 
-	totalApplied := 0
-	for _, g := range results {
-		totalApplied += g.settingsCount
-	}
-	r.Recorder.Event(zoneConfig, corev1.EventTypeNormal, "SettingsApplied",
-		fmt.Sprintf("Applied %d settings to zone %s", totalApplied, zoneID))
-
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
@@ -451,14 +446,18 @@ func (r *CloudflareZoneConfigReconciler) emitGroupTransitionEvents(
 
 // aggregateErr produces a single error summarizing all failed groups,
 // suitable for failReconcile to log/surface in the Ready condition.
+// The summary uses each group's classified reason rather than the raw
+// error string, so the wrapped underlying error (via %w) does not appear
+// duplicated in the human-readable message.
 func aggregateErr(failed []groupResult) error {
 	parts := make([]string, 0, len(failed))
 	for _, g := range failed {
-		parts = append(parts, fmt.Sprintf("%s: %s", g.groupLabel, g.err.Error()))
+		parts = append(parts, fmt.Sprintf("%s: %s", g.groupLabel, g.reason()))
 	}
 	// Wrap the first failed group's underlying error so errors.Is/As can still
 	// classify it (e.g., IsPermissionDenied for a single 403).
-	return fmt.Errorf("partial apply failed for %d group(s): %s: %w", len(failed), strings.Join(parts, "; "), failed[0].err)
+	return fmt.Errorf("partial apply failed for %d group(s) [%s]: %w",
+		len(failed), strings.Join(parts, ", "), failed[0].err)
 }
 
 // hashZoneConfigSpec returns a sha256 hex digest over the settings-relevant

--- a/internal/controller/cloudflarezoneconfig_controller.go
+++ b/internal/controller/cloudflarezoneconfig_controller.go
@@ -24,6 +24,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -116,7 +117,7 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 		logger.Error(err, "reconciliation failed")
 		r.Recorder.Event(&zoneConfig, corev1.EventTypeWarning, "SyncFailed", err.Error())
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
-			cloudflarev1alpha1.ReasonCloudflareError, err, time.Minute)
+			cloudflarev1alpha1.ReasonPartialApply, err, time.Minute)
 	}
 
 	// 7. Persist status only if anything materially changed.
@@ -146,16 +147,6 @@ func appendIfSet[T any](updates []settingUpdate, id string, value *T) []settingU
 		return updates
 	}
 	return append(updates, settingUpdate{id, *value})
-}
-
-// collectSettings maps non-nil spec fields to Cloudflare setting IDs and values.
-func collectSettings(spec *cloudflarev1alpha1.CloudflareZoneConfigSpec) []settingUpdate {
-	var updates []settingUpdate
-	updates = appendSSL(updates, spec.SSL)
-	updates = appendSecurity(updates, spec.Security)
-	updates = appendPerformance(updates, spec.Performance)
-	updates = appendNetwork(updates, spec.Network)
-	return updates
 }
 
 func appendSSL(updates []settingUpdate, ssl *cloudflarev1alpha1.SSLSettings) []settingUpdate {
@@ -223,6 +214,51 @@ func appendNetwork(updates []settingUpdate, net *cloudflarev1alpha1.NetworkSetti
 	return updates
 }
 
+// groupResult captures the outcome of applying a single settings group.
+type groupResult struct {
+	conditionType string // e.g., ConditionTypeSSLApplied
+	groupLabel    string // human-readable, e.g., "SSL"
+	configured    bool   // true if the user set this section
+	err           error  // nil on success or NotConfigured
+	settingsCount int    // count of settings touched on success
+}
+
+// status returns the metav1.ConditionStatus for this group.
+func (g groupResult) status() metav1.ConditionStatus {
+	if !g.configured {
+		return metav1.ConditionFalse
+	}
+	if g.err != nil {
+		return metav1.ConditionFalse
+	}
+	return metav1.ConditionTrue
+}
+
+// reason returns the condition reason for this group.
+func (g groupResult) reason() string {
+	if !g.configured {
+		return cloudflarev1alpha1.ReasonNotConfigured
+	}
+	if g.err == nil {
+		return cloudflarev1alpha1.ReasonApplied
+	}
+	if cfclient.IsPermissionDenied(g.err) {
+		return cloudflarev1alpha1.ReasonPermissionDenied
+	}
+	return cloudflarev1alpha1.ReasonCloudflareError
+}
+
+// message returns the condition message for this group.
+func (g groupResult) message() string {
+	if !g.configured {
+		return fmt.Sprintf("%s settings not configured", g.groupLabel)
+	}
+	if g.err == nil {
+		return fmt.Sprintf("applied %d %s settings", g.settingsCount, g.groupLabel)
+	}
+	return g.err.Error()
+}
+
 func (r *CloudflareZoneConfigReconciler) reconcileZoneConfig(ctx context.Context, zoneConfig *cloudflarev1alpha1.CloudflareZoneConfig, zoneClient cfclient.ZoneClient, zoneID string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -240,33 +276,189 @@ func (r *CloudflareZoneConfigReconciler) reconcileZoneConfig(ctx context.Context
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
-	// Apply regular zone settings
-	settings := collectSettings(&zoneConfig.Spec)
-	for _, s := range settings {
-		if err := zoneClient.UpdateSetting(ctx, zoneID, s.id, s.value); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update setting %s: %w", s.id, err)
-		}
-	}
-	appliedCount := len(settings)
+	// Snapshot prior per-group condition status so we can emit transition events.
+	priorStatuses := snapshotGroupStatuses(zoneConfig.Status.Conditions)
 
-	// Handle bot management separately (different API)
-	if zoneConfig.Spec.BotManagement != nil {
-		config := cfclient.BotManagementConfig{
-			EnableJS:  zoneConfig.Spec.BotManagement.EnableJS,
-			FightMode: zoneConfig.Spec.BotManagement.FightMode,
-		}
-		if err := zoneClient.UpdateBotManagement(ctx, zoneID, config); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update bot management: %w", err)
-		}
-		appliedCount++
+	results := []groupResult{
+		applySSLGroup(ctx, zoneClient, zoneID, zoneConfig.Spec.SSL),
+		applySecurityGroup(ctx, zoneClient, zoneID, zoneConfig.Spec.Security),
+		applyPerformanceGroup(ctx, zoneClient, zoneID, zoneConfig.Spec.Performance),
+		applyNetworkGroup(ctx, zoneClient, zoneID, zoneConfig.Spec.Network),
+		applyBotManagementGroup(ctx, zoneClient, zoneID, zoneConfig.Spec.BotManagement),
 	}
 
+	// Persist per-group conditions.
+	for _, g := range results {
+		status.SetCondition(&zoneConfig.Status.Conditions, g.conditionType, g.status(), g.reason(), g.message(), zoneConfig.Generation)
+	}
+
+	// Emit transition events.
+	r.emitGroupTransitionEvents(zoneConfig, priorStatuses, results)
+
+	// Aggregate failures.
+	var failed []groupResult
+	for _, g := range results {
+		if g.configured && g.err != nil {
+			failed = append(failed, g)
+		}
+	}
+	if len(failed) > 0 {
+		// Don't update appliedSpecHash — failed groups must retry next reconcile.
+		return ctrl.Result{}, aggregateErr(failed)
+	}
+
+	// All configured groups succeeded.
 	zoneConfig.Status.AppliedSpecHash = desiredHash
 
+	totalApplied := 0
+	for _, g := range results {
+		totalApplied += g.settingsCount
+	}
 	r.Recorder.Event(zoneConfig, corev1.EventTypeNormal, "SettingsApplied",
-		fmt.Sprintf("Applied %d settings to zone %s", appliedCount, zoneID))
+		fmt.Sprintf("Applied %d settings to zone %s", totalApplied, zoneID))
 
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+// applySSLGroup applies the SSL settings group, if configured.
+func applySSLGroup(ctx context.Context, zoneClient cfclient.ZoneClient, zoneID string, ssl *cloudflarev1alpha1.SSLSettings) groupResult {
+	g := groupResult{conditionType: cloudflarev1alpha1.ConditionTypeSSLApplied, groupLabel: "SSL"}
+	if ssl == nil {
+		return g
+	}
+	g.configured = true
+	updates := appendSSL(nil, ssl)
+	for _, s := range updates {
+		if err := zoneClient.UpdateSetting(ctx, zoneID, s.id, s.value); err != nil {
+			g.err = fmt.Errorf("update setting %s: %w", s.id, err)
+			return g
+		}
+	}
+	g.settingsCount = len(updates)
+	return g
+}
+
+// applySecurityGroup applies the Security settings group, if configured.
+func applySecurityGroup(ctx context.Context, zoneClient cfclient.ZoneClient, zoneID string, sec *cloudflarev1alpha1.SecuritySettings) groupResult {
+	g := groupResult{conditionType: cloudflarev1alpha1.ConditionTypeSecurityApplied, groupLabel: "Security"}
+	if sec == nil {
+		return g
+	}
+	g.configured = true
+	updates := appendSecurity(nil, sec)
+	for _, s := range updates {
+		if err := zoneClient.UpdateSetting(ctx, zoneID, s.id, s.value); err != nil {
+			g.err = fmt.Errorf("update setting %s: %w", s.id, err)
+			return g
+		}
+	}
+	g.settingsCount = len(updates)
+	return g
+}
+
+// applyPerformanceGroup applies the Performance settings group, if configured.
+func applyPerformanceGroup(ctx context.Context, zoneClient cfclient.ZoneClient, zoneID string, perf *cloudflarev1alpha1.PerformanceSettings) groupResult {
+	g := groupResult{conditionType: cloudflarev1alpha1.ConditionTypePerformanceApplied, groupLabel: "Performance"}
+	if perf == nil {
+		return g
+	}
+	g.configured = true
+	updates := appendPerformance(nil, perf)
+	for _, s := range updates {
+		if err := zoneClient.UpdateSetting(ctx, zoneID, s.id, s.value); err != nil {
+			g.err = fmt.Errorf("update setting %s: %w", s.id, err)
+			return g
+		}
+	}
+	g.settingsCount = len(updates)
+	return g
+}
+
+// applyNetworkGroup applies the Network settings group, if configured.
+func applyNetworkGroup(ctx context.Context, zoneClient cfclient.ZoneClient, zoneID string, net *cloudflarev1alpha1.NetworkSettings) groupResult {
+	g := groupResult{conditionType: cloudflarev1alpha1.ConditionTypeNetworkApplied, groupLabel: "Network"}
+	if net == nil {
+		return g
+	}
+	g.configured = true
+	updates := appendNetwork(nil, net)
+	for _, s := range updates {
+		if err := zoneClient.UpdateSetting(ctx, zoneID, s.id, s.value); err != nil {
+			g.err = fmt.Errorf("update setting %s: %w", s.id, err)
+			return g
+		}
+	}
+	g.settingsCount = len(updates)
+	return g
+}
+
+// applyBotManagementGroup applies the BotManagement settings group, if configured.
+func applyBotManagementGroup(ctx context.Context, zoneClient cfclient.ZoneClient, zoneID string, bm *cloudflarev1alpha1.BotManagementSettings) groupResult {
+	g := groupResult{conditionType: cloudflarev1alpha1.ConditionTypeBotManagementApplied, groupLabel: "BotManagement"}
+	if bm == nil {
+		return g
+	}
+	g.configured = true
+	config := cfclient.BotManagementConfig{
+		EnableJS:  bm.EnableJS,
+		FightMode: bm.FightMode,
+	}
+	if err := zoneClient.UpdateBotManagement(ctx, zoneID, config); err != nil {
+		g.err = fmt.Errorf("update bot management: %w", err)
+		return g
+	}
+	g.settingsCount = 1 // bot_management is one logical group/api call
+	return g
+}
+
+// snapshotGroupStatuses returns a map of condition type -> status from the
+// pre-reconcile condition list, used to detect transitions.
+func snapshotGroupStatuses(conds []metav1.Condition) map[string]metav1.ConditionStatus {
+	out := map[string]metav1.ConditionStatus{}
+	for _, c := range conds {
+		out[c.Type] = c.Status
+	}
+	return out
+}
+
+// emitGroupTransitionEvents emits SettingsApplied / SettingsApplyFailed events
+// for groups whose status changed since the prior reconcile. Steady-state
+// reconciles produce no events for these groups.
+func (r *CloudflareZoneConfigReconciler) emitGroupTransitionEvents(
+	obj client.Object,
+	prior map[string]metav1.ConditionStatus,
+	results []groupResult,
+) {
+	for _, g := range results {
+		newStatus := g.status()
+		oldStatus, hadPrior := prior[g.conditionType]
+		// Skip NotConfigured groups — they don't change state in a way users care about.
+		if !g.configured && (!hadPrior || oldStatus == newStatus) {
+			continue
+		}
+		if hadPrior && oldStatus == newStatus {
+			continue
+		}
+		if g.configured && g.err == nil {
+			r.Recorder.Eventf(obj, corev1.EventTypeNormal, "SettingsApplied",
+				"%s applied (%d settings)", g.groupLabel, g.settingsCount)
+		} else if g.configured && g.err != nil {
+			r.Recorder.Eventf(obj, corev1.EventTypeWarning, "SettingsApplyFailed",
+				"%s failed: %s: %s", g.groupLabel, g.reason(), g.err.Error())
+		}
+	}
+}
+
+// aggregateErr produces a single error summarizing all failed groups,
+// suitable for failReconcile to log/surface in the Ready condition.
+func aggregateErr(failed []groupResult) error {
+	parts := make([]string, 0, len(failed))
+	for _, g := range failed {
+		parts = append(parts, fmt.Sprintf("%s: %s", g.groupLabel, g.err.Error()))
+	}
+	// Wrap the first failed group's underlying error so errors.Is/As can still
+	// classify it (e.g., IsPermissionDenied for a single 403).
+	return fmt.Errorf("partial apply failed for %d group(s): %s: %w", len(failed), strings.Join(parts, "; "), failed[0].err)
 }
 
 // hashZoneConfigSpec returns a sha256 hex digest over the settings-relevant

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -918,3 +918,72 @@ func TestZoneConfigReconcile_GroupRemovedFromSpec(t *testing.T) {
 		t.Errorf("Ready = %+v, want True", ready)
 	}
 }
+
+// TestZoneConfigReconcile_NoEventSpamInSteadyDegradedState verifies that a
+// CloudflareZoneConfig stuck in a degraded state (e.g. persistent BotManagement
+// 403) does not produce a fresh Warning event on every reconcile. Per design
+// §4.5, per-group events fire only on transitions, and the top-level
+// SyncFailed event has been removed in favor of the Ready=False condition's
+// aggregated message.
+func TestZoneConfigReconcile_NoEventSpamInSteadyDegradedState(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+	enableJS := true
+	zoneConfig.Spec.BotManagement = &cloudflarev1alpha1.BotManagementSettings{EnableJS: &enableJS}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	mock.botUpdateErr = &cfgov6.Error{StatusCode: http.StatusForbidden}
+
+	recorder := record.NewFakeRecorder(20)
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+	r.Recorder = recorder
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"}}
+
+	// Two consecutive failing reconciles with the bot 403 still injected.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile error: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second reconcile error: %v", err)
+	}
+
+	// Confirm steady-state degraded conditions persist on the object.
+	var updated cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	bm := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeBotManagementApplied)
+	if bm == nil || bm.Status != metav1.ConditionFalse || bm.Reason != cloudflarev1alpha1.ReasonPermissionDenied {
+		t.Errorf("BotManagementApplied = %+v, want False/PermissionDenied", bm)
+	}
+	ready := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != cloudflarev1alpha1.ReasonPartialApply {
+		t.Errorf("Ready = %+v, want False/PartialApply", ready)
+	}
+
+	// Drain events accumulated across both reconciles.
+	got := drainEvents(recorder)
+
+	// Count by reason.
+	syncFailedCount := 0
+	bmApplyFailedCount := 0
+	for _, e := range got {
+		if strings.Contains(e, " SyncFailed ") {
+			syncFailedCount++
+		}
+		if strings.HasPrefix(e, "Warning SettingsApplyFailed BotManagement") {
+			bmApplyFailedCount++
+		}
+	}
+
+	if syncFailedCount != 0 {
+		t.Errorf("expected 0 SyncFailed events (top-level event was removed); got %d. events=%v", syncFailedCount, got)
+	}
+	if bmApplyFailedCount != 1 {
+		t.Errorf("expected exactly 1 SettingsApplyFailed BotManagement event (transition-only); got %d. events=%v", bmApplyFailedCount, got)
+	}
+}

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -670,4 +671,250 @@ func findCondition(conds []metav1.Condition, t string) *metav1.Condition {
 		}
 	}
 	return nil
+}
+
+func TestZoneConfigReconcile_PartialApply_Generic5xx(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+
+	secLevel := "medium"
+	zoneConfig.Spec.Security = &cloudflarev1alpha1.SecuritySettings{SecurityLevel: &secLevel}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	mock.updateErrors["ssl"] = &cfgov6.Error{StatusCode: http.StatusBadGateway}
+
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if contains(mock.appliedSettings, "ssl") {
+		t.Error("ssl should not have been recorded as applied")
+	}
+	if !contains(mock.appliedSettings, "security_level") {
+		t.Errorf("security_level expected; appliedSettings=%v", mock.appliedSettings)
+	}
+
+	var updated cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	ssl := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeSSLApplied)
+	if ssl == nil || ssl.Status != metav1.ConditionFalse || ssl.Reason != cloudflarev1alpha1.ReasonCloudflareError {
+		t.Errorf("ssl condition = %+v, want False/CloudflareAPIError", ssl)
+	}
+	sec := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeSecurityApplied)
+	if sec == nil || sec.Status != metav1.ConditionTrue || sec.Reason != cloudflarev1alpha1.ReasonApplied {
+		t.Errorf("security condition = %+v, want True/Applied", sec)
+	}
+}
+
+func TestZoneConfigReconcile_FullSuccess_SetsHashAndReady(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+	enableJS := true
+	zoneConfig.Spec.BotManagement = &cloudflarev1alpha1.BotManagementSettings{EnableJS: &enableJS}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	if updated.Status.AppliedSpecHash == "" {
+		t.Error("expected appliedSpecHash to be set on full success")
+	}
+	ready := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionTrue || ready.Reason != cloudflarev1alpha1.ReasonReconcileSuccess {
+		t.Errorf("ready = %+v, want True/ReconcileSuccess", ready)
+	}
+}
+
+func TestZoneConfigReconcile_HashSkip(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+
+	// Pre-set the hash to match the current spec to simulate "already converged".
+	zoneConfig.Status.AppliedSpecHash = hashZoneConfigSpec(&zoneConfig.Spec)
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mock.updateSettingCalls != 0 {
+		t.Errorf("expected 0 UpdateSetting calls when hash matches, got %d", mock.updateSettingCalls)
+	}
+	if mock.updateBotCalled {
+		t.Error("expected UpdateBotManagement NOT to be called when hash matches")
+	}
+}
+
+func TestZoneConfigReconcile_RecoverFromPartial(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+	enableJS := true
+	zoneConfig.Spec.BotManagement = &cloudflarev1alpha1.BotManagementSettings{EnableJS: &enableJS}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	mock.botUpdateErr = &cfgov6.Error{StatusCode: http.StatusForbidden}
+
+	recorder := record.NewFakeRecorder(20)
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+	r.Recorder = recorder
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"}}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile error: %v", err)
+	}
+
+	// Now clear the bot 403 and re-reconcile.
+	mock.botUpdateErr = nil
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second reconcile error: %v", err)
+	}
+
+	var updated cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	if updated.Status.AppliedSpecHash == "" {
+		t.Error("expected appliedSpecHash to be set after recovery")
+	}
+	bm := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeBotManagementApplied)
+	if bm == nil || bm.Status != metav1.ConditionTrue {
+		t.Errorf("BotManagementApplied = %+v, want True", bm)
+	}
+
+	// Drain the recorder and assert at least one Normal SettingsApplied event for BotManagement.
+	got := drainEvents(recorder)
+	wantPrefix := "Normal SettingsApplied BotManagement applied"
+	found := false
+	for _, e := range got {
+		if strings.HasPrefix(e, wantPrefix) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected event with prefix %q; got %v", wantPrefix, got)
+	}
+}
+
+func TestZoneConfigReconcile_NotConfiguredCondition(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+	// No Security / Performance / Network / BotManagement.
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	for _, ct := range []string{
+		cloudflarev1alpha1.ConditionTypeSecurityApplied,
+		cloudflarev1alpha1.ConditionTypePerformanceApplied,
+		cloudflarev1alpha1.ConditionTypeNetworkApplied,
+		cloudflarev1alpha1.ConditionTypeBotManagementApplied,
+	} {
+		c := findCondition(updated.Status.Conditions, ct)
+		if c == nil {
+			t.Errorf("%s not set", ct)
+			continue
+		}
+		if c.Status != metav1.ConditionFalse || c.Reason != cloudflarev1alpha1.ReasonNotConfigured {
+			t.Errorf("%s = %+v, want False/NotConfigured", ct, c)
+		}
+	}
+	ssl := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeSSLApplied)
+	if ssl == nil || ssl.Status != metav1.ConditionTrue || ssl.Reason != cloudflarev1alpha1.ReasonApplied {
+		t.Errorf("SSLApplied = %+v, want True/Applied", ssl)
+	}
+}
+
+func TestZoneConfigReconcile_GroupRemovedFromSpec(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+	enableJS := true
+	zoneConfig.Spec.BotManagement = &cloudflarev1alpha1.BotManagementSettings{EnableJS: &enableJS}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"}}
+
+	// First reconcile: both groups apply.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	// Mutate the spec — remove BotManagement.
+	var updated cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	updated.Spec.BotManagement = nil
+	updated.Generation = 2
+	if err := r.Update(context.Background(), &updated); err != nil {
+		t.Fatalf("update spec: %v", err)
+	}
+
+	// Second reconcile.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	if err := r.Get(context.Background(), req.NamespacedName, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+	bm := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeBotManagementApplied)
+	if bm == nil || bm.Status != metav1.ConditionFalse || bm.Reason != cloudflarev1alpha1.ReasonNotConfigured {
+		t.Errorf("BotManagementApplied = %+v, want False/NotConfigured", bm)
+	}
+	ready := findCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if ready == nil || ready.Status != metav1.ConditionTrue {
+		t.Errorf("Ready = %+v, want True", ready)
+	}
 }

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -2,12 +2,14 @@ package controller
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
 	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	cfclient "github.com/jacaudi/cloudflare-operator/internal/cloudflare"
 
+	cfgov6 "github.com/cloudflare/cloudflare-go/v6"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -577,4 +579,95 @@ func TestZoneConfigReconcile_ZoneRefNotReady(t *testing.T) {
 	if !foundCondition {
 		t.Error("expected Ready condition to be set")
 	}
+}
+
+func TestZoneConfigReconcile_PartialApply_BotManagement403(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+
+	secLevel := "medium"
+	zoneConfig.Spec.Security = &cloudflarev1alpha1.SecuritySettings{SecurityLevel: &secLevel}
+
+	enableJS := true
+	zoneConfig.Spec.BotManagement = &cloudflarev1alpha1.BotManagementSettings{EnableJS: &enableJS}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	mock.botUpdateErr = &cfgov6.Error{StatusCode: http.StatusForbidden}
+
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	})
+	// failReconcile returns nil err and a requeue, so the outer Reconcile returns nil.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// SSL and Security applied; BotManagement attempted and failed.
+	if !contains(mock.appliedSettings, "ssl") {
+		t.Errorf("expected ssl to be applied, got %v", mock.appliedSettings)
+	}
+	if !contains(mock.appliedSettings, "security_level") {
+		t.Errorf("expected security_level to be applied, got %v", mock.appliedSettings)
+	}
+	if !mock.updateBotCalled {
+		t.Error("expected UpdateBotManagement to be attempted")
+	}
+
+	var updated cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get updated: %v", err)
+	}
+
+	wantConditions := map[string]struct {
+		status metav1.ConditionStatus
+		reason string
+	}{
+		cloudflarev1alpha1.ConditionTypeSSLApplied:           {metav1.ConditionTrue, cloudflarev1alpha1.ReasonApplied},
+		cloudflarev1alpha1.ConditionTypeSecurityApplied:      {metav1.ConditionTrue, cloudflarev1alpha1.ReasonApplied},
+		cloudflarev1alpha1.ConditionTypePerformanceApplied:   {metav1.ConditionFalse, cloudflarev1alpha1.ReasonNotConfigured},
+		cloudflarev1alpha1.ConditionTypeNetworkApplied:       {metav1.ConditionFalse, cloudflarev1alpha1.ReasonNotConfigured},
+		cloudflarev1alpha1.ConditionTypeBotManagementApplied: {metav1.ConditionFalse, cloudflarev1alpha1.ReasonPermissionDenied},
+		cloudflarev1alpha1.ConditionTypeReady:                {metav1.ConditionFalse, cloudflarev1alpha1.ReasonPartialApply},
+	}
+	for ct, want := range wantConditions {
+		got := findCondition(updated.Status.Conditions, ct)
+		if got == nil {
+			t.Errorf("condition %s not set", ct)
+			continue
+		}
+		if got.Status != want.status {
+			t.Errorf("%s status = %s, want %s", ct, got.Status, want.status)
+		}
+		if got.Reason != want.reason {
+			t.Errorf("%s reason = %s, want %s", ct, got.Reason, want.reason)
+		}
+	}
+
+	if updated.Status.AppliedSpecHash != "" {
+		t.Errorf("expected appliedSpecHash to be empty on partial failure, got %q", updated.Status.AppliedSpecHash)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func findCondition(conds []metav1.Condition, t string) *metav1.Condition {
+	for i := range conds {
+		if conds[i].Type == t {
+			return &conds[i]
+		}
+	}
+	return nil
 }

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -32,6 +32,7 @@ type mockZoneClient struct {
 	updateSettingCalls int
 	updateBotCalled    bool
 	lastZoneID         string
+	appliedSettings    []string // ordered list of setting IDs successfully applied
 }
 
 func newMockZoneClient() *mockZoneClient {
@@ -55,6 +56,7 @@ func (m *mockZoneClient) UpdateSetting(_ context.Context, zoneID, settingID stri
 	}
 	m.lastZoneID = zoneID
 	m.settings[settingID] = value
+	m.appliedSettings = append(m.appliedSettings, settingID)
 	m.updateSettingCalls++
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #51. The `CloudflareZoneConfig` reconciler previously walked all settings as a single sequence and aborted on the first error, so a 403 on `bot_management` (most commonly: token without `Zone:Bot Management:Edit`, or a Free zone that doesn't permit it) prevented `ssl`, `security`, `performance`, and `network` from being applied at all.

This PR refactors the reconciler into per-group apply functions:

- Each settings group (SSL / Security / Performance / Network / BotManagement) gets its own `<Group>Applied` status condition with classified reason: `Applied`, `NotConfigured`, `PermissionDenied`, or `CloudflareAPIError`.
- A failure in one group no longer prevents the others from converging.
- `Ready=True` only when every configured group succeeded; `Ready=False, Reason=PartialApply` when any failed.
- `appliedSpecHash` is set only on full success, so failed groups retry every interval until they succeed; converged resources still get the hash-skip fast-path.
- Per-group `SettingsApplied` / `SettingsApplyFailed` events emit only on transitions, so a steady-state degraded resource produces no event spam.

Adds a wrap-safe `cfclient.IsPermissionDenied(err)` helper that lifts the existing `*cfgo.Error` / `StatusCode == 403` pattern into a named predicate.

Documents required token scopes per group in `docs/README.md`, the sample manifest, and the `BotManagementSettings` Go doc comment.

## Test Plan

- [x] `go test ./... -count=1` — all packages pass (15 `TestZoneConfigReconcile*` tests including: full success, hash skip, partial 403, partial 5xx, recovery, NotConfigured, group removed, no event spam in steady degraded state)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `make manifests` — no CRD diff (field-level doc unchanged; type-level doc improvement is for godoc/IDE)
- [ ] Manual: apply a `CloudflareZoneConfig` with `botManagement` + `ssl` + `security` to a Free-plan zone using a token without `Zone:Bot Management:Edit`. Confirm via `kubectl describe`:
  - `Ready=False, Reason=PartialApply`
  - `SSLApplied=True`, `SecurityApplied=True`
  - `BotManagementApplied=False, Reason=PermissionDenied`
  - Cloudflare dashboard shows the SSL + Security values applied