### PR TITLE
feat(connector,chart): PodDisruptionBudget + topologySpreadConstraint defaults

### DIFF
--- a/chart/templates/_values-controllers.tpl
+++ b/chart/templates/_values-controllers.tpl
@@ -2,6 +2,9 @@
 Build controllers structure from flat values
 */}}
 {{- define "cloudflare-operator.values.controllers" -}}
+{{- $replicas := int (.Values.controller.replicas | default 1) -}}
+{{- $tsc := .Values.controller.topologySpreadConstraints | default list -}}
+{{- $aff := .Values.controller.affinity | default dict -}}
 controllers:
   main:
     type: deployment
@@ -11,6 +14,27 @@ controllers:
     serviceAccount:
       identifier: main
     {{- end }}
+    {{- if and .Values.controller.podDisruptionBudget.enabled (gt $replicas 1) }}
+    podDisruptionBudget:
+      minAvailable: 1
+    {{- end }}
+    pod:
+      {{- if and (gt $replicas 1) (empty $tsc) (empty $aff) }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "cloudflare-operator.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/controller: main
+      {{- else if not (empty $tsc) }}
+      topologySpreadConstraints: {{ toYaml $tsc | nindent 8 }}
+      {{- end }}
+      {{- if not (empty $aff) }}
+      affinity: {{ toYaml $aff | nindent 8 }}
+      {{- end }}
     containers:
       main:
         image:

--- a/chart/templates/_values-rbac.tpl
+++ b/chart/templates/_values-rbac.tpl
@@ -120,6 +120,18 @@ rbac:
             - get
             - list
             - watch
+        - apiGroups:
+            - policy
+          resources:
+            - poddisruptionbudgets
+          verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
 {{- if .Values.leaderElection.enabled }}
     leader-election:
       enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,26 @@ controller:
   replicas: 1
   strategy: Recreate
 
+  # -- Default soft per-hostname topologySpreadConstraints applied when
+  # replicas > 1 AND neither controller.affinity nor
+  # controller.topologySpreadConstraints is set. To disable, leave both
+  # empty (single-replica deployments don't benefit from spread). To
+  # override the default, set controller.affinity or
+  # controller.topologySpreadConstraints to your desired value — the
+  # operator-injected default is replaced wholesale, never merged.
+  topologySpreadConstraints: []
+
+  # -- Affinity rules. When set, suppresses the default
+  # topologySpreadConstraint above.
+  affinity: {}
+
+  # -- PodDisruptionBudget for the operator deployment. Created with
+  # minAvailable:1 only when replicas > 1; ignored at replicas:1 because
+  # a minAvailable:1 PDB on a single-replica deployment blocks all
+  # voluntary disruptions, which is strictly worse than no PDB.
+  podDisruptionBudget:
+    enabled: true
+
 # -- Leader election for HA (active-passive)
 # When enabled with multiple replicas, only one instance processes resources
 leaderElection:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -113,3 +113,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -274,6 +274,54 @@ Conditions: `Ready`, `IngressConfigured`, and (when connector is enabled) `Conne
 - **Conflict-tolerant connector reconcile**: SA / ConfigMap / Deployment update paths absorb transient optimistic-concurrency conflicts in-process via `retry.RetryOnConflict`, so a churning connector resource never inflates the controller workqueue's exponential backoff or wedges finalizer cleanup.
 - **Adoption**: If a tunnel with the same name exists in Cloudflare, the operator adopts it rather than creating a duplicate.
 
+### Default scheduling and disruption budget
+
+When `spec.connector.replicas` is `>= 2`, the operator automatically creates two safe-by-default Kubernetes objects to keep the connector available during voluntary disruption:
+
+- A **`PodDisruptionBudget`** named `<connector-base>-pdb` (where `<connector-base>` follows the same naming as the Deployment, including any `spec.connector.nameOverride`) with `minAvailable: 1`. This protects the connector from node drains, autoscaler scale-downs, and manual evictions.
+- A **`topologySpreadConstraint`** on the connector pod template with `maxSkew: 1`, `topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`. Connector replicas land on different nodes by default. Soft semantics preserve scheduling on small clusters where `replicas > nodes`.
+
+Both defaults are skipped at `replicas: 1`. A `minAvailable: 1` PDB on a single-replica deployment blocks all voluntary disruptions (strictly worse than no PDB), and a `topologySpreadConstraint` across one pod is meaningless.
+
+**Override semantics**: the default `topologySpreadConstraint` is injected **only when both `spec.connector.affinity` and `spec.connector.topologySpreadConstraints` are unset**. Setting either one disables the default wholesale — the operator never merges user input with its defaults. Any scheduling override the user provides is honoured exactly, with no silent additions.
+
+The PDB is unconditional at `replicas >= 2`. There is no `spec.connector.disruptionBudget` knob; if you need one, file an issue.
+
+#### Rendered example
+
+At `spec.connector.replicas: 2` with no scheduling overrides, the operator emits:
+
+```yaml
+# Connector Deployment pod spec gains:
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloudflared
+              app.kubernetes.io/instance: <tunnel-name>
+              app.kubernetes.io/managed-by: cloudflare-operator
+              cloudflare.io/tunnel: <tunnel-name>
+
+# Alongside the Deployment, this PDB is created:
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: <tunnel-name>-connector-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflared
+      app.kubernetes.io/instance: <tunnel-name>
+      app.kubernetes.io/managed-by: cloudflare-operator
+      cloudflare.io/tunnel: <tunnel-name>
+```
+
 ### Example
 
 ```yaml

--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -62,6 +62,8 @@ spec:
 
 All fields in `connector` except `enabled` are optional. Omitting `connector` entirely (or setting `enabled: false`) means you are responsible for running cloudflared yourself.
 
+At `replicas: 2` or higher the operator additionally creates a `PodDisruptionBudget` and injects a default per-hostname `topologySpreadConstraint`. See [crd-reference.md → Default scheduling and disruption budget](crd-reference.md#default-scheduling-and-disruption-budget) for the override semantics.
+
 ### Naming the connector resources
 
 By default the operator names the Deployment, ServiceAccount, and ConfigMap as `<tunnel.metadata.name>-connector`, `<tunnel.metadata.name>-connector`, and `<tunnel.metadata.name>-connector-config`. To use a different name family — for example, to fit existing monitoring labels or GitOps drift expectations — set `spec.connector.nameOverride`:

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -13,6 +13,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -203,6 +204,9 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	}
 	if err := appsv1.AddToScheme(s); err != nil {
 		t.Fatalf("failed to add appsv1 to scheme: %v", err)
+	}
+	if err := policyv1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add policyv1 to scheme: %v", err)
 	}
 	return s
 }

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -161,10 +161,11 @@ func applyOwnedPDB(ctx context.Context, c client.Client, tun *cloudflarev1alpha1
 	desired := BuildConnectorPodDisruptionBudget(tun)
 	name := ConnectorNames(tun).PodDisruptionBudget
 
-	var existing policyv1.PodDisruptionBudget
-	getErr := c.Get(ctx, types.NamespacedName{Name: name, Namespace: tun.Namespace}, &existing)
-
 	if desired == nil {
+		// Ensure absent: single Get + Delete; no retry needed because the
+		// existing-state check already handled the race at the call site.
+		var existing policyv1.PodDisruptionBudget
+		getErr := c.Get(ctx, types.NamespacedName{Name: name, Namespace: tun.Namespace}, &existing)
 		if errors.IsNotFound(getErr) {
 			return nil
 		}
@@ -177,24 +178,24 @@ func applyOwnedPDB(ctx context.Context, c client.Client, tun *cloudflarev1alpha1
 		return nil
 	}
 
-	if errors.IsNotFound(getErr) {
-		if createErr := c.Create(ctx, desired); createErr != nil {
-			return fmt.Errorf("create PDB %s/%s: %w", tun.Namespace, name, createErr)
-		}
-		return nil
-	}
-	if getErr != nil {
-		return fmt.Errorf("get PDB %s/%s: %w", tun.Namespace, name, getErr)
-	}
-
+	// Ensure present: re-fetch inside the retry closure on every iteration so
+	// that a genuine optimistic-concurrency conflict can be healed. Mirrors the
+	// Deployment apply idiom in reconcileConnectorResources.
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		existing.Spec = desired.Spec
-		existing.Labels = desired.Labels
-		existing.OwnerReferences = desired.OwnerReferences
-		if updateErr := c.Update(ctx, &existing); updateErr != nil {
-			return fmt.Errorf("update PDB %s/%s: %w", tun.Namespace, name, updateErr)
+		var existing policyv1.PodDisruptionBudget
+		err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: tun.Namespace}, &existing)
+		switch {
+		case errors.IsNotFound(err):
+			// Race: PDB was deleted between the outer nil-check and now. Create.
+			return c.Create(ctx, desired)
+		case err != nil:
+			return fmt.Errorf("get PDB %s/%s: %w", tun.Namespace, name, err)
+		default:
+			existing.Spec = desired.Spec
+			existing.Labels = desired.Labels
+			existing.OwnerReferences = desired.OwnerReferences
+			return c.Update(ctx, &existing)
 		}
-		return nil
 	})
 }
 

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,7 +124,7 @@ func reconcileConnectorResources(ctx context.Context, c client.Client, tun *clou
 
 	desired := BuildConnectorDeployment(tun, agg.ConfigHash)
 
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var existing appsv1.Deployment
 		err := c.Get(ctx, types.NamespacedName{Namespace: desired.Namespace, Name: desired.Name}, &existing)
 		switch {
@@ -145,6 +146,55 @@ func reconcileConnectorResources(ctx context.Context, c client.Client, tun *clou
 			existing.OwnerReferences = desired.OwnerReferences
 			return c.Update(ctx, &existing)
 		}
+	}); err != nil {
+		return err
+	}
+
+	return applyOwnedPDB(ctx, c, tun)
+}
+
+// applyOwnedPDB ensures the connector PDB matches what
+// BuildConnectorPodDisruptionBudget returns. A nil desired value means
+// "ensure absent" — so dropping spec.connector.replicas from 2 to 1 removes
+// the PDB on the next reconcile.
+func applyOwnedPDB(ctx context.Context, c client.Client, tun *cloudflarev1alpha1.CloudflareTunnel) error {
+	desired := BuildConnectorPodDisruptionBudget(tun)
+	name := ConnectorNames(tun).PodDisruptionBudget
+
+	var existing policyv1.PodDisruptionBudget
+	getErr := c.Get(ctx, types.NamespacedName{Name: name, Namespace: tun.Namespace}, &existing)
+
+	if desired == nil {
+		if errors.IsNotFound(getErr) {
+			return nil
+		}
+		if getErr != nil {
+			return fmt.Errorf("get PDB %s/%s: %w", tun.Namespace, name, getErr)
+		}
+		if delErr := c.Delete(ctx, &existing); delErr != nil && !errors.IsNotFound(delErr) {
+			return fmt.Errorf("delete PDB %s/%s: %w", tun.Namespace, name, delErr)
+		}
+		return nil
+	}
+
+	if errors.IsNotFound(getErr) {
+		if createErr := c.Create(ctx, desired); createErr != nil {
+			return fmt.Errorf("create PDB %s/%s: %w", tun.Namespace, name, createErr)
+		}
+		return nil
+	}
+	if getErr != nil {
+		return fmt.Errorf("get PDB %s/%s: %w", tun.Namespace, name, getErr)
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing.Spec = desired.Spec
+		existing.Labels = desired.Labels
+		existing.OwnerReferences = desired.OwnerReferences
+		if updateErr := c.Update(ctx, &existing); updateErr != nil {
+			return fmt.Errorf("update PDB %s/%s: %w", tun.Namespace, name, updateErr)
+		}
+		return nil
 	})
 }
 

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -41,6 +41,11 @@ import (
 // Tests MUST use errors.Is(err, ErrUnownedDeployment) to assert this case.
 var ErrUnownedDeployment = stderrors.New("refusing to adopt Deployment not owned by this tunnel")
 
+// ErrUnownedPDB is returned when applyOwnedPDB finds an existing
+// PodDisruptionBudget that is not owned by the reconciled CloudflareTunnel.
+// Tests MUST use errors.Is(err, ErrUnownedPDB) to assert this case.
+var ErrUnownedPDB = stderrors.New("refusing to adopt PodDisruptionBudget not owned by this tunnel")
+
 // ReconcileConnectorAndRules performs the Task 8 additions to the tunnel
 // reconcile: aggregates CloudflareTunnelRule CRs for this tunnel, renders
 // config.yaml, reconciles the connector workload (when enabled), and writes
@@ -191,6 +196,9 @@ func applyOwnedPDB(ctx context.Context, c client.Client, tun *cloudflarev1alpha1
 		case err != nil:
 			return fmt.Errorf("get PDB %s/%s: %w", tun.Namespace, name, err)
 		default:
+			if !isOwnedBy(existing.OwnerReferences, tun.UID) {
+				return fmt.Errorf("%w: %s/%s", ErrUnownedPDB, existing.Namespace, existing.Name)
+			}
 			existing.Spec = desired.Spec
 			existing.Labels = desired.Labels
 			existing.OwnerReferences = desired.OwnerReferences

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -1152,6 +1152,99 @@ func TestCloudflareTunnel_NoPDBAtReplicasOne(t *testing.T) {
 	}
 }
 
+// TestCloudflareTunnel_PDBIdempotentUpdate exercises the default branch of
+// applyOwnedPDB's switch — the path where a PDB already exists, ownership
+// passes, and Spec/Labels/OwnerReferences are re-applied and Update is called.
+// This is the path that fires on every steady-state reconcile after the first.
+func TestCloudflareTunnel_PDBIdempotentUpdate(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true) // Replicas==2 → PDB desired
+	c := buildAggFakeClient(tun)
+
+	// First reconcile: creates the PDB.
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("first ReconcileConnectorAndRules: %v", err)
+	}
+
+	n := ConnectorNames(tun)
+	var pdbAfterCreate policyv1.PodDisruptionBudget
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: tun.Namespace, Name: n.PodDisruptionBudget}, &pdbAfterCreate); err != nil {
+		t.Fatalf("PDB not found after first reconcile: %v", err)
+	}
+
+	// Second reconcile: PDB exists → must hit the default (update) branch.
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("second ReconcileConnectorAndRules: %v", err)
+	}
+
+	// Assert PDB still exists with the correct shape after the update path.
+	var pdb policyv1.PodDisruptionBudget
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: tun.Namespace, Name: n.PodDisruptionBudget}, &pdb); err != nil {
+		t.Fatalf("expected PDB to exist after second reconcile: %v", err)
+	}
+
+	// MinAvailable must be 1.
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.IntValue() != 1 {
+		t.Errorf("MinAvailable = %v, want 1", pdb.Spec.MinAvailable)
+	}
+
+	// Selector.MatchLabels must match the canonical four connectorLabels.
+	wantSelectorLabels := map[string]string{
+		"app.kubernetes.io/name":       "cloudflared",
+		"app.kubernetes.io/instance":   tun.Name,
+		"app.kubernetes.io/managed-by": "cloudflare-operator",
+		"cloudflare.io/tunnel":         tun.Name,
+	}
+	if pdb.Spec.Selector == nil {
+		t.Fatal("PDB Spec.Selector is nil after update")
+	}
+	if !reflect.DeepEqual(pdb.Spec.Selector.MatchLabels, wantSelectorLabels) {
+		t.Errorf("Selector.MatchLabels = %v, want %v", pdb.Spec.Selector.MatchLabels, wantSelectorLabels)
+	}
+
+	// OwnerReferences must point back to the tunnel with Controller=true, BlockOwnerDeletion=true.
+	if len(pdb.OwnerReferences) != 1 || pdb.OwnerReferences[0].UID != tun.UID {
+		t.Errorf("OwnerReferences missing or wrong tunnel UID: %+v", pdb.OwnerReferences)
+	}
+	ref := pdb.OwnerReferences[0]
+	if ref.Controller == nil || !*ref.Controller {
+		t.Errorf("OwnerReferences[0].Controller = %v, want true", ref.Controller)
+	}
+	if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+		t.Errorf("OwnerReferences[0].BlockOwnerDeletion = %v, want true", ref.BlockOwnerDeletion)
+	}
+}
+
+// TestCloudflareTunnel_PDBOwnershipGuard asserts applyOwnedPDB refuses to
+// adopt a pre-existing PDB at the standard name that isn't owner-referenced
+// by this tunnel. The error must satisfy errors.Is(err, ErrUnownedPDB).
+func TestCloudflareTunnel_PDBOwnershipGuard(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true) // Replicas==2 → PDB desired
+	n := ConnectorNames(tun)
+
+	// Pre-create a PDB at the standard name owned by a DIFFERENT tunnel.
+	preExisting := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n.PodDisruptionBudget,
+			Namespace: tun.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: cloudflarev1alpha1.GroupVersion.String(),
+				Kind:       "CloudflareTunnel",
+				Name:       "other-tunnel",
+				UID:        "different-tunnel-uid",
+			}},
+		},
+	}
+	c := buildAggFakeClient(tun, preExisting)
+
+	err := ReconcileConnectorAndRules(context.Background(), c, tun, nil)
+	if err == nil {
+		t.Fatal("expected error for unowned PDB, got nil")
+	}
+	if !errors.Is(err, ErrUnownedPDB) {
+		t.Errorf("expected errors.Is(err, ErrUnownedPDB), got: %v", err)
+	}
+}
+
 // TestApplyOwned_RetriesOnServiceAccountConflict verifies the same recovery
 // for the ServiceAccount Update path.
 func TestApplyOwned_RetriesOnServiceAccountConflict(t *testing.T) {

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1074,6 +1075,25 @@ func TestCloudflareTunnel_PDBCreated(t *testing.T) {
 	}
 	if len(pdb.OwnerReferences) != 1 || pdb.OwnerReferences[0].UID != tun.UID {
 		t.Errorf("OwnerReferences missing tunnel ref: %+v", pdb.OwnerReferences)
+	}
+	ref := pdb.OwnerReferences[0]
+	if ref.Controller == nil || !*ref.Controller {
+		t.Errorf("OwnerReferences[0].Controller = %v, want true", ref.Controller)
+	}
+	if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+		t.Errorf("OwnerReferences[0].BlockOwnerDeletion = %v, want true", ref.BlockOwnerDeletion)
+	}
+	wantSelectorLabels := map[string]string{
+		"app.kubernetes.io/name":       "cloudflared",
+		"app.kubernetes.io/instance":   tun.Name,
+		"app.kubernetes.io/managed-by": "cloudflare-operator",
+		"cloudflare.io/tunnel":         tun.Name,
+	}
+	if pdb.Spec.Selector == nil {
+		t.Fatal("PDB Spec.Selector is nil")
+	}
+	if !reflect.DeepEqual(pdb.Spec.Selector.MatchLabels, wantSelectorLabels) {
+		t.Errorf("Selector.MatchLabels = %v, want %v", pdb.Spec.Selector.MatchLabels, wantSelectorLabels)
 	}
 }
 

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -26,6 +26,7 @@ import (
 	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,9 +37,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-// aggTestScheme builds a scheme with v1alpha1, corev1, and appsv1 registered.
-// testScheme (from cloudflarednsrecord_controller_test.go) only registers
-// v1alpha1 and corev1; we extend it here with appsv1 for Deployment support.
+// aggTestScheme builds a scheme with v1alpha1, corev1, appsv1, and policyv1
+// registered. testScheme (from cloudflarednsrecord_controller_test.go) only
+// registers v1alpha1, corev1, appsv1, and policyv1; we mirror those here so
+// the aggregation client supports PodDisruptionBudget objects.
 func aggTestScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	if err := cloudflarev1alpha1.AddToScheme(s); err != nil {
@@ -49,6 +51,9 @@ func aggTestScheme() *runtime.Scheme {
 	}
 	if err := appsv1.AddToScheme(s); err != nil {
 		panic("add appsv1 to scheme: " + err.Error())
+	}
+	if err := policyv1.AddToScheme(s); err != nil {
+		panic("add policyv1 to scheme: " + err.Error())
 	}
 	return s
 }
@@ -1043,6 +1048,87 @@ func TestApplyOwned_RetriesOnConfigMapConflict(t *testing.T) {
 	}
 	if calls < 3 {
 		t.Errorf("expected >=3 update attempts, got %d", calls)
+	}
+}
+
+// ---- PDB reconcile tests ----------------------------------------------------
+
+// TestCloudflareTunnel_PDBCreated asserts that reconciling a connector-enabled
+// tunnel with replicas==2 produces an owner-ref-bound PDB alongside the
+// Deployment.
+func TestCloudflareTunnel_PDBCreated(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true) // Replicas==2
+	c := buildAggFakeClient(tun)
+
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("ReconcileConnectorAndRules: %v", err)
+	}
+
+	n := ConnectorNames(tun)
+	var pdb policyv1.PodDisruptionBudget
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: tun.Namespace, Name: n.PodDisruptionBudget}, &pdb); err != nil {
+		t.Fatalf("expected PDB to be created: %v", err)
+	}
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.IntValue() != 1 {
+		t.Errorf("MinAvailable = %v, want 1", pdb.Spec.MinAvailable)
+	}
+	if len(pdb.OwnerReferences) != 1 || pdb.OwnerReferences[0].UID != tun.UID {
+		t.Errorf("OwnerReferences missing tunnel ref: %+v", pdb.OwnerReferences)
+	}
+}
+
+// TestCloudflareTunnel_PDBDeletedOnReplicasDowngrade asserts the operator
+// removes the PDB when spec.connector.replicas drops to 1
+// (BuildConnectorPodDisruptionBudget returns nil → applyOwnedPDB sees
+// existing PDB + nil desired → Delete).
+func TestCloudflareTunnel_PDBDeletedOnReplicasDowngrade(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true)
+	tun.Spec.Connector.Replicas = 1 // downgrade: PDB should be absent
+
+	// Pre-create a PDB at the standard name (simulates PDB left over from replicas==2).
+	n := ConnectorNames(tun)
+	preExistingPDB := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            n.PodDisruptionBudget,
+			Namespace:       tun.Namespace,
+			OwnerReferences: connectorOwnerRef(tun),
+		},
+	}
+	c := buildAggFakeClient(tun, preExistingPDB)
+
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("ReconcileConnectorAndRules: %v", err)
+	}
+
+	var pdb policyv1.PodDisruptionBudget
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: tun.Namespace, Name: n.PodDisruptionBudget}, &pdb)
+	if err == nil {
+		t.Fatal("expected PDB to be deleted after replicas downgrade to 1, but it still exists")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected IsNotFound error after PDB deletion, got: %v", err)
+	}
+}
+
+// TestCloudflareTunnel_NoPDBAtReplicasOne asserts no PDB is created when a
+// fresh tunnel starts at replicas==1.
+func TestCloudflareTunnel_NoPDBAtReplicasOne(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true)
+	tun.Spec.Connector.Replicas = 1
+	c := buildAggFakeClient(tun)
+
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("ReconcileConnectorAndRules: %v", err)
+	}
+
+	n := ConnectorNames(tun)
+	var pdb policyv1.PodDisruptionBudget
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: tun.Namespace, Name: n.PodDisruptionBudget}, &pdb)
+	if err == nil {
+		t.Fatal("expected no PDB at replicas==1, but one was created")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected IsNotFound error, got: %v", err)
 	}
 }
 

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -27,6 +27,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,6 +63,7 @@ type CloudflareTunnelReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 
 // Reconcile moves the current state of the cluster closer to the desired state
