### PR TITLE
fix(connector): httpGet readiness probe + safe rollout strategy

### DIFF
--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -24,7 +24,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+// connectorMetricsPort is the bind port for cloudflared's metrics server.
+// The cloudflared CLI requires --metrics to be passed for `tunnel ... ready`
+// to function and for the kubelet to probe /ready. The port is fixed so the
+// container port, args, and readiness probe stay in lock-step.
+const connectorMetricsPort = 20241
 
 // Default connector image components. DefaultConnectorImage is built from
 // these so version bumps stay consistent with the partial-image fallback in
@@ -238,7 +245,15 @@ func BuildConnectorDeployment(tun *cloudflarev1alpha1.CloudflareTunnel, configHa
 				Args: []string{
 					"tunnel",
 					"--config", "/etc/cloudflared/config.yaml",
+					"--metrics", fmt.Sprintf("0.0.0.0:%d", connectorMetricsPort),
 					"run",
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "metrics",
+						ContainerPort: connectorMetricsPort,
+						Protocol:      corev1.ProtocolTCP,
+					},
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot:             &nonRoot,
@@ -252,14 +267,16 @@ func BuildConnectorDeployment(tun *cloudflarev1alpha1.CloudflareTunnel, configHa
 					{Name: "config", MountPath: "/etc/cloudflared", ReadOnly: true},
 					{Name: "credentials", MountPath: "/etc/cloudflared/credentials", ReadOnly: true},
 				},
+				// Readiness probes the metrics server's /ready endpoint, which
+				// reports whether cloudflared has registered tunnel connections
+				// to the Cloudflare edge. The exec form (`cloudflared tunnel
+				// ready`) requires --metrics on the CLI and is brittle across
+				// cloudflared versions; httpGet is the documented stable surface.
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
-						Exec: &corev1.ExecAction{
-							Command: []string{
-								"cloudflared", "tunnel",
-								"--config", "/etc/cloudflared/config.yaml",
-								"ready",
-							},
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/ready",
+							Port: intstr.FromInt(connectorMetricsPort),
 						},
 					},
 					PeriodSeconds: 10,
@@ -267,6 +284,14 @@ func BuildConnectorDeployment(tun *cloudflarev1alpha1.CloudflareTunnel, configHa
 			},
 		},
 	}
+
+	// Rollout strategy: at most one replica may be unavailable, and at most one
+	// surge replica is created. With replicas==1 this gives surge-then-terminate
+	// ordering so an image upgrade never runs zero ready tunnels. With replicas>1
+	// it is at least as safe as the percentage-based default and removes the
+	// replica-count dependency.
+	maxUnavailable := intstr.FromInt(1)
+	maxSurge := intstr.FromInt(1)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -278,6 +303,18 @@ func BuildConnectorDeployment(tun *cloudflarev1alpha1.CloudflareTunnel, configHa
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			// 10s grace before kubelet flips the new replica to Ready. cloudflared
+			// reports /ready as soon as the first edge connection is registered,
+			// but the tunnel only becomes truly redundant after multiple
+			// connections are up — this gap covers that window.
+			MinReadySeconds: 10,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &maxUnavailable,
+					MaxSurge:       &maxSurge,
+				},
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -18,9 +18,11 @@ package controller
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -348,7 +350,9 @@ func TestBuildConnectorDeployment_SecurityPosture(t *testing.T) {
 }
 
 // TestBuildConnectorDeployment_ReadinessProbe asserts the cloudflared
