### PR TITLE
fix(sources): propagate secret namespace into emitted SecretRef (closes #70 #72)

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -7,6 +7,11 @@ type SecretReference struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
+
+	// Namespace of the Secret. Defaults to the dependent CR's own namespace
+	// when empty.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // ZoneReference refers to a CloudflareZone CR.

--- a/chart/crds/cloudflare.io_cloudflarednsrecords.yaml
+++ b/chart/crds/cloudflare.io_cloudflarednsrecords.yaml
@@ -93,6 +93,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/chart/crds/cloudflare.io_cloudflarerulesets.yaml
+++ b/chart/crds/cloudflare.io_cloudflarerulesets.yaml
@@ -152,6 +152,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/chart/crds/cloudflare.io_cloudflaretunnels.yaml
+++ b/chart/crds/cloudflare.io_cloudflaretunnels.yaml
@@ -1393,6 +1393,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/chart/crds/cloudflare.io_cloudflarezoneconfigs.yaml
+++ b/chart/crds/cloudflare.io_cloudflarezoneconfigs.yaml
@@ -211,6 +211,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/chart/crds/cloudflare.io_cloudflarezones.yaml
+++ b/chart/crds/cloudflare.io_cloudflarezones.yaml
@@ -85,6 +85,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/cloudflare.io_cloudflarednsrecords.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarednsrecords.yaml
@@ -93,6 +93,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/cloudflare.io_cloudflarerulesets.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarerulesets.yaml
@@ -152,6 +152,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
@@ -1393,6 +1393,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/cloudflare.io_cloudflarezoneconfigs.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarezoneconfigs.yaml
@@ -211,6 +211,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/crd/bases/cloudflare.io_cloudflarezones.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarezones.yaml
@@ -85,6 +85,11 @@ spec:
                     description: Name of the Secret.
                     minLength: 1
                     type: string
+                  namespace:
+                    description: |-
+                      Namespace of the Secret. Defaults to the dependent CR's own namespace
+                      when empty.
+                    type: string
                 required:
                 - name
                 type: object

--- a/internal/controller/cloudflarednsrecord_controller.go
+++ b/internal/controller/cloudflarednsrecord_controller.go
@@ -169,7 +169,8 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	// 4. Get API token
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, dnsRecord.Spec.SecretRef.Name, dnsRecord.Namespace)
+	secretNs := secretRefNamespace(dnsRecord.Spec.SecretRef, dnsRecord.Namespace)
+	apiToken, err := r.ClientFactory.GetAPIToken(ctx, dnsRecord.Spec.SecretRef.Name, secretNs)
 	if err != nil {
 		logger.Error(err, "failed to get API token")
 		return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
@@ -375,7 +376,8 @@ func (r *CloudflareDNSRecordReconciler) reconcileDelete(ctx context.Context, dns
 				cloudflarev1alpha1.ReasonZoneRefNotReady, wrapDeleteErr(err), 30*time.Second)
 		}
 
-		apiToken, err := r.ClientFactory.GetAPIToken(ctx, dnsRecord.Spec.SecretRef.Name, dnsRecord.Namespace)
+		secretNs := secretRefNamespace(dnsRecord.Spec.SecretRef, dnsRecord.Namespace)
+		apiToken, err := r.ClientFactory.GetAPIToken(ctx, dnsRecord.Spec.SecretRef.Name, secretNs)
 		if err != nil {
 			logger.Error(err, "failed to get API token during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -414,6 +414,57 @@ func TestReconcile_SecretNotFound(t *testing.T) {
 	}
 }
 