@@ -358,6 +360,7 @@ func (r *CloudflareTunnelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.Secret{}).
 		Watches(&cloudflarev1alpha1.CloudflareTunnelRule{}, handler.EnqueueRequestsFromMapFunc(r.mapRuleToTunnel)).
 		Complete(r)

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -170,7 +170,7 @@ func BuildConnectorPodDisruptionBudget(tun *cloudflarev1alpha1.CloudflareTunnel)
 		return nil
 	}
 	n := ConnectorNames(tun)
-	minAvail := intstr.FromInt(1)
+	minAvail := intstr.FromInt32(1)
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            n.PodDisruptionBudget,

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -187,6 +187,43 @@ func BuildConnectorPodDisruptionBudget(tun *cloudflarev1alpha1.CloudflareTunnel)
 	}
 }
 
+// orDefault returns user when non-empty, otherwise fallback. Used to apply
+// scheduling defaults only when the user has not set a value.
+func orDefault[T any](user []T, fallback []T) []T {
+	if len(user) > 0 {
+		return user
+	}
+	return fallback
+}
+
+// defaultTopologySpread returns the default soft per-hostname
+// topologySpreadConstraint slice when:
+//   - replicas > 1, AND
+//   - cspec.Affinity is unset, AND
+//   - cspec.TopologySpreadConstraints is empty.
+//
+// Returns nil otherwise — any user-set scheduling knob disables the default
+// wholesale (least-surprise: user intent honoured exactly, no merging).
+func defaultTopologySpread(cspec *cloudflarev1alpha1.ConnectorSpec, replicas int32, labels map[string]string) []corev1.TopologySpreadConstraint {
+	if replicas < 2 {
+		return nil
+	}
+	if cspec == nil {
+		return nil
+	}
+	if cspec.Affinity != nil || len(cspec.TopologySpreadConstraints) > 0 {
+		return nil
+	}
+	return []corev1.TopologySpreadConstraint{{
+		MaxSkew:           1,
+		TopologyKey:       "kubernetes.io/hostname",
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: labels,
+		},
+	}}
+}
+
 // BuildConnectorDeployment produces the desired Deployment running cloudflared.
 //
 // Replicas: when cspec is nil (defensive path), default to 2. When cspec is