-// readiness probe is wired correctly so failing connectors are flagged unready.
+// readiness probe targets the metrics server's /ready endpoint via httpGet.
+// The exec form is rejected by current cloudflared releases without --metrics
+// on the CLI; httpGet is the stable, documented surface (see issue #76).
 func TestBuildConnectorDeployment_ReadinessProbe(t *testing.T) {
 	tun := tunnelFixture(true)
 	dep := BuildConnectorDeployment(tun, "h")
@@ -359,15 +363,71 @@ func TestBuildConnectorDeployment_ReadinessProbe(t *testing.T) {
 	if probe == nil {
 		t.Fatal("ReadinessProbe is nil")
 	}
-	if probe.Exec == nil {
-		t.Fatal("ReadinessProbe.Exec is nil")
+	if probe.HTTPGet == nil {
+		t.Fatal("ReadinessProbe.HTTPGet is nil; want httpGet probe (issue #76)")
 	}
-	wantCmd := []string{"cloudflared", "tunnel", "--config", "/etc/cloudflared/config.yaml", "ready"}
-	if !reflect.DeepEqual(probe.Exec.Command, wantCmd) {
-		t.Errorf("ReadinessProbe.Exec.Command = %v, want %v", probe.Exec.Command, wantCmd)
+	if probe.HTTPGet.Path != "/ready" {
+		t.Errorf("ReadinessProbe.HTTPGet.Path = %q, want /ready", probe.HTTPGet.Path)
+	}
+	if probe.HTTPGet.Port.IntValue() != connectorMetricsPort {
+		t.Errorf("ReadinessProbe.HTTPGet.Port = %v, want %d", probe.HTTPGet.Port, connectorMetricsPort)
 	}
 	if probe.PeriodSeconds != 10 {
 		t.Errorf("ReadinessProbe.PeriodSeconds = %d, want 10", probe.PeriodSeconds)
+	}
+}
+
+// TestBuildConnectorDeployment_MetricsArgsAndPort asserts cloudflared is
+// started with --metrics bound on the well-known port and that the matching
+// containerPort is declared. Both are required for the readiness probe to
+// resolve and for ServiceMonitor scrapes to land.
+func TestBuildConnectorDeployment_MetricsArgsAndPort(t *testing.T) {
+	tun := tunnelFixture(true)
+	dep := BuildConnectorDeployment(tun, "h")
+	c := dep.Spec.Template.Spec.Containers[0]
+
+	wantArg := "0.0.0.0:" + strconv.Itoa(connectorMetricsPort)
+	foundMetricsFlag := false
+	for i, a := range c.Args {
+		if a == "--metrics" {
+			if i+1 < len(c.Args) && c.Args[i+1] == wantArg {
+				foundMetricsFlag = true
+			}
+			break
+		}
+	}
+	if !foundMetricsFlag {
+		t.Errorf("Args = %v; expected '--metrics %s' (issue #76)", c.Args, wantArg)
+	}
+
+	if len(c.Ports) != 1 || c.Ports[0].Name != "metrics" || c.Ports[0].ContainerPort != connectorMetricsPort {
+		t.Errorf("expected single 'metrics' containerPort %d, got %v", connectorMetricsPort, c.Ports)
+	}
+}
+
+// TestBuildConnectorDeployment_RolloutStrategy asserts the Deployment uses an
+// explicit RollingUpdate with maxUnavailable=maxSurge=1 and a 10s
+// minReadySeconds grace period, so single-replica image upgrades surge-then-
+// terminate and never run zero ready tunnels (issue #75).
+func TestBuildConnectorDeployment_RolloutStrategy(t *testing.T) {
+	tun := tunnelFixture(true)
+	dep := BuildConnectorDeployment(tun, "h")
+
+	if dep.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
+		t.Errorf("Strategy.Type = %v, want RollingUpdate", dep.Spec.Strategy.Type)
+	}
+	ru := dep.Spec.Strategy.RollingUpdate
+	if ru == nil {
+		t.Fatal("Strategy.RollingUpdate is nil")
+	}
+	if ru.MaxUnavailable == nil || ru.MaxUnavailable.IntValue() != 1 {
+		t.Errorf("Strategy.RollingUpdate.MaxUnavailable = %v, want 1", ru.MaxUnavailable)
+	}
+	if ru.MaxSurge == nil || ru.MaxSurge.IntValue() != 1 {
+		t.Errorf("Strategy.RollingUpdate.MaxSurge = %v, want 1", ru.MaxSurge)
+	}
+	if dep.Spec.MinReadySeconds != 10 {
+		t.Errorf("MinReadySeconds = %d, want 10", dep.Spec.MinReadySeconds)
 	}
 }
 
@@ -428,15 +488,20 @@ func TestBuildConnectorDeployment_PartialResources_LimitsOnly(t *testing.T) {
 	}
 }
 
-// TestBuildConnectorDeployment_ArgsExact pins the cloudflared Args to
-// [tunnel, --config, /etc/cloudflared/config.yaml, run]. The credentials
-// path is in config.yaml (see Aggregate), so --credentials-file must NOT
-// appear in Args (#58 follow-up: single source of truth for identity).
+// TestBuildConnectorDeployment_ArgsExact pins the cloudflared Args. The
+// credentials path is in config.yaml (see Aggregate), so --credentials-file
+// must NOT appear in Args (#58 follow-up: single source of truth for
+// identity). --metrics is required for the readiness probe to resolve (#76).
 func TestBuildConnectorDeployment_ArgsExact(t *testing.T) {
 	tun := tunnelFixture(true)
 	dep := BuildConnectorDeployment(tun, "h")
 	got := dep.Spec.Template.Spec.Containers[0].Args
-	want := []string{"tunnel", "--config", "/etc/cloudflared/config.yaml", "run"}
+	want := []string{
+		"tunnel",
+		"--config", "/etc/cloudflared/config.yaml",
+		"--metrics", "0.0.0.0:" + strconv.Itoa(connectorMetricsPort),
+		"run",
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Args = %v, want %v", got, want)
 	}


### PR DESCRIPTION
## Summary

Fixes two stability gaps in the operator-managed cloudflared Deployment.

### Issue #76 — readiness probe broken on current cloudflared

The probe ran `cloudflared tunnel ready` via `exec`. Current cloudflared releases reject this with `--metrics has to be provided` and exit non-zero, so the kubelet sees the probe failing every poll and pods stay `Ready=False` even when all four edge connections are registered. End-state for users: connectors permanently unready, ServiceMonitor scrapes blocked, real failures masked.

**Fix:** switch the probe to `httpGet /ready` on the metrics port, add `--metrics 0.0.0.0:20241` to the cloudflared args, and declare a matching `metrics` containerPort. Binding on `0.0.0.0` (vs. loopback) is required so the kubelet — which probes the pod IP, not localhost — can reach it. As a bonus this readies the pod for a future ServiceMonitor without another change.

### Issue #75 (core) — single-replica image upgrades can flap to zero ready

The Deployment had no explicit rollout `Strategy` and no `MinReadySeconds`, so the percentage-based defaults (`maxUnavailable=25%`, `maxSurge=25%`) collapse to `maxUnavailable=1`/`maxSurge=1` on a `replicas: 1` Deployment, briefly running zero ready replicas during an image upgrade. With `replicas >= 2` the percentage default is fine but ties surge behavior to replica count.

**Fix:** explicit `Strategy: RollingUpdate` with `maxUnavailable=1`/`maxSurge=1` (constant regardless of replica count, gives surge-then-terminate ordering at `replicas: 1`) and `MinReadySeconds: 10` to cover the gap between cloudflared registering its first edge connection and the tunnel being truly redundant across multiple connections.

## What's not in this PR

The broader #75 scope — operator-managed `PodDisruptionBudget` and default anti-affinity / `topologySpreadConstraints` when `replicas > 1` — is tracked in **#77**. Both items add a new operator-managed resource or default that warrants independent design and (for the PDB) a chart RBAC bump.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/controller/...` green; new + updated tests:
  - `TestBuildConnectorDeployment_ReadinessProbe` — asserts httpGet shape, path `/ready`, port `20241`
  - `TestBuildConnectorDeployment_MetricsArgsAndPort` — locks the `--metrics 0.0.0.0:20241` arg pair and the `metrics` containerPort
  - `TestBuildConnectorDeployment_RolloutStrategy` — locks `Strategy.RollingUpdate{MaxUnavailable:1, MaxSurge:1}` and `MinReadySeconds: 10`
- [ ] Apply against a live cluster: cloudflared pod transitions to `Ready=True` once edge connections register; image-tag bump triggers surge-then-terminate without a `Ready=0` window

## Related

- Closes #76
- Closes #75 (core rollout safeguards; PDB and default anti-affinity moved to #77)
- Tracks #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)