### PR TITLE
feat(sources)!: rename emitted CR names to <kind>-<source-name>-<hash>[-txt]

### DIFF
--- a/internal/controller/httproute_source_controller.go
+++ b/internal/controller/httproute_source_controller.go
@@ -289,7 +289,7 @@ func (r *HTTPRouteSourceReconciler) reconcileTunnelRule(
 	ownerRefs []metav1.OwnerReference,
 ) error {
 	upstream := ann[AnnotationTunnelUpstream]
-	ruleName := fmt.Sprintf("httproute-%s-%s", route.Namespace, route.Name)
+	ruleName := emittedTunnelRuleName("httproute", route.Name)
 
 	if upstream != "" {
 		rule := &cloudflarev1alpha1.CloudflareTunnelRule{
@@ -392,7 +392,7 @@ func (r *HTTPRouteSourceReconciler) emitDNSPair(
 	ownerRefs []metav1.OwnerReference,
 	sourceAnnotations map[string]string,
 ) error {
-	crName := capCRName(fmt.Sprintf("httproute-%s-%s-%s", route.Namespace, route.Name, sanitizeDNSForCRName(hostname)))
+	crName := emittedDNSRecordName("httproute", route.Name, hostname)
 	// Propagate cloudflare.io/adopt from the source object to the emitted CR so
 	// the DNS controller's registry decision can honour it.
 	var dnsRecordAnnotations map[string]string
@@ -434,7 +434,7 @@ func (r *HTTPRouteSourceReconciler) emitDNSPair(
 		SourceNamespace: route.Namespace,
 		SourceName:      route.Name,
 	})
-	txtCRName := capCRName(fmt.Sprintf("httproute-%s-%s-%s-txt", route.Namespace, route.Name, sanitizeDNSForCRName(hostname)))
+	txtCRName := crName + "-txt"
 	txtRecord := &cloudflarev1alpha1.CloudflareDNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      txtCRName,

--- a/internal/controller/httproute_source_controller_test.go
+++ b/internal/controller/httproute_source_controller_test.go
@@ -357,7 +357,7 @@ func TestHTTPRouteSource_TunnelUpstreamAbsent_DeletesOrphanRule(t *testing.T) {
 	// Pre-create the orphan rule at the expected name.
 	orphanRule := &cloudflarev1alpha1.CloudflareTunnelRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "httproute-apps-my-route",
+			Name:      emittedTunnelRuleName("httproute", "my-route"),
 			Namespace: "apps",
 		},
 		Spec: cloudflarev1alpha1.CloudflareTunnelRuleSpec{
@@ -693,9 +693,9 @@ func TestHTTPRouteSource_CRNaming_HTTPRoutePrefix(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expectedDNSName := "httproute-apps-my-route-foo-example-com"
-	expectedTXTName := "httproute-apps-my-route-foo-example-com-txt"
-	expectedRuleName := "httproute-apps-my-route"
+	expectedDNSName := emittedDNSRecordName("httproute", "my-route", "foo.example.com")
+	expectedTXTName := expectedDNSName + "-txt"
+	expectedRuleName := emittedTunnelRuleName("httproute", "my-route")
 
 	var records cloudflarev1alpha1.CloudflareDNSRecordList
 	if err := r.List(context.Background(), &records); err != nil {
@@ -1465,18 +1465,15 @@ func TestHTTPRouteSource_AdoptAnnotation_PropagatedToCR(t *testing.T) {
 }
 
 // ---- TestHTTPRouteSource_CRNameCapped_LongInput ----------------------------
-// P2.9: CR name for an HTTPRoute with a very long namespace+name+hostname must
-// be ≤ 253 chars (no trailing dashes).
+// P2.9: CR name for an HTTPRoute with a long namespace+name+hostname must
+// be ≤ 253 chars and a valid DNS-1123 subdomain. Under the new
+// emittedDNSRecordName scheme, hostname goes only into the hash, so length is
+// driven by sourceName plus a fixed kind prefix and 8-char suffix.
 
 func TestHTTPRouteSource_CRNameCapped_LongInput(t *testing.T) {
 	longNS := strings.Repeat("a", 63)
 	longName := strings.Repeat("b", 63)
 	longHostname := strings.Repeat("c", 63) + "." + strings.Repeat("d", 63) + ".example.com"
-
-	uncapped := "httproute-" + longNS + "-" + longName + "-" + sanitizeDNSForCRName(longHostname)
-	if len(uncapped) <= 253 {
-		t.Skipf("test setup error: uncapped name is only %d chars (want >253)", len(uncapped))
-	}
 
 	s := httpRouteScheme(t)
 	zone := newZone("z", longNS, "example.com", "cf-secret")

--- a/internal/controller/service_source_controller.go
+++ b/internal/controller/service_source_controller.go
@@ -212,7 +212,7 @@ func (r *ServiceSourceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// 15. Emit TunnelRule when target is tunnel.
 	if ts.Kind == TargetKindTunnel {
-		ruleName := fmt.Sprintf("svc-%s-%s", svc.Namespace, svc.Name)
+		ruleName := emittedTunnelRuleName("svc", svc.Name)
 		rule := &cloudflarev1alpha1.CloudflareTunnelRule{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            ruleName,
@@ -282,7 +282,7 @@ func (r *ServiceSourceReconciler) emitDNSPair(
 	sourceAnnotations map[string]string,
 ) error {
 	const recordType = "CNAME"
-	crName := capCRName(fmt.Sprintf("svc-%s-%s-%s", svc.Namespace, svc.Name, sanitizeDNSForCRName(hostname)))
+	crName := emittedDNSRecordName("svc", svc.Name, hostname)
 	// Propagate cloudflare.io/adopt from the source object to the emitted CR so
 	// the DNS controller's registry decision can honour it.
 	var dnsRecordAnnotations map[string]string
@@ -324,7 +324,7 @@ func (r *ServiceSourceReconciler) emitDNSPair(
 		SourceNamespace: svc.Namespace,
 		SourceName:      svc.Name,
 	})
-	txtCRName := capCRName(fmt.Sprintf("svc-%s-%s-%s-txt", svc.Namespace, svc.Name, sanitizeDNSForCRName(hostname)))
+	txtCRName := crName + "-txt"
 	txtRecord := &cloudflarev1alpha1.CloudflareDNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      txtCRName,

--- a/internal/controller/service_source_controller_test.go
+++ b/internal/controller/service_source_controller_test.go
@@ -670,9 +670,10 @@ func TestServiceSource_UpsertExistingRecord(t *testing.T) {
 	})
 
 	// Pre-create a DNS record at the expected name with wrong content.
+	expectedDNSName := emittedDNSRecordName("svc", "my-svc", "foo.example.com")
 	existingRecord := &cloudflarev1alpha1.CloudflareDNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "svc-apps-my-svc-foo-example-com",
+			Name:      expectedDNSName,
 			Namespace: "apps",
 		},
 		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
@@ -693,7 +694,7 @@ func TestServiceSource_UpsertExistingRecord(t *testing.T) {
 	// Re-fetch the record and verify it was updated.
 	var updated cloudflarev1alpha1.CloudflareDNSRecord
 	if err := r.Get(context.Background(),
-		types.NamespacedName{Namespace: "apps", Name: "svc-apps-my-svc-foo-example-com"},
+		types.NamespacedName{Namespace: "apps", Name: expectedDNSName},
 		&updated); err != nil {
 		t.Fatalf("get updated record: %v", err)
 	}
@@ -753,27 +754,17 @@ func TestServiceSource_WildcardHostname_Sanitized(t *testing.T) {
 	if err := r.List(context.Background(), &records); err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	// All emitted CRs should have "wild" in the name and no asterisks or dots.
-	found := false
+	// Wildcard FQDNs are folded into the name hash, so no asterisks or dots
+	// should ever appear in the emitted CR names.
+	if len(records.Items) == 0 {
+		t.Fatal("expected at least one emitted CR for a wildcard hostname")
+	}
 	for _, rec := range records.Items {
 		for _, ch := range rec.Name {
 			if ch == '*' || ch == '.' {
 				t.Errorf("CR name %q contains invalid character %q", rec.Name, ch)
 			}
 		}
-		if strings.Contains(rec.Name, "wild") {
-			found = true
-		}
-	}
-	if !found && len(records.Items) > 0 {
-		t.Errorf("expected at least one CR name containing 'wild', got %v",
-			func() []string {
-				names := make([]string, len(records.Items))
-				for i, r := range records.Items {
-					names[i] = r.Name
-				}
-				return names
-			}())
 	}
 }
 
@@ -1163,22 +1154,15 @@ func TestServiceSource_AdoptAnnotation_PropagatedToCR(t *testing.T) {
 }
 
 // ---- TestServiceSource_CRNameCapped_LongInput ------------------------------
-// P2.9: CR name for a Service with a very long namespace+name+hostname must be
-// ≤ 253 chars and be a valid DNS-1123 subdomain (no trailing dashes).
+// P2.9: CR name for a Service with a long namespace+name+hostname must be
+// ≤ 253 chars and be a valid DNS-1123 subdomain (no trailing dashes). Under
+// the new emittedDNSRecordName scheme, hostname goes only into the hash, so
+// length is driven by sourceName plus a fixed kind prefix and 8-char suffix.
 
 func TestServiceSource_CRNameCapped_LongInput(t *testing.T) {
-	// Build a hostname that pushes the svc-<ns>-<name>-<hostname> pattern well past 253.
-	// Build inputs that together produce an uncapped CR name > 253 chars.
-	// svc-<ns>-<name>-<sanitized-hostname> = 4 + 63 + 1 + 63 + 1 + 63+1+63+11 = well over 253.
 	longNS := strings.Repeat("a", 63)
 	longName := strings.Repeat("b", 63)
 	longHostname := strings.Repeat("c", 63) + "." + strings.Repeat("d", 63) + ".example.com"
-
-	// Verify our test input actually produces a name > 253 before capping.
-	uncapped := "svc-" + longNS + "-" + longName + "-" + sanitizeDNSForCRName(longHostname)
-	if len(uncapped) <= 253 {
-		t.Skipf("test setup error: uncapped name is only %d chars (want >253)", len(uncapped))
-	}
 
 	s := svcTestScheme(t)
 	zone := newZone("z", longNS, "example.com", "cf-secret")

--- a/internal/controller/source_helpers.go
+++ b/internal/controller/source_helpers.go
@@ -19,9 +19,7 @@ package controller
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -50,42 +48,6 @@ func splitAndTrim(s string) []string {
 		}
 	}
 	return out
-}
-
-var (
-	// invalidCRNameChars matches characters that are not valid in a DNS1123 subdomain label.
-	invalidCRNameChars = regexp.MustCompile(`[^a-z0-9-]`)
-	// multipleDashes collapses consecutive dashes.
-	multipleDashes = regexp.MustCompile(`-{2,}`)
-)
-
-// sanitizeDNSForCRName converts a DNS hostname into a valid Kubernetes
-// DNS1123 subdomain name suitable for use as a CR metadata.name.
-//
-// Transformation rules (applied in order):
-//  1. Lowercase.
-//  2. Replace leading wildcard "*" with "wild".
-//  3. Replace dots with dashes.
-//  4. Strip any remaining characters that are not [a-z0-9-].
-//  5. Collapse consecutive dashes.
-//  6. Trim leading/trailing dashes.
-func sanitizeDNSForCRName(s string) string {
-	s = strings.ToLower(s)
-	// Replace wildcard leaf with "wild".
-	if strings.HasPrefix(s, "*.") {
-		s = "wild" + s[1:]
-	} else if s == "*" {
-		s = "wild"
-	}
-	// Replace dots with dashes.
-	s = strings.ReplaceAll(s, ".", "-")
-	// Strip invalid characters.
-	s = invalidCRNameChars.ReplaceAllString(s, "")
-	// Collapse consecutive dashes.
-	s = multipleDashes.ReplaceAllString(s, "-")
-	// Trim leading/trailing dashes.
-	s = strings.Trim(s, "-")
-	return s
 }
 
 // isValidDNSName reports whether hostname is a valid DNS name for use as a
@@ -129,27 +91,23 @@ func isValidDNSName(hostname string) bool {
 	return true
 }
 
-// maxK8sName is the Kubernetes maximum length for resource names (DNS-1123 subdomain).
-const maxK8sName = 253
+// emittedDNSRecordName returns the deterministic CR name for a
+// source-emitted CloudflareDNSRecord. The 8-char suffix is a hash of
+// (sourceKind, fqdn) so that multiple FQDNs from the same source produce
+// distinct CR names while staying well under the DNS-1123 length limit.
+//
+// Wildcard FQDNs (e.g. "*.example.com") are safe: the asterisk is part of
+// the hash input only, not the visible CR name.
+func emittedDNSRecordName(sourceKind, sourceName, fqdn string) string {
+	sum := sha256.Sum256([]byte(sourceKind + "|" + fqdn))
+	return fmt.Sprintf("%s-%s-%x", sourceKind, sourceName, sum[:4])
+}
 
-// capCRName ensures a generated CR name does not exceed maxK8sName characters.
-// When the name is already within the limit, it is returned unchanged.
-// When it exceeds the limit, it is truncated and a 9-character hash suffix
-// ("-" + 8 hex chars from sha256 of the original full name) is appended to
-// preserve uniqueness. The result always satisfies DNS-1123 subdomain rules
-// (no trailing dashes — the truncation point trims any trailing dashes before
-// appending the hash).
-func capCRName(name string) string {
-	if len(name) <= maxK8sName {
-		return name
-	}
-	h := sha256.Sum256([]byte(name))
-	suffix := "-" + hex.EncodeToString(h[:4]) // "-" + 8 hex chars = 9 chars
-	maxHead := maxK8sName - len(suffix)
-	head := name[:maxHead]
-	// Trim any trailing dash introduced by truncation.
-	head = strings.TrimRight(head, "-")
-	return head + suffix
+// emittedTunnelRuleName returns the deterministic CR name for a
+// source-emitted CloudflareTunnelRule. There is one TunnelRule per source,
+// so no FQDN hash is needed.
+func emittedTunnelRuleName(sourceKind, sourceName string) string {
+	return fmt.Sprintf("%s-%s", sourceKind, sourceName)
 }
 
 // firstNonEmpty returns the first non-empty string among a and b.

--- a/internal/controller/source_helpers_test.go
+++ b/internal/controller/source_helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -68,49 +69,6 @@ func TestSplitAndTrim_TrailingComma(t *testing.T) {
 	got := splitAndTrim("foo.example.com,")
 	if len(got) != 1 || got[0] != testHostnameFoo {
 		t.Errorf("unexpected result: %v", got)
-	}
-}
-
-// ---- TestSanitizeDNSForCRName -----------------------------------------------
-
-func TestSanitizeDNSForCRName_Normal(t *testing.T) {
-	got := sanitizeDNSForCRName(testHostnameFoo)
-	if got != "foo-example-com" {
-		t.Errorf("expected foo-example-com, got %q", got)
-	}
-}
-
-func TestSanitizeDNSForCRName_Uppercase(t *testing.T) {
-	got := sanitizeDNSForCRName("FOO.EXAMPLE.COM")
-	if got != "foo-example-com" {
-		t.Errorf("expected foo-example-com, got %q", got)
-	}
-}
-
-func TestSanitizeDNSForCRName_Wildcard(t *testing.T) {
-	got := sanitizeDNSForCRName("*.apps.example.com")
-	if got != "wild-apps-example-com" {
-		t.Errorf("expected wild-apps-example-com, got %q", got)
-	}
-}
-
-func TestSanitizeDNSForCRName_WildcardIsValidDNS1123(t *testing.T) {
-	got := sanitizeDNSForCRName("*.apps.example.com")
-	// Must not contain asterisk or dots.
-	for _, ch := range got {
-		if ch == '*' || ch == '.' {
-			t.Errorf("invalid character %q in CR name %q", ch, got)
-		}
-	}
-	if len(got) == 0 {
-		t.Error("empty CR name")
-	}
-}
-
-func TestSanitizeDNSForCRName_BareWildcard(t *testing.T) {
-	got := sanitizeDNSForCRName("*")
-	if got != "wild" {
-		t.Errorf("expected wild, got %q", got)
 	}
 }
 
@@ -220,6 +178,58 @@ func TestSecretRefNamespace_BothEmpty(t *testing.T) {
 	got := secretRefNamespace(ref, "")
 	if got != "" {
 		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+// ---- TestEmittedDNSRecordName / TestEmittedTunnelRuleName -------------------
+
+func TestEmittedDNSRecordName_Shape(t *testing.T) {
+	name := emittedDNSRecordName("httproute", "jellyfin", "app.example.com")
+	// <kind>-<source-name>-<8 hex chars>
+	if !regexp.MustCompile(`^httproute-jellyfin-[0-9a-f]{8}$`).MatchString(name) {
+		t.Errorf("name = %q does not match expected shape", name)
+	}
+	// Length check: bounded.
+	if len(name) > 63 {
+		t.Errorf("name = %q exceeds 63 chars (DNS-1123 label limit)", name)
+	}
+}
+
+func TestEmittedDNSRecordName_DistinctFQDNsHashDistinctly(t *testing.T) {
+	a := emittedDNSRecordName("httproute", "jellyfin", "app.example.com")
+	b := emittedDNSRecordName("httproute", "jellyfin", "api.example.com")
+	if a == b {
+		t.Errorf("distinct FQDNs produced same name: %q", a)
+	}
+}
+
+func TestEmittedDNSRecordName_WildcardSafe(t *testing.T) {
+	name := emittedDNSRecordName("httproute", "apps", "*.example.com")
+	// The asterisk must NOT appear in the CR name (DNS-1123 forbids it).
+	if strings.Contains(name, "*") {
+		t.Errorf("name contains asterisk: %q", name)
+	}
+	// Must still match the expected shape.
+	if !regexp.MustCompile(`^httproute-apps-[0-9a-f]{8}$`).MatchString(name) {
+		t.Errorf("wildcard name shape wrong: %q", name)
+	}
+}
+
+func TestEmittedDNSRecordName_DeterministicAcrossKinds(t *testing.T) {
+	// Same FQDN, different source kinds: distinct names (hash input differs).
+	a := emittedDNSRecordName("httproute", "myapp", "app.example.com")
+	b := emittedDNSRecordName("svc", "myapp", "app.example.com")
+	if a == b {
+		t.Errorf("different source kinds produced same name: %q", a)
+	}
+}
+
+func TestEmittedTunnelRuleName(t *testing.T) {
+	if got := emittedTunnelRuleName("httproute", "jellyfin"); got != "httproute-jellyfin" {
+		t.Errorf("got %q", got)
+	}
+	if got := emittedTunnelRuleName("svc", "myapp"); got != "svc-myapp" {
+		t.Errorf("got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Source-emitted `CloudflareDNSRecord` and `CloudflareTunnelRule` CR names today follow `<kind>-<namespace>-<source-name>-<sanitized-hostname>[-txt]`, which produces unwieldy 80–100+ character names (and longer with long FQDNs). They also leak the source object's namespace into the CR name even though the CR is co-located with the source.

This PR replaces the scheme with **Option I** from #71 — short, deterministic, hash-stable across reconciles, and wildcard-safe:

- **DNSRecord**: `<kind>-<source-name>-<8-hex-chars-of-sha256(kind|fqdn)>` (with `<...>-txt` for the TXT registry record)
- **TunnelRule**: `<kind>-<source-name>` (one per source — no FQDN hash needed)

`<kind>` is `httproute` for `HTTPRoute` sources and `svc` for `Service` sources. The 8-char hash is over `(kind|fqdn)` so multiple FQDNs from the same source get distinct names without leaking the FQDN. Wildcards (`*.example.com`) fold into the hash and never appear in the visible CR name.

Example: `httproute-jellyfin-7f8a9b2c` (28 chars) instead of `httproute-selfhosted-jellyfin-jellyfin-example-com` (50 chars).

## Implementation

- New `emittedDNSRecordName` and `emittedTunnelRuleName` helpers in `internal/controller/source_helpers.go`.
- Six emit sites in `httproute_source_controller.go` and `service_source_controller.go` updated to call the helpers.
- Dead `sanitizeDNSForCRName` / `capCRName` helpers + their tests removed (only callers were the now-replaced emit sites).
- Tests asserting on literal old-format names updated to call the new helpers.
- Long-input regression tests retained — the new helper is bounded by construction (kind prefix + source name + 8-char hash), so the tests now lock that property under long inputs rather than the old truncation behavior.

## Migration

This is a **clean redo with no migration helper** (per the issue discussion). On upgrade, CRs created under the old scheme become orphans:

- Owner-reference garbage collection cleans them up automatically when the source `HTTPRoute` / `Service` is deleted.
- Otherwise, operators can run something like:
  ```sh
  kubectl get cloudflarednsrecord -A -l cloudflare.io/managed-by=cloudflare-operator -o name | xargs kubectl delete
  ```
  and let the source controllers recreate them with the new names.

The TXT registry continues to use FQDN-based ownership keys (independent of CR names), so no DNS-record churn or external-dns coexistence regression.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` green; new helper tests cover shape, distinct-hashes, wildcard-safety, kind-distinguishes
- [x] Existing reconcile tests updated to use the helpers; orphan-rule deletion test still locks the contract
- [ ] Apply to a live cluster: confirm new HTTPRoute / Service emits short CR names; confirm orphans GC out when source is deleted

## Notes

- One pre-existing edge case surfaced during review (not in scope for this PR): `firstGatewayAddress` returns `gw.Status.Addresses[0].Value` without filtering by `Address.Type`. With `IPAddress` (A/AAAA) and `Hostname` (CNAME) it works correctly, but `NamedAddress` would be misclassified. Not a regression here — happy to file a follow-up issue if you want it tracked.

## Breaking change

Emitted CR names change shape. Existing CRs are not migrated and become orphans until owner-ref GC removes them or operators clean up manually.

## Related

- Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)