@@ -246,7 +283,7 @@ func BuildConnectorDeployment(tun *cloudflarev1alpha1.CloudflareTunnel, configHa
 		NodeSelector:              cspec.NodeSelector,
 		Tolerations:               cspec.Tolerations,
 		Affinity:                  cspec.Affinity,
-		TopologySpreadConstraints: cspec.TopologySpreadConstraints,
+		TopologySpreadConstraints: orDefault(cspec.TopologySpreadConstraints, defaultTopologySpread(cspec, replicas, labels)),
 		// FSGroup is intentionally unset: both volumes are read-only, and
 		// FSGroup forces a recursive chown on some CSI drivers.
 		SecurityContext: &corev1.PodSecurityContext{

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -22,6 +22,7 @@ import (
 	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -47,9 +48,10 @@ const DefaultConnectorImage = defaultConnectorRepo + ":" + defaultConnectorTag
 // ConnectorResourceNames are the deterministic names of the resources the
 // connector sub-reconciler manages for a given CloudflareTunnel.
 type ConnectorResourceNames struct {
-	Deployment     string
-	ConfigMap      string
-	ServiceAccount string
+	Deployment          string
+	ConfigMap           string
+	ServiceAccount      string
+	PodDisruptionBudget string
 }
 
 // ConnectorNames returns the deterministic resource names for tun.
@@ -64,9 +66,10 @@ func ConnectorNames(tun *cloudflarev1alpha1.CloudflareTunnel) ConnectorResourceN
 		base = tun.Spec.Connector.NameOverride
 	}
 	return ConnectorResourceNames{
-		Deployment:     base,
-		ConfigMap:      base + "-config",
-		ServiceAccount: base,
+		Deployment:          base,
+		ConfigMap:           base + "-config",
+		ServiceAccount:      base,
+		PodDisruptionBudget: base + "-pdb",
 	}
 }
 
@@ -145,6 +148,41 @@ func BuildConnectorConfigMap(tun *cloudflarev1alpha1.CloudflareTunnel, renderedC
 		},
 		Data: map[string]string{
 			"config.yaml": string(renderedConfig),
+		},
+	}
+}
+
+// BuildConnectorPodDisruptionBudget returns the PDB that protects the
+// cloudflared connector deployment from voluntary disruption (node drain,
+// autoscaler scale-down, manual evict).
+//
+// Returns nil when:
+//   - tun.Spec.Connector is unset (connector disabled), or
+//   - replicas < 2.
+//
+// At replicas == 1 a minAvailable:1 PDB blocks all voluntary disruptions
+// (strictly worse than no PDB) and maxUnavailable:1 permits all evictions
+// (no protection). Skipping the PDB entirely is the correct call. The
+// reconciler treats nil as "ensure absent" so transitions from replicas:2
+// to replicas:1 cleanly delete the PDB.
+func BuildConnectorPodDisruptionBudget(tun *cloudflarev1alpha1.CloudflareTunnel) *policyv1.PodDisruptionBudget {
+	if tun.Spec.Connector == nil || tun.Spec.Connector.Replicas < 2 {
+		return nil
+	}
+	n := ConnectorNames(tun)
+	minAvail := intstr.FromInt(1)
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            n.PodDisruptionBudget,
+			Namespace:       tun.Namespace,
+			Labels:          connectorLabels(tun),
+			OwnerReferences: connectorOwnerRef(tun),
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvail,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: connectorLabels(tun),
+			},
 		},
 	}
 }

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -574,6 +574,88 @@ func TestBuildConnectorPodDisruptionBudget_NameOverride(t *testing.T) {
 	}
 }
 