+// TestReconcile_SecretRefCrossNamespace is a regression test for issue #70.
+// When the CloudflareDNSRecord lives in one namespace ("apps") but the
+// credentials Secret lives in another ("zones") — typical when an HTTPRoute or
+// Service source emits a DNSRecord referencing a Secret co-located with the
+// zone — the controller must honor Spec.SecretRef.Namespace and resolve the
+// Secret in that namespace. Without the fix, GetAPIToken would look in the
+// CR's own namespace and fail.
+func TestReconcile_SecretRefCrossNamespace(t *testing.T) {
+	s := testScheme(t)
+	dnsRecord := newTestDNSRecord("test-rec", "apps")
+	dnsRecord.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	// Point SecretRef at the Secret in "zones", not "apps".
+	dnsRecord.Spec.SecretRef = cloudflarev1alpha1.SecretReference{
+		Name:      "cf-secret",
+		Namespace: "zones",
+	}
+	secret := newTestSecret("zones")
+	mock := newMockDNSClient()
+
+	r := buildReconciler(s, mock, dnsRecord, secret)
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-rec", Namespace: "apps"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	// Reconcile should reach the create path (5m requeue), not fall through
+	// to a 30s SecretNotFound requeue.
+	if result.RequeueAfter != 5*time.Minute {
+		t.Errorf("expected RequeueAfter=5m (success), got %v", result.RequeueAfter)
+	}
+
+	// Verify Ready condition is True (Secret was resolved + record created).
+	var updated cloudflarev1alpha1.CloudflareDNSRecord
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-rec", Namespace: "apps"}, &updated); err != nil {
+		t.Fatalf("failed to get updated record: %v", err)
+	}
+	for _, c := range updated.Status.Conditions {
+		if c.Type == cloudflarev1alpha1.ConditionTypeReady {
+			if c.Reason == cloudflarev1alpha1.ReasonSecretNotFound {
+				t.Errorf("expected Secret to be resolved across namespaces, got SecretNotFound: %s", c.Message)
+			}
+		}
+	}
+	if !mock.createCalled {
+		t.Error("expected CreateRecord to be called (Secret resolved cross-namespace)")
+	}
+}
+
 func TestReconcile_DeletesRecord(t *testing.T) {
 	s := testScheme(t)
 	dnsRecord := newTestDNSRecord("test-rec", "default")

--- a/internal/controller/cloudflareruleset_controller.go
+++ b/internal/controller/cloudflareruleset_controller.go
@@ -101,7 +101,8 @@ func (r *CloudflareRulesetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	// 4. Get API token
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, ruleset.Spec.SecretRef.Name, ruleset.Namespace)
+	secretNs := secretRefNamespace(ruleset.Spec.SecretRef, ruleset.Namespace)
+	apiToken, err := r.ClientFactory.GetAPIToken(ctx, ruleset.Spec.SecretRef.Name, secretNs)
 	if err != nil {
 		logger.Error(err, "failed to get API token")
 		return failReconcile(ctx, r.Client, &ruleset, &ruleset.Status.Conditions,

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -99,7 +99,8 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// 4. Get Cloudflare credentials (API token + Account ID)
-	creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, tunnel.Namespace)
+	secretNs := secretRefNamespace(tunnel.Spec.SecretRef, tunnel.Namespace)
+	creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, secretNs)
 	if err != nil {
 		logger.Error(err, "failed to get credentials")
 		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
@@ -107,7 +108,7 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	if creds.AccountID == "" {
 		err := fmt.Errorf("secret %s/%s does not contain %q key",
-			tunnel.Namespace, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
+			secretNs, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
 			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
@@ -311,7 +312,8 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 	logger := log.FromContext(ctx)
 
 	if tunnel.Status.TunnelID != "" {
-		creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, tunnel.Namespace)
+		secretNs := secretRefNamespace(tunnel.Spec.SecretRef, tunnel.Namespace)
+		creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, secretNs)
 		if err != nil {
 			logger.Error(err, "failed to get credentials during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
@@ -319,7 +321,7 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 		}
 		if creds.AccountID == "" {
 			err := fmt.Errorf("secret %s/%s does not contain %q key",
-				tunnel.Namespace, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
+				secretNs, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 			logger.Error(err, "missing Account ID during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
 				cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)

--- a/internal/controller/cloudflarezone_controller.go
+++ b/internal/controller/cloudflarezone_controller.go
@@ -85,7 +85,8 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// 4. Get Cloudflare credentials (API token + Account ID)
-	creds, err := r.ClientFactory.GetCredentials(ctx, zone.Spec.SecretRef.Name, zone.Namespace)
+	secretNs := secretRefNamespace(zone.Spec.SecretRef, zone.Namespace)
+	creds, err := r.ClientFactory.GetCredentials(ctx, zone.Spec.SecretRef.Name, secretNs)
 	if err != nil {
 		logger.Error(err, "failed to get credentials")
 		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
@@ -93,7 +94,7 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	if creds.AccountID == "" {
 		err := fmt.Errorf("secret %s/%s does not contain %q key",
-			zone.Namespace, zone.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
+			secretNs, zone.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
 			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
@@ -238,7 +239,8 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 	logger := log.FromContext(ctx)
 
 	if zone.Spec.DeletionPolicy == cloudflarev1alpha1.DeletionPolicyDelete && zone.Status.ZoneID != "" {
-		apiToken, err := r.ClientFactory.GetAPIToken(ctx, zone.Spec.SecretRef.Name, zone.Namespace)
+		secretNs := secretRefNamespace(zone.Spec.SecretRef, zone.Namespace)
+		apiToken, err := r.ClientFactory.GetAPIToken(ctx, zone.Spec.SecretRef.Name, secretNs)
 		if err != nil {
 			logger.Error(err, "failed to get API token during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, zone, &zone.Status.Conditions,

--- a/internal/controller/cloudflarezoneconfig_controller.go
+++ b/internal/controller/cloudflarezoneconfig_controller.go
@@ -105,7 +105,8 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	zoneConfig.Status.ZoneID = resolvedZoneID
 
 	// 4. Get API token
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, zoneConfig.Spec.SecretRef.Name, zoneConfig.Namespace)
+	secretNs := secretRefNamespace(zoneConfig.Spec.SecretRef, zoneConfig.Namespace)
+	apiToken, err := r.ClientFactory.GetAPIToken(ctx, zoneConfig.Spec.SecretRef.Name, secretNs)
 	if err != nil {
 		logger.Error(err, "failed to get API token")
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,

--- a/internal/controller/httproute_source_controller.go
+++ b/internal/controller/httproute_source_controller.go
@@ -413,7 +413,10 @@ func (r *HTTPRouteSourceReconciler) emitDNSPair(
 			Content:   strPtr(content),
 			Proxied:   boolPtr(proxied),
 			TTL:       ttl,
-			SecretRef: cloudflarev1alpha1.SecretReference{Name: zone.Spec.SecretRef.Name},
+			SecretRef: cloudflarev1alpha1.SecretReference{
+				Name:      zone.Spec.SecretRef.Name,
+				Namespace: zone.Namespace,
+			},
 			ZoneRef: &cloudflarev1alpha1.ZoneReference{
 				Name:      zone.Name,
 				Namespace: zone.Namespace,
@@ -447,7 +450,10 @@ func (r *HTTPRouteSourceReconciler) emitDNSPair(
 			Type:      "TXT",
 			Content:   strPtr(txtContent),
 			TTL:       120,
-			SecretRef: cloudflarev1alpha1.SecretReference{Name: zone.Spec.SecretRef.Name},
+			SecretRef: cloudflarev1alpha1.SecretReference{
+				Name:      zone.Spec.SecretRef.Name,
+				Namespace: zone.Namespace,
+			},
 			ZoneRef: &cloudflarev1alpha1.ZoneReference{
 				Name:      zone.Name,
 				Namespace: zone.Namespace,

--- a/internal/controller/httproute_source_controller_test.go
+++ b/internal/controller/httproute_source_controller_test.go
@@ -1642,3 +1642,56 @@ func TestHTTPRouteSource_ZoneRefCrossNamespace_PropagatedToEmittedCR(t *testing.
 		}
 	}
 }
+
+// ---- TestHTTPRouteSource_SecretRefCrossNamespace_PropagatedToEmittedCR -----
+// Regression for issue #70: when the CloudflareZone (and the credentials
+// Secret it references) live in a different namespace than the HTTPRoute, the
+// emitted CloudflareDNSRecord (data + TXT) must carry the zone's namespace in
+// Spec.SecretRef.Namespace so the DNSRecord controller's GetAPIToken call
+// resolves the Secret in the right namespace. Without the fix, the call would
+// look up the Secret in the emitted CR's namespace (= source namespace) and
+// fail with "Secret … not found".
+
+func TestHTTPRouteSource_SecretRefCrossNamespace_PropagatedToEmittedCR(t *testing.T) {
+	s := httpRouteScheme(t)
+
+	// Zone + secret live in "zones"; route + tunnel live in "apps".
+	zone := newZone("example-com", "zones", "example.com", "cf-creds")
+	zone.Status.ZoneID = "zone-id-from-status"
+
+	tunnel := newReadyTunnel("home", "apps")
+	route := newHTTPRoute("apps", "my-route", map[string]string{
+		AnnotationTarget:           "tunnel:home",
+		AnnotationZoneRef:          "example-com",
+		AnnotationZoneRefNamespace: "zones",
+	}, hostnames("foo.example.com"), nil)
+
+	r, _ := buildHTTPRouteReconciler(s, "owner1", route, zone, tunnel)
+
+	if _, err := r.Reconcile(context.Background(), req("apps", "my-route")); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	var records cloudflarev1alpha1.CloudflareDNSRecordList
+	if err := r.List(context.Background(), &records); err != nil {
+		t.Fatalf("list DNS records: %v", err)
+	}
+	if len(records.Items) < 2 {
+		t.Fatalf("expected at least 2 emitted DNS records (data + TXT), got %d", len(records.Items))
+	}
+
+	for i := range records.Items {
+		rec := &records.Items[i]
+		if rec.Spec.SecretRef.Name != "cf-creds" {
+			t.Errorf("emitted CR %q: SecretRef.Name = %q, want %q", rec.Name, rec.Spec.SecretRef.Name, "cf-creds")
+		}
+		if rec.Spec.SecretRef.Namespace != "zones" {
+			t.Errorf("emitted CR %q: SecretRef.Namespace = %q, want %q", rec.Name, rec.Spec.SecretRef.Namespace, "zones")
+		}
+		// Sanity: secretRefNamespace returns the zone's namespace, not the CR's.
+		got := secretRefNamespace(rec.Spec.SecretRef, rec.Namespace)
+		if got != "zones" {
+			t.Errorf("secretRefNamespace for emitted CR %q resolved to %q, want %q", rec.Name, got, "zones")
+		}
+	}
+}

--- a/internal/controller/service_source_controller.go
+++ b/internal/controller/service_source_controller.go
@@ -303,7 +303,10 @@ func (r *ServiceSourceReconciler) emitDNSPair(
 			Content:   strPtr(content),
 			Proxied:   boolPtr(proxied),
 			TTL:       ttl,
-			SecretRef: cloudflarev1alpha1.SecretReference{Name: zone.Spec.SecretRef.Name},
+			SecretRef: cloudflarev1alpha1.SecretReference{
+				Name:      zone.Spec.SecretRef.Name,
+				Namespace: zone.Namespace,
+			},
 			ZoneRef: &cloudflarev1alpha1.ZoneReference{
 				Name:      zone.Name,
 				Namespace: zone.Namespace,
@@ -337,7 +340,10 @@ func (r *ServiceSourceReconciler) emitDNSPair(
 			Type:      "TXT",
 			Content:   strPtr(txtContent),
 			TTL:       120,
-			SecretRef: cloudflarev1alpha1.SecretReference{Name: zone.Spec.SecretRef.Name},
+			SecretRef: cloudflarev1alpha1.SecretReference{
+				Name:      zone.Spec.SecretRef.Name,
+				Namespace: zone.Namespace,
+			},
 			ZoneRef: &cloudflarev1alpha1.ZoneReference{
 				Name:      zone.Name,
 				Namespace: zone.Namespace,

--- a/internal/controller/service_source_controller_test.go
+++ b/internal/controller/service_source_controller_test.go
@@ -1369,3 +1369,57 @@ func TestServiceSource_ZoneRefCrossNamespace_PropagatedToEmittedCR(t *testing.T)
 		}
 	}
 }
+
+// ---- TestServiceSource_SecretRefCrossNamespace_PropagatedToEmittedCR -------
+// Regression for issue #70: when the CloudflareZone (and the credentials
+// Secret it references) live in a different namespace than the Service, the
+// emitted CloudflareDNSRecord (data + TXT) must carry the zone's namespace in
+// Spec.SecretRef.Namespace so the DNSRecord controller's GetAPIToken call
+// resolves the Secret in the right namespace. Without the fix, the call would
+// look up the Secret in the emitted CR's namespace (= source namespace) and
+// fail with "Secret … not found".
+
+func TestServiceSource_SecretRefCrossNamespace_PropagatedToEmittedCR(t *testing.T) {
+	s := svcTestScheme(t)
+
+	// Zone + secret live in "zones"; service + tunnel live in "apps".
+	zone := newZone("example-com", "zones", "example.com", "cf-creds")
+	zone.Status.ZoneID = "zone-id-from-status"
+
+	tunnel := newReadyTunnel("home", "apps")
+	svc := newSvc("my-svc", "apps", map[string]string{
+		AnnotationTarget:           "tunnel:home",
+		AnnotationHostnames:        "foo.example.com",
+		AnnotationZoneRef:          "example-com",
+		AnnotationZoneRefNamespace: "zones",
+	})
+
+	r, _ := buildSvcReconciler(s, "owner1", svc, zone, tunnel)
+
+	if _, err := r.Reconcile(context.Background(), req("apps", "my-svc")); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	var records cloudflarev1alpha1.CloudflareDNSRecordList
+	if err := r.List(context.Background(), &records); err != nil {
+		t.Fatalf("list DNS records: %v", err)
+	}
+	if len(records.Items) < 2 {
+		t.Fatalf("expected at least 2 emitted DNS records (data + TXT), got %d", len(records.Items))
+	}
+
+	for i := range records.Items {
+		rec := &records.Items[i]
+		if rec.Spec.SecretRef.Name != "cf-creds" {
+			t.Errorf("emitted CR %q: SecretRef.Name = %q, want %q", rec.Name, rec.Spec.SecretRef.Name, "cf-creds")
+		}
+		if rec.Spec.SecretRef.Namespace != "zones" {
+			t.Errorf("emitted CR %q: SecretRef.Namespace = %q, want %q", rec.Name, rec.Spec.SecretRef.Namespace, "zones")
+		}
+		// Sanity: secretRefNamespace returns the zone's namespace, not the CR's.
+		got := secretRefNamespace(rec.Spec.SecretRef, rec.Namespace)
+		if got != "zones" {
+			t.Errorf("secretRefNamespace for emitted CR %q resolved to %q, want %q", rec.Name, got, "zones")
+		}
+	}
+}

--- a/internal/controller/source_helpers.go
+++ b/internal/controller/source_helpers.go
@@ -160,6 +160,17 @@ func firstNonEmpty(a, b string) string {
 	return b
 }
 
+// secretRefNamespace returns ref.Namespace when set; otherwise fallback.
+// This lets a SecretReference target a Secret in a namespace other than the
+// dependent CR's own (e.g. credentials co-located with a CloudflareZone in a
+// shared namespace, while the emitted CR lives alongside the workload).
+func secretRefNamespace(ref cloudflarev1alpha1.SecretReference, fallback string) string {
+	if ref.Namespace != "" {
+		return ref.Namespace
+	}
+	return fallback
+}
+
 // ownerRefsFor returns a single-element slice containing an OwnerReference
 // for obj with Controller=true and BlockOwnerDeletion=true.
 // The caller must ensure obj has its TypeMeta set (GroupVersionKind populated)

--- a/internal/controller/source_helpers_test.go
+++ b/internal/controller/source_helpers_test.go
@@ -197,6 +197,32 @@ func TestFirstNonEmpty_BothEmpty(t *testing.T) {
 	}
 }
 
+// ---- TestSecretRefNamespace -------------------------------------------------
+
+func TestSecretRefNamespace_RefNamespaceWins(t *testing.T) {
+	ref := cloudflarev1alpha1.SecretReference{Name: "cf-creds", Namespace: "zones"}
+	got := secretRefNamespace(ref, "apps")
+	if got != "zones" {
+		t.Errorf("expected zones, got %q", got)
+	}
+}
+
+func TestSecretRefNamespace_FallbackUsedWhenEmpty(t *testing.T) {
+	ref := cloudflarev1alpha1.SecretReference{Name: "cf-creds"}
+	got := secretRefNamespace(ref, "apps")
+	if got != "apps" {
+		t.Errorf("expected apps, got %q", got)
+	}
+}
+
+func TestSecretRefNamespace_BothEmpty(t *testing.T) {
+	ref := cloudflarev1alpha1.SecretReference{Name: "cf-creds"}
+	got := secretRefNamespace(ref, "")
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
 // ---- TestOwnerRefsFor -------------------------------------------------------
 
 func TestOwnerRefsFor(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes both #70 and #72 — same root-cause bug, filed independently.

When the HTTPRoute or Service source controllers emit a \`CloudflareDNSRecord\` from a source object that lives in a different namespace from the \`CloudflareZone\`, the emitted DNSRecord's \`secretRef\` pointed at a Secret in the DNSRecord's own namespace. The DNSRecord controller then resolved the Secret in that namespace and got \`Secret … not found\`. Symmetric in shape to #65 (cross-namespace \`zoneRef\`) but for credentials Secrets.

## Approach

Two reasonable fixes were proposed (in #72): (1) derive the Secret namespace at lookup time from the zone's namespace; (2) add an optional \`namespace\` field to \`secretRef\` and have source controllers populate it.

This PR takes approach (2) because it's a strict superset of (1):

- Source controllers auto-populate \`secretRef.namespace\` from \`zone.Namespace\` — produces the same effective behaviour #72 asked for, no user-visible config change required.
- Users who want a truly decoupled credentials Secret (Secret in namespace X, zone in namespace Y) can set \`secretRef.namespace\` explicitly on hand-authored CRs.
- Backward compatible: empty \`secretRef.namespace\` falls back to the dependent CR's own namespace, which is the existing behaviour.

## Changes

**API:** \`SecretReference\` gains an optional \`Namespace\` field (mirrors \`ZoneReference\` from #65).

**Helper:** \`secretRefNamespace(ref, fallback)\` in \`internal/controller/source_helpers.go\` — single resolution point.

**Consumers (7 call sites):** every \`GetAPIToken\` / \`GetCredentials\` call now resolves the namespace via the helper.

**Source emit sites (4):** HTTPRoute (data + TXT) and Service (data + TXT) now write \`Namespace: zone.Namespace\` alongside \`Name\`.

**CRD regen:** \`make manifests sync-helm-crds\` updates 5 CRDs in \`config/crd/bases/\` and \`chart/crds/\` to expose the new field.

**Error messages:** the \`secret %s/%s does not contain %q\` errors in tunnel + zone controllers now use the resolved namespace.

## Tests

TDD throughout — confirmed FAIL on pre-fix code, PASS post-fix:

- 3 unit tests for \`secretRefNamespace\` (ref wins, fallback, both empty).
- \`TestHTTPRouteSource_SecretRefCrossNamespace_PropagatedToEmittedCR\` regression test.
- \`TestServiceSource_SecretRefCrossNamespace_PropagatedToEmittedCR\` regression test.
- \`TestReconcile_SecretRefCrossNamespace\` drives the consumer call site.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] Full \`go test ./...\` — all 7 packages pass
- [x] CRD regen + Helm sync committed
- [x] No \`docs/plans/\` files in diff

Closes #70. Closes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)