### PR TITLE
ci: bump lint and test jobs to Go 1.26

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       yaml: true
       go: true
-      go-version: '1.25'
+      go-version: '1.26'
 
   # Run Go tests with coverage
   test:
@@ -37,7 +37,7 @@ jobs:
       contents: read
     with:
       test-framework: 'go'
-      go-version: '1.25'
+      go-version: '1.26'
       coverage: true
       coverage-threshold: 40
       test-packages: './internal/controller/... ./internal/cloudflare/... ./internal/ipresolver/... ./internal/status/... ./api/...'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       yaml: true
       go: true
-      go-version: '1.25'
+      go-version: '1.26'
       helm: true
       helm-chart-path: 'chart'
 
@@ -28,7 +28,7 @@ jobs:
     uses: jacaudi/github-actions/.github/workflows/component-test.yml@v0.20.1
     with:
       test-framework: 'go'
-      go-version: '1.25'
+      go-version: '1.26'
       coverage: true
       coverage-threshold: 40
       test-packages: './internal/controller/... ./internal/cloudflare/... ./internal/ipresolver/... ./internal/status/... ./api/...'


### PR DESCRIPTION
## Summary

Bumps \`go-version\` from \`'1.25'\` to \`'1.26'\` in the lint and test jobs across both \`pr.yml\` and \`ci-cd.yml\` (4 occurrences). The \`verify-helm-rbac\` and \`verify-helm-crds\` jobs in \`pr.yml\` are already on \`'1.26'\` — this aligns the rest of the pipeline.

## Why

Renovate PR #36 (\`kubernetes-client-libraries\`) bumps the \`go.mod\` directive from \`go 1.25.3\` to \`go 1.26.0\` (Kubernetes 1.36 client libraries require it). The Go toolchain enforces the \`go.mod\` minimum at build time, so the lint and test jobs would fail on #36 without this CI alignment.

This is a no-op for the current codebase (already builds and tests cleanly on Go 1.26 — verified locally) and unblocks #36 once merged.

## Test plan

- [ ] CI passes (this PR's own lint + test runs verify the bump works)
- [ ] After merge: PR #36 unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)