+// TestBuildConnectorDeployment_DefaultTSC_AppliedAtReplicas2 asserts the
+// default soft per-hostname topologySpreadConstraint is injected when the
+// user has not set spec.connector.affinity or spec.connector.topologySpreadConstraints.
+func TestBuildConnectorDeployment_DefaultTSC_AppliedAtReplicas2(t *testing.T) {
+	tun := tunnelFixture(true) // Replicas == 2, no affinity, no TSC
+	dep := BuildConnectorDeployment(tun, "h")
+	tsc := dep.Spec.Template.Spec.TopologySpreadConstraints
+	if len(tsc) != 1 {
+		t.Fatalf("expected 1 default TSC, got %d: %+v", len(tsc), tsc)
+	}
+	c := tsc[0]
+	if c.MaxSkew != 1 {
+		t.Errorf("MaxSkew = %d, want 1", c.MaxSkew)
+	}
+	if c.TopologyKey != "kubernetes.io/hostname" {
+		t.Errorf("TopologyKey = %q, want kubernetes.io/hostname", c.TopologyKey)
+	}
+	if c.WhenUnsatisfiable != corev1.ScheduleAnyway {
+		t.Errorf("WhenUnsatisfiable = %v, want ScheduleAnyway", c.WhenUnsatisfiable)
+	}
+	if c.LabelSelector == nil || !reflect.DeepEqual(c.LabelSelector.MatchLabels, connectorLabels(tun)) {
+		t.Errorf("LabelSelector.MatchLabels = %v, want %v", c.LabelSelector, connectorLabels(tun))
+	}
+}
+
+// TestBuildConnectorDeployment_DefaultTSC_NotAppliedAtReplicasOne asserts
+// no default TSC is injected at replicas==1 (TSC across one pod is meaningless).
+func TestBuildConnectorDeployment_DefaultTSC_NotAppliedAtReplicasOne(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector.Replicas = 1
+	dep := BuildConnectorDeployment(tun, "h")
+	if got := dep.Spec.Template.Spec.TopologySpreadConstraints; len(got) != 0 {
+		t.Errorf("expected no TSC at replicas==1, got %+v", got)
+	}
+}
+
+// TestBuildConnectorDeployment_DefaultTSC_RespectUserAffinity asserts the
+// default TSC is NOT injected when the user has set spec.connector.affinity.
+// Any user customization disables the default wholesale (least-surprise rule
+// from the design doc).
+func TestBuildConnectorDeployment_DefaultTSC_RespectUserAffinity(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key:      "node-role.kubernetes.io/worker",
+						Operator: corev1.NodeSelectorOpExists,
+					}},
+				}},
+			},
+		},
+	}
+	dep := BuildConnectorDeployment(tun, "h")
+	if got := dep.Spec.Template.Spec.TopologySpreadConstraints; len(got) != 0 {
+		t.Errorf("expected no default TSC when Affinity is set, got %+v", got)
+	}
+	// User Affinity must still flow through.
+	if dep.Spec.Template.Spec.Affinity == nil {
+		t.Error("user-supplied Affinity dropped from podSpec")
+	}
+}
+
+// TestBuildConnectorDeployment_DefaultTSC_RespectUserTSC asserts user-supplied
+// TopologySpreadConstraints land verbatim with no default appended.
+func TestBuildConnectorDeployment_DefaultTSC_RespectUserTSC(t *testing.T) {
+	tun := tunnelFixture(true)
+	userTSC := []corev1.TopologySpreadConstraint{{
+		MaxSkew:           2,
+		TopologyKey:       "topology.kubernetes.io/zone",
+		WhenUnsatisfiable: corev1.DoNotSchedule,
+		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+	}}
+	tun.Spec.Connector.TopologySpreadConstraints = userTSC
+	dep := BuildConnectorDeployment(tun, "h")
+	got := dep.Spec.Template.Spec.TopologySpreadConstraints
+	if !reflect.DeepEqual(got, userTSC) {
+		t.Errorf("user TSC altered: got %+v, want %+v", got, userTSC)
+	}
+}
+
 // TestBuildConnectorDeployment_ArgsExact pins the cloudflared Args. The
 // credentials path is in config.yaml (see Aggregate), so --credentials-file
 // must NOT appear in Args (#58 follow-up: single source of truth for

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -55,6 +55,9 @@ func TestConnectorNames(t *testing.T) {
 	if n.ServiceAccount != "home-connector" {
 		t.Errorf("ServiceAccount name = %q", n.ServiceAccount)
 	}
+	if n.PodDisruptionBudget != "home-connector-pdb" {
+		t.Errorf("PodDisruptionBudget name = %q, want %q", n.PodDisruptionBudget, "home-connector-pdb")
+	}
 }
 
 // TestConnectorNames_NameOverride verifies that spec.connector.nameOverride
