### PR TITLE
docs: document new emitted CR naming + v0.10.0 upgrade orphans

### DIFF
--- a/docs/gateway-api-source.md
+++ b/docs/gateway-api-source.md
@@ -11,6 +11,31 @@ Sources never call the Cloudflare API directly. They only emit primitive CRs tha
 
 **Prerequisite:** Set `registry.txtOwnerID` in your Helm values (or the `TXT_OWNER_ID` environment variable). Without it, source controllers are inert.
 
+### Emitted CR naming
+
+Source controllers name the CRs they emit deterministically:
+
+- **`CloudflareDNSRecord`**: `<kind>-<source-name>-<8-hex-hash>` (and `<...>-txt` for the companion ownership TXT)
+- **`CloudflareTunnelRule`**: `<kind>-<source-name>` (one per source — no FQDN hash needed)
+
+`<kind>` is `httproute` for `HTTPRoute` sources and `svc` for `Service` sources. The 8-hex-char hash is `sha256(kind|fqdn)` truncated, so multiple FQDNs from the same source produce distinct CR names without leaking the FQDN. Wildcards (`*.example.com`) fold into the hash and never appear in the visible CR name.
+
+Example: an HTTPRoute named `jellyfin` carrying `app.example.com` produces a CR like `httproute-jellyfin-7f8a9b2c` (and `httproute-jellyfin-7f8a9b2c-txt`).
+
+### Upgrading from earlier operator versions
+
+Releases before v0.10.0 used a longer name shape: `<kind>-<namespace>-<source-name>-<sanitized-hostname>[-txt]`. After upgrading, the source controllers emit only the new short-form CRs; previously emitted long-form CRs become **orphans** in your cluster.
+
+The simplest cleanup is to delete every operator-managed `CloudflareDNSRecord` and let the source controllers re-emit them with the new names on the next reconcile:
+
+```bash
+kubectl get cloudflarednsrecord -A \
+  -l app.kubernetes.io/managed-by=cloudflare-operator \
+  -o name | xargs -r kubectl delete
+```
+
+Owner-reference garbage collection also removes long-form CRs automatically when the source `HTTPRoute` or `Service` is deleted, so leaving them in place is safe — they will eventually disappear on their own. Cloudflare DNS records themselves are unaffected: the TXT registry uses FQDN-based ownership keys independent of CR names, so re-emitted CRs adopt the existing records cleanly without churn.
+
 ---
 
 ## Annotation Reference

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -283,7 +283,7 @@ The operator retries on the next reconcile and adopts the record, rewriting the 
 
 ## 6. Two Routes or Services Conflict on the Same FQDN
 
-**Symptom:** Two `HTTPRoute` or `Service` objects both claim the same hostname. Because each source controller names its emitted `CloudflareDNSRecord` after itself (e.g. `httproute-<ns>-<name>-<fqdn>` vs. `svc-<ns>-<name>-<fqdn>`), two CRs for the same FQDN can coexist and both attempt to reconcile the Cloudflare record. The TXT registry mediates ownership: the first CR to write the companion TXT claims ownership (`owner = txtOwnerID`). The second CR finds a TXT whose owner matches `txtOwnerID` and treats the record as already-owned, so it overwrites the DNS content on every reconcile cycle. The result is last-write-wins churn, not a hard error.
+**Symptom:** Two `HTTPRoute` or `Service` objects both claim the same hostname. Because each source controller names its emitted `CloudflareDNSRecord` after itself (e.g. `httproute-<source-name>-<hash>` vs. `svc-<source-name>-<hash>`, where `<hash>` is 8 hex chars derived from the source kind and FQDN), two CRs for the same FQDN can coexist and both attempt to reconcile the Cloudflare record. The TXT registry mediates ownership: the first CR to write the companion TXT claims ownership (`owner = txtOwnerID`). The second CR finds a TXT whose owner matches `txtOwnerID` and treats the record as already-owned, so it overwrites the DNS content on every reconcile cycle. The result is last-write-wins churn, not a hard error.
 
 ```bash
 # Find all CloudflareDNSRecord CRs for a hostname to identify competing sources


### PR DESCRIPTION
## Summary

Follow-up to #71 / #79 (v0.10.0). The source-emitted CR naming changed shape in v0.10.0; this PR brings the docs in line.

### `docs/gateway-api-source.md`

- New **Emitted CR naming** subsection at the top, documenting the deterministic shape (`<kind>-<source-name>-<8-hex-hash>` for `CloudflareDNSRecord`, `<kind>-<source-name>` for `CloudflareTunnelRule`) and how the hash protects against FQDN-leak / wildcard conflicts.
- New **Upgrading from earlier operator versions** callout explaining that long-form CRs from earlier releases become orphans after upgrade. Includes the `kubectl` one-liner to batch-delete operator-managed records so the source controllers re-emit them under the new names. Notes that the TXT registry uses FQDN-based ownership keys (independent of CR names) so re-emission adopts existing Cloudflare records without DNS churn.

### `docs/troubleshooting.md`

- Section 6 ("Two Routes or Services Conflict on the Same FQDN"): inline pattern updated from `httproute-<ns>-<name>-<fqdn>` to `httproute-<source-name>-<hash>` to match v0.10.0.

## Scope check

Swept the full `docs/` tree (excluding `docs/plans/`, which is local-only) for old-format CR-name references. Only `troubleshooting.md` and the new `gateway-api-source.md` callout needed changes — `domain-onboarding.md`, `external-dns-migration.md`, `tunnels.md`, and `README.md` use generic `<cr-name>` placeholders or no CR-name examples at all.

## Test plan

- [x] `grep` for old-format patterns confirms only intentional historical reference remains (in the upgrade callout)
- [x] Renders correctly in GitHub markdown preview

## Related

- Follow-up to #71 (v0.10.0 source CR rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)