### PR TITLE
feat(connector): add spec.connector.nameOverride to customize resource names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 
 ## Unreleased
 
+### Added
+
+- `CloudflareTunnel.spec.connector.nameOverride`: optional field to set the base name used for the operator-managed Deployment, ServiceAccount, and ConfigMap. When set, the Deployment and ServiceAccount are named exactly `<nameOverride>` and the ConfigMap is named `<nameOverride>-config`. When unset, the existing `<tunnel.metadata.name>-connector` family is preserved. ([#68](https://github.com/jacaudi/cloudflare-operator/issues/68))
+
 ### Fixed
 
 - `CloudflareZoneConfig`: a permission/plan failure on one settings group (most commonly `bot_management` on Free zones, or a token without `Zone:Bot Management:Edit`) no longer blocks the rest of the spec from being applied. Each group now records its own `<Group>Applied` status condition with reason `Applied`, `NotConfigured`, `PermissionDenied`, or `CloudflareAPIError`. The resource's `Ready` condition is `False` with `Reason=PartialApply` until every configured group succeeds. ([#51](https://github.com/jacaudi/cloudflare-operator/issues/51))

--- a/api/v1alpha1/cloudflaretunnel_types.go
+++ b/api/v1alpha1/cloudflaretunnel_types.go
@@ -92,6 +92,20 @@ type ConnectorSpec struct {
 	// TopologySpreadConstraints is a pass-through to the pod spec.
 	// +optional
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
+	// NameOverride sets the base name for the operator-managed connector
+	// resources. When set, the Deployment and ServiceAccount are named
+	// exactly NameOverride and the ConfigMap is named "<NameOverride>-config".
+	// When unset, the operator falls back to "<tunnel.metadata.name>-connector"
+	// for the Deployment + ServiceAccount and "<tunnel.metadata.name>-connector-config"
+	// for the ConfigMap.
+	//
+	// Changing NameOverride on a live tunnel reconciles new resources at the
+	// new name; the old resources are not cleaned up automatically (see #52).
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=253
+	// +optional
+	NameOverride string `json:"nameOverride,omitempty"`
 }
 
 // ConnectorImage specifies the cloudflared container image.

--- a/chart/crds/cloudflare.io_cloudflaretunnels.yaml
+++ b/chart/crds/cloudflare.io_cloudflaretunnels.yaml
@@ -1002,6 +1002,20 @@ spec:
                           compile-time default bumped per operator release.
                         type: string
                     type: object
+                  nameOverride:
+                    description: |-
+                      NameOverride sets the base name for the operator-managed connector
+                      resources. When set, the Deployment and ServiceAccount are named
+                      exactly NameOverride and the ConfigMap is named "<NameOverride>-config".
+                      When unset, the operator falls back to "<tunnel.metadata.name>-connector"
+                      for the Deployment + ServiceAccount and "<tunnel.metadata.name>-connector-config"
+                      for the ConfigMap.
+
+                      Changing NameOverride on a live tunnel reconciles new resources at the
+                      new name; the old resources are not cleaned up automatically (see #52).
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string

--- a/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
@@ -1002,6 +1002,20 @@ spec:
                           compile-time default bumped per operator release.
                         type: string
                     type: object
+                  nameOverride:
+                    description: |-
+                      NameOverride sets the base name for the operator-managed connector
+                      resources. When set, the Deployment and ServiceAccount are named
+                      exactly NameOverride and the ConfigMap is named "<NameOverride>-config".
+                      When unset, the operator falls back to "<tunnel.metadata.name>-connector"
+                      for the Deployment + ServiceAccount and "<tunnel.metadata.name>-connector-config"
+                      for the ConfigMap.
+
+                      Changing NameOverride on a live tunnel reconciles new resources at the
+                      new name; the old resources are not cleaned up automatically (see #52).
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -240,6 +240,7 @@ For the full operator-managed connector story — connector spec fields in depth
 |-------|------|---------|-------------|
 | `enabled` | bool | `false` | When `true`, the operator reconciles a Deployment, ConfigMap, and ServiceAccount running cloudflared. |
 | `replicas` | int | `2` | Number of cloudflared replicas. Minimum `1`. |
+| `nameOverride` | string | `""` | Optional base name for the connector resources. When set, the Deployment and ServiceAccount are named exactly `<nameOverride>` and the ConfigMap is named `<nameOverride>-config`. When unset, the operator falls back to `<tunnel.metadata.name>-connector` (and `…-config` for the ConfigMap). DNS-1123 subdomain validation. See [`tunnels.md`](tunnels.md) for caveats around live renames. |
 | `image.repository` | string | `docker.io/cloudflare/cloudflared` | Container image repository. |
 | `image.tag` | string | compile-time default | Container image tag. |
 | `resources` | object | sane defaults | Container `resources` (requests + limits). |

--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -42,6 +42,9 @@ spec:
   connector:
     enabled: true           # default: false. Must be true to deploy cloudflared.
     replicas: 2             # default: 2. Minimum: 1.
+    nameOverride: ""        # default: "". When set, names the Deployment + SA exactly
+                            # this value and the ConfigMap "<nameOverride>-config".
+                            # When unset, names use "<tunnel.metadata.name>-connector".
     image:
       repository: docker.io/cloudflare/cloudflared
       tag: "2026.3.0"       # omit to use the operator's compile-time default
@@ -58,6 +61,27 @@ spec:
 ```
 
 All fields in `connector` except `enabled` are optional. Omitting `connector` entirely (or setting `enabled: false`) means you are responsible for running cloudflared yourself.
+
+### Naming the connector resources
+
+By default the operator names the Deployment, ServiceAccount, and ConfigMap as `<tunnel.metadata.name>-connector`, `<tunnel.metadata.name>-connector`, and `<tunnel.metadata.name>-connector-config`. To use a different name family — for example, to fit existing monitoring labels or GitOps drift expectations — set `spec.connector.nameOverride`:
+
+```yaml
+spec:
+  connector:
+    enabled: true
+    nameOverride: cloudflared-prod
+```
+
+This produces:
+
+- Deployment: `cloudflared-prod`
+- ServiceAccount: `cloudflared-prod`
+- ConfigMap: `cloudflared-prod-config`
+
+Changing `nameOverride` on a live tunnel reconciles new resources at the new name; the old resources are NOT cleaned up automatically (tracked alongside [#52](https://github.com/jacaudi/cloudflare-operator/issues/52)). Delete the orphaned Deployment/SA/ConfigMap manually after a rename.
+
+`nameOverride` must be a valid DNS-1123 subdomain (lowercase alphanumerics and `-`, length ≤ 253).
 
 ### Upgrading the cloudflared image
 

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -46,11 +46,20 @@ type ConnectorResourceNames struct {
 }
 
 // ConnectorNames returns the deterministic resource names for tun.
+//
+// When tun.Spec.Connector.NameOverride is set, the Deployment and
+// ServiceAccount are named exactly NameOverride and the ConfigMap is named
+// "<NameOverride>-config". When unset, names fall back to the
+// "<tunnel.metadata.name>-connector" family.
 func ConnectorNames(tun *cloudflarev1alpha1.CloudflareTunnel) ConnectorResourceNames {
+	base := tun.Name + "-connector"
+	if tun.Spec.Connector != nil && tun.Spec.Connector.NameOverride != "" {
+		base = tun.Spec.Connector.NameOverride
+	}
 	return ConnectorResourceNames{
-		Deployment:     tun.Name + "-connector",
-		ConfigMap:      tun.Name + "-connector-config",
-		ServiceAccount: tun.Name + "-connector",
+		Deployment:     base,
+		ConfigMap:      base + "-config",
+		ServiceAccount: base,
 	}
 }
 

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -55,6 +55,56 @@ func TestConnectorNames(t *testing.T) {
 	}
 }
 
+// TestConnectorNames_NameOverride verifies that spec.connector.nameOverride
+// replaces the default "<tunnel-name>-connector" base across the Deployment,
+// ServiceAccount, and ConfigMap. ConfigMap retains its "-config" suffix to
+// disambiguate it from the Deployment/SA, which share the override name (#68).
+func TestConnectorNames_NameOverride(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector.NameOverride = "cloudflared-prod"
+
+	n := ConnectorNames(tun)
+	if n.Deployment != "cloudflared-prod" {
+		t.Errorf("Deployment name = %q, want %q", n.Deployment, "cloudflared-prod")
+	}
+	if n.ServiceAccount != "cloudflared-prod" {
+		t.Errorf("ServiceAccount name = %q, want %q", n.ServiceAccount, "cloudflared-prod")
+	}
+	if n.ConfigMap != "cloudflared-prod-config" {
+		t.Errorf("ConfigMap name = %q, want %q", n.ConfigMap, "cloudflared-prod-config")
+	}
+}
+
+// TestConnectorNames_NameOverrideEmpty verifies that an empty NameOverride
+// (the zero value) falls back to the default "<tunnel-name>-connector" family.
+func TestConnectorNames_NameOverrideEmpty(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector.NameOverride = ""
+
+	n := ConnectorNames(tun)
+	if n.Deployment != "home-connector" {
+		t.Errorf("Deployment name = %q, want default %q", n.Deployment, "home-connector")
+	}
+	if n.ConfigMap != "home-connector-config" {
+		t.Errorf("ConfigMap name = %q, want default %q", n.ConfigMap, "home-connector-config")
+	}
+	if n.ServiceAccount != "home-connector" {
+		t.Errorf("ServiceAccount name = %q, want default %q", n.ServiceAccount, "home-connector")
+	}
+}
+
+// TestConnectorNames_NameOverrideNilConnector verifies that ConnectorNames
+// is safe when tun.Spec.Connector is nil (e.g., connector disabled / unset).
+func TestConnectorNames_NameOverrideNilConnector(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector = nil
+
+	n := ConnectorNames(tun)
+	if n.Deployment != "home-connector" {
+		t.Errorf("Deployment name = %q, want default %q", n.Deployment, "home-connector")
+	}
+}
+
 func TestBuildConnectorResources_Basic(t *testing.T) {
 	tun := tunnelFixture(true)
 	configYAML := []byte("ingress:\n  - service: http_status:404\n")


### PR DESCRIPTION
## Summary

Adds optional \`spec.connector.nameOverride\` to \`CloudflareTunnel\`. When set, the operator-managed connector resources use the override as their base name:

- Deployment: \`<nameOverride>\`
- ServiceAccount: \`<nameOverride>\`
- ConfigMap: \`<nameOverride>-config\`

When unset, the existing \`<tunnel.metadata.name>-connector\` family is preserved — pure addition, no breaking change.

The change is localized: API field addition + a one-line conditional in \`ConnectorNames\` (\`internal/controller/connector.go\`). Aggregation, ownership, and cleanup logic all read names through \`ConnectorNames(tun)\`, so they pick up the override automatically.

Validation: DNS-1123 subdomain, max length 253 (CRD field validator).

## Why

Users want explicit names for the connector Deployment to fit existing monitoring labels, GitOps drift expectations, or naming conventions across multiple tunnels. Currently the only way to control the name is to rename the \`CloudflareTunnel\` CR, which isn't possible in-place — you have to delete and recreate, churning the tunnel.

## Caveats (documented)

- Renaming on a live tunnel via spec edit reconciles new resources at the new name; the old resources are NOT cleaned up automatically. Documented in \`docs/tunnels.md\` and tracked alongside [#52](https://github.com/jacaudi/cloudflare-operator/issues/52) (connector cleanup on disable).
- The \`-config\` suffix on the ConfigMap is preserved by design — it disambiguates between the data-bearing ConfigMap and the Deployment / SA, which already share a name in the default behaviour.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] Full uncached \`go test ./...\` — all 7 packages pass
- [x] Three new tests in \`connector_test.go\`: override path, empty-override fallback, nil-Connector defensive path
- [x] CRD regen + Helm sync committed (\`make manifests sync-helm-crds\`)
- [x] \`docs/tunnels.md\` and \`docs/crd-reference.md\` updated

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)