@@ -534,6 +537,22 @@ func TestBuildConnectorPodDisruptionBudget_AtReplicasTwo(t *testing.T) {
 	wantSelector := connectorLabels(tun)
 	if !reflect.DeepEqual(pdb.Spec.Selector.MatchLabels, wantSelector) {
 		t.Errorf("Selector.MatchLabels = %v, want %v", pdb.Spec.Selector.MatchLabels, wantSelector)
+	}
+	wantLabels := map[string]string{
+		"app.kubernetes.io/name":       "cloudflared",
+		"app.kubernetes.io/instance":   tun.Name,
+		"app.kubernetes.io/managed-by": "cloudflare-operator",
+		"cloudflare.io/tunnel":         tun.Name,
+	}
+	gotLabels := pdb.Labels
+	// Pattern #6: assert total map length to catch label-bleed regressions.
+	if len(gotLabels) != len(wantLabels) {
+		t.Errorf("PDB labels count = %d, want %d: %v", len(gotLabels), len(wantLabels), gotLabels)
+	}
+	for k, v := range wantLabels {
+		if gotLabels[k] != v {
+			t.Errorf("label %q = %q, want %q", k, gotLabels[k], v)
+		}
 	}
 	if len(pdb.OwnerReferences) != 1 || pdb.OwnerReferences[0].UID != tun.UID {
 		t.Errorf("OwnerReferences missing tunnel ref: %+v", pdb.OwnerReferences)

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -488,6 +488,73 @@ func TestBuildConnectorDeployment_PartialResources_LimitsOnly(t *testing.T) {
 	}
 }
 
+// TestBuildConnectorPodDisruptionBudget_NilWhenReplicasOne asserts the build
+// function returns nil at replicas==1 so the reconciler treats this as
+// "ensure absent" — a minAvailable:1 PDB on a single-replica deployment
+// blocks all voluntary disruptions and is strictly worse than no PDB.
+func TestBuildConnectorPodDisruptionBudget_NilWhenReplicasOne(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector.Replicas = 1
+	if got := BuildConnectorPodDisruptionBudget(tun); got != nil {
+		t.Errorf("expected nil at replicas==1, got %+v", got)
+	}
+}
+
+// TestBuildConnectorPodDisruptionBudget_NilWhenConnectorNil covers the
+// defensive case where Spec.Connector is unset (connector disabled).
+func TestBuildConnectorPodDisruptionBudget_NilWhenConnectorNil(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector = nil
+	if got := BuildConnectorPodDisruptionBudget(tun); got != nil {
+		t.Errorf("expected nil when connector spec absent, got %+v", got)
+	}
+}
+
+// TestBuildConnectorPodDisruptionBudget_AtReplicasTwo locks the shape:
+// minAvailable=1, selector matches connector labels exactly, owner-ref to
+// the tunnel, name picks up the standard "<base>-pdb" suffix.
+func TestBuildConnectorPodDisruptionBudget_AtReplicasTwo(t *testing.T) {
+	tun := tunnelFixture(true) // Replicas == 2 in the fixture
+	pdb := BuildConnectorPodDisruptionBudget(tun)
+	if pdb == nil {
+		t.Fatal("expected non-nil PDB at replicas==2")
+	}
+	if pdb.Name != "home-connector-pdb" {
+		t.Errorf("Name = %q, want %q", pdb.Name, "home-connector-pdb")
+	}
+	if pdb.Namespace != tun.Namespace {
+		t.Errorf("Namespace = %q, want %q", pdb.Namespace, tun.Namespace)
+	}
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.IntValue() != 1 {
+		t.Errorf("MinAvailable = %v, want 1", pdb.Spec.MinAvailable)
+	}
+	if pdb.Spec.MaxUnavailable != nil {
+		t.Errorf("MaxUnavailable = %v, want nil (we set MinAvailable)", pdb.Spec.MaxUnavailable)
+	}
+	wantSelector := connectorLabels(tun)
+	if !reflect.DeepEqual(pdb.Spec.Selector.MatchLabels, wantSelector) {
+		t.Errorf("Selector.MatchLabels = %v, want %v", pdb.Spec.Selector.MatchLabels, wantSelector)
+	}
+	if len(pdb.OwnerReferences) != 1 || pdb.OwnerReferences[0].UID != tun.UID {
+		t.Errorf("OwnerReferences missing tunnel ref: %+v", pdb.OwnerReferences)
+	}
+}
+
+// TestBuildConnectorPodDisruptionBudget_NameOverride verifies that
+// spec.connector.nameOverride flows through to the PDB name (since
+// ConnectorNames.PodDisruptionBudget derives from the same base).
+func TestBuildConnectorPodDisruptionBudget_NameOverride(t *testing.T) {
+	tun := tunnelFixture(true)
+	tun.Spec.Connector.NameOverride = "cloudflared-prod"
+	pdb := BuildConnectorPodDisruptionBudget(tun)
+	if pdb == nil {
+		t.Fatal("expected non-nil PDB at replicas==2")
+	}
+	if pdb.Name != "cloudflared-prod-pdb" {
+		t.Errorf("Name = %q, want %q", pdb.Name, "cloudflared-prod-pdb")
+	}
+}
+
 // TestBuildConnectorDeployment_ArgsExact pins the cloudflared Args. The
 // credentials path is in config.yaml (see Aggregate), so --credentials-file
 // must NOT appear in Args (#58 follow-up: single source of truth for


### PR DESCRIPTION
## Summary

Adds safe-by-default disruption protection for both the operator-managed cloudflared connector pods and the cloudflare-operator's own pods at `replicas >= 2`. Closes #77 (deferred from #75).

When `replicas >= 2`:
- A `policy/v1 PodDisruptionBudget` with `minAvailable: 1` is created — protects against node drains, autoscaler scale-downs, and manual evictions.
- A soft per-hostname `topologySpreadConstraint` is injected (`maxSkew: 1`, `topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`) — replicas spread across nodes by default; soft semantics preserve scheduling on small clusters where `replicas > nodes`.

When `replicas: 1`: nothing changes. A `minAvailable: 1` PDB on a single-replica deployment blocks all voluntary disruptions (strictly worse than no PDB), and a TSC across one pod is meaningless.

**Override semantics** (identical at both layers): the default `topologySpreadConstraint` is suppressed if the user has set EITHER `affinity` OR `topologySpreadConstraints` — any user scheduling override disables the default wholesale, never merges.

## Two layers, same behavior

### Connector pods (per `CloudflareTunnel` CR)
- `BuildConnectorPodDisruptionBudget` synthesizes the PDB; nil at `replicas < 2`.
- `defaultTopologySpread` helper in `BuildConnectorDeployment` injects the TSC under the override rule above.
- `applyOwnedPDB` reconcile step mirrors `applyOwnedDeployment`'s retry-on-conflict idiom (re-fetches inside the retry closure) and refuses to adopt unowned PDBs (`ErrUnownedPDB`).
- `Owns(&policyv1.PodDisruptionBudget{})` registered for cache + watch.
- Kubebuilder RBAC marker for `policy/poddisruptionbudgets`; `config/rbac/role.yaml` regenerated via `make manifests`; chart RBAC synced.

### Operator pods (via Helm chart)
- `controller.podDisruptionBudget.enabled` (default `true`), `controller.topologySpreadConstraints` (default `[]`), `controller.affinity` (default `{}`) added to `chart/values.yaml`.
- Plumbed through the `bjw-s` app-template shim in `chart/templates/_values-controllers.tpl` onto the native `controllers.<name>.podDisruptionBudget` and `controllers.<name>.pod.{topologySpreadConstraints,affinity}` keys.
- Same `replicas > 1` gate; same override semantics.

## Tests

- 4 new unit tests for `BuildConnectorPodDisruptionBudget` (nil at replicas==1, nil when connector spec absent, full PDB shape pinned at replicas==2, name override propagates).
- 4 new unit tests for the default TSC injection (applied at replicas==2, suppressed at replicas==1, suppressed under user-set affinity, user TSC passes through verbatim).
- 5 new reconcile tests: `PDBCreated`, `PDBDeletedOnReplicasDowngrade`, `NoPDBAtReplicasOne`, `PDBIdempotentUpdate` (steady-state update path), `PDBOwnershipGuard` (`ErrUnownedPDB` is returned for unowned PDBs at the standard name).
- 4 helm-template smoke scenarios verified manually: `replicas=1`, `replicas=2-defaults`, `replicas=2-user-TSC`, `replicas=2-user-affinity`.

Reviewed in stages: per-task spec compliance + code quality reviews (with one fix-round each on T1 and T3 plus a final full-diff fix-round for two test-coverage gaps). Independent comprehensive review passed after the gap-fix.

## Test plan

- [x] `go vet ./...`, `go build ./...`, `go test ./...` all clean
- [x] `helm lint chart/` clean
- [x] `helm template chart/` renders correctly at `replicas=1`, `replicas=2`, `replicas=2 + user TSC`, `replicas=2 + user affinity`
- [x] RBAC parity: `config/rbac/role.yaml` and `chart/templates/_values-rbac.tpl` both list `policy/poddisruptionbudgets` with the seven verbs
- [ ] Apply against a live cluster: confirm PDB created at `replicas: 2`, deleted on downgrade to `replicas: 1`, and that `kubectl drain` against a connector node respects the PDB

## Closes
- #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)