### PR TITLE
feat: label-gated Secret cache filter and SecretNotLabeled disambiguation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 GOLANGCI_LINT_VERSION ?= v2.12.1
 ENVTEST_K8S_VERSION ?= 1.30.0
+SETUP_ENVTEST_VERSION ?= release-0.21
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -140,4 +141,4 @@ $(CUSTOM_GCL): .custom-gcl.yml $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet ## Run tests.
-	go test ./... -coverprofile cover.out
+test: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 .PHONY: lint
 lint: custom-gcl ## Run golangci-lint linter
@@ -115,10 +115,12 @@ $(LOCALBIN):
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 CUSTOM_GCL = $(LOCALBIN)/custom-gcl
+ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 GOLANGCI_LINT_VERSION ?= v2.12.1
+ENVTEST_K8S_VERSION ?= 1.30.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -134,3 +136,8 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 custom-gcl: golangci-lint $(CUSTOM_GCL) ## Build custom golangci-lint with module plugins.
 $(CUSTOM_GCL): .custom-gcl.yml $(LOCALBIN)
 	$(GOLANGCI_LINT) custom && mv custom-gcl $(CUSTOM_GCL)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ kubectl apply -f cloudflare-operator/crds/
 
 Check [`CHANGELOG.md`](CHANGELOG.md) for breaking changes before upgrading.
 
+### Stuck-deleting CRs
+
+If a CR is stuck deleting because the credentials Secret it references is missing or unlabeled, the operator's `Ready` condition will surface `Reason=SecretNotFound` or `Reason=SecretNotLabeled`. The `Condition.Message` no longer carries the manual-finalizer guidance for credential-load failures during delete (it does on remote-API delete failures); check the operator logs for `"Remove the finalizer manually to force deletion"`. To unstick, label the Secret (or set the chart's `secretCacheLabelSelector: ""` to disable the filter) so the credential load succeeds, then let the finalizer drain. As a last resort, `kubectl patch` to remove the finalizer manually.
+
 ## Uninstall
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -69,9 +69,15 @@ kubectl create secret generic cloudflare-api-token \
   --namespace cloudflare-operator \
   --from-literal=apiToken=<your-cloudflare-api-token> \
   --from-literal=accountID=<your-cloudflare-account-id>
+
+kubectl label secret cloudflare-api-token \
+  --namespace cloudflare-operator \
+  cloudflare.io/managed=true
 ```
 
 Every CR references this Secret via `secretRef.name`. Place the Secret in the same namespace as the CRs that use it. `accountID` is required for `CloudflareZone` and `CloudflareTunnel`; other CRs only read `apiToken`.
+
+The `cloudflare.io/managed=true` label is required: the operator's manager cache filters Secrets by this label so it only loads Secrets you've explicitly opted in. A Secret without the label produces `Ready=False` with `Reason=SecretNotLabeled` on any CR that references it. To stage a migration across many existing Secrets, set the chart value `secretCacheLabelSelector: ""` (or the env `SECRET_CACHE_LABEL_SELECTOR=""`) to disable the filter, label your Secrets, then restore the default. The operator-owned tunnel credentials Secret is auto-labeled.
 
 ### 3. Onboard your zone
 

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -63,6 +63,7 @@ const (
 	ReasonReconcileError    = "ReconcileError"
 	ReasonCloudflareError   = "CloudflareAPIError"
 	ReasonSecretNotFound    = "SecretNotFound"
+	ReasonSecretNotLabeled  = "SecretNotLabeled"
 	ReasonInvalidSpec       = "InvalidSpec"
 	ReasonRemoteGone        = "RemoteGone"
 	ReasonDeletingResource  = "DeletingResource"

--- a/chart/templates/_values-controllers.tpl
+++ b/chart/templates/_values-controllers.tpl
@@ -64,6 +64,7 @@ controllers:
           {{- if .Values.registry.txtWildcardReplacement }}
           TXT_WILDCARD_REPLACEMENT: {{ .Values.registry.txtWildcardReplacement | quote }}
           {{- end }}
+          SECRET_CACHE_LABEL_SELECTOR: {{ .Values.secretCacheLabelSelector | quote }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -94,6 +94,14 @@ registry:
   # config when migrating.
   txtWildcardReplacement: ""
 
+# -- Secret cache filter (security + memory).
+# Label selector applied to corev1.Secret in the manager cache. The
+# operator's tunnel credentials Secret is auto-labeled; user-supplied
+# credential Secrets MUST carry this label or the operator cannot read
+# them. Empty string disables the filter (caches every Secret in scope
+# of RBAC) — useful for staged migrations.
+secretCacheLabelSelector: "cloudflare.io/managed=true"
+
 # -- Metrics and monitoring configuration
 metrics:
   serviceMonitor:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,12 +26,17 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -101,8 +106,6 @@ func main() {
 		}
 		secretLabelSelectorParsed = parsed
 	}
-	_ = secretLabelSelectorParsed // Wired into the manager cache in Task 7.
-
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -111,6 +114,31 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b74fd608.io",
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				// Secret is the only type with a label filter; all others are
+				// enumerated explicitly so that any addition to the watched
+				// surface is a documented decision rather than an implicit default.
+				&corev1.Secret{}: {Label: secretLabelSelectorParsed},
+
+				// Owned / watched CRDs.
+				&cloudflarev1alpha1.CloudflareZone{}:       {},
+				&cloudflarev1alpha1.CloudflareDNSRecord{}:  {},
+				&cloudflarev1alpha1.CloudflareTunnel{}:     {},
+				&cloudflarev1alpha1.CloudflareTunnelRule{}: {},
+				&cloudflarev1alpha1.CloudflareZoneConfig{}: {},
+				&cloudflarev1alpha1.CloudflareRuleset{}:    {},
+
+				// Connector-owned core types and watched source types.
+				&corev1.Service{}:               {},
+				&corev1.ConfigMap{}:             {},
+				&corev1.ServiceAccount{}:        {},
+				&appsv1.Deployment{}:            {},
+				&policyv1.PodDisruptionBudget{}: {},
+				&gwv1.HTTPRoute{}:               {},
+				&gwv1.Gateway{}:                 {},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "Failed to start manager")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -72,12 +73,35 @@ func main() {
 		"Log level (debug, info, warn, error). Can also be set via LOG_LEVEL.")
 	flag.StringVar(&logFormat, "log-format", lookupEnvOrString("LOG_FORMAT", "json"),
 		"Log format (json, text). Can also be set via LOG_FORMAT.")
+
+	var secretCacheLabelSelector string
+	flag.StringVar(&secretCacheLabelSelector, "secret-cache-label-selector",
+		lookupEnvOrString("SECRET_CACHE_LABEL_SELECTOR", "cloudflare.io/managed=true"),
+		"Label selector applied to corev1.Secret in the manager cache. "+
+			"Empty string disables the filter (caches every Secret in scope of RBAC). "+
+			"Default: 'cloudflare.io/managed=true'. Override via --secret-cache-label-selector "+
+			"or SECRET_CACHE_LABEL_SELECTOR.")
 	flag.Parse()
 
 	slogLogger := setupLogger(logLevel, logFormat)
 	slog.SetDefault(slogLogger)
 	ctrl.SetLogger(logr.FromSlogHandler(slogLogger.Handler()))
 	klog.SetSlogLogger(slogLogger)
+
+	var secretLabelSelectorParsed labels.Selector
+	if secretCacheLabelSelector == "" {
+		secretLabelSelectorParsed = labels.Everything()
+		setupLog.Info("Secret cache filter disabled (SECRET_CACHE_LABEL_SELECTOR=\"\"); operator will cache every Secret in scope of RBAC")
+	} else {
+		parsed, err := labels.Parse(secretCacheLabelSelector)
+		if err != nil {
+			setupLog.Error(err, "invalid secret cache label selector",
+				"selector", secretCacheLabelSelector)
+			os.Exit(1)
+		}
+		secretLabelSelectorParsed = parsed
+	}
+	_ = secretLabelSelectorParsed // Wired into the manager cache in Task 7.
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,7 +93,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	clientFactory := cfclient.NewClientFactory(mgr.GetClient())
+	clientFactory := cfclient.NewClientFactory(mgr.GetClient(), mgr.GetAPIReader())
 	ipResolver := ipresolver.NewResolver()
 
 	// setupCtx is a background context used for startup-time API calls

--- a/internal/cloudflare/client.go
+++ b/internal/cloudflare/client.go
@@ -27,13 +27,22 @@ const (
 )
 
 // ClientFactory creates Cloudflare API clients from Kubernetes Secrets.
+//
+// k8sClient is the cached client used for steady-state Secret reads.
+// apiReader is the manager's uncached API reader, used only to
+// disambiguate the cache-miss path (label-filtered vs. truly missing).
+// In tests where the cache and API server are not distinguished,
+// the same reader may be passed for both fields.
 type ClientFactory struct {
 	k8sClient client.Client
+	apiReader client.Reader
 }
 
-// NewClientFactory creates a new ClientFactory.
-func NewClientFactory(k8sClient client.Client) *ClientFactory {
-	return &ClientFactory{k8sClient: k8sClient}
+// NewClientFactory creates a new ClientFactory. apiReader must be the
+// manager's non-caching API reader (mgr.GetAPIReader()) so the
+// disambiguation path bypasses the (label-filtered) cache.
+func NewClientFactory(k8sClient client.Client, apiReader client.Reader) *ClientFactory {
+	return &ClientFactory{k8sClient: k8sClient, apiReader: apiReader}
 }
 
 // Credentials holds the Cloudflare API token and, optionally, the Account ID

--- a/internal/cloudflare/client.go
+++ b/internal/cloudflare/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -63,15 +64,43 @@ func (f *ClientFactory) GetAPIToken(ctx context.Context, secretName, namespace s
 
 // GetCredentials reads the Cloudflare API token (required) and Account ID
 // (optional, empty string if not set) from a single Kubernetes Secret.
-// Controllers that need both call this to avoid two Secret reads.
+//
+// On cache miss (k8sClient returns IsNotFound), GetCredentials does a
+// single uncached read via apiReader to disambiguate:
+//   - apiReader also returns IsNotFound → the original cache error is
+//     returned (downstream surfaces ReasonSecretNotFound as today).
+//   - apiReader returns the Secret → the Secret exists in the API server
+//     but the cache filter has excluded it; ErrSecretNotLabeled is
+//     returned so reconcilers can surface the actionable
+//     ReasonSecretNotLabeled message.
+//   - apiReader returns any other error → that error is returned (rare,
+//     e.g. transient API server unavailability on the slow path).
+//
+// The fallback runs only on the cache-miss path. Steady-state credential
+// reads remain fully cached.
 func (f *ClientFactory) GetCredentials(ctx context.Context, secretName, namespace string) (Credentials, error) {
+	key := types.NamespacedName{Name: secretName, Namespace: namespace}
+
 	secret := &corev1.Secret{}
-	err := f.k8sClient.Get(ctx, types.NamespacedName{
-		Name:      secretName,
-		Namespace: namespace,
-	}, secret)
+	err := f.k8sClient.Get(ctx, key, secret)
 	if err != nil {
-		return Credentials{}, fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
+		if !apierrors.IsNotFound(err) {
+			return Credentials{}, fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
+		}
+		// Cache miss — disambiguate via the uncached API reader.
+		probe := &corev1.Secret{}
+		probeErr := f.apiReader.Get(ctx, key, probe)
+		switch {
+		case probeErr == nil:
+			// Secret exists in the API server but the cache filter excluded it.
+			return Credentials{}, fmt.Errorf("secret %s/%s: %w", namespace, secretName, ErrSecretNotLabeled)
+		case apierrors.IsNotFound(probeErr):
+			// Genuinely missing — surface the original cache error so
+			// callers' apierrors.IsNotFound checks continue to match.
+			return Credentials{}, fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
+		default:
+			return Credentials{}, fmt.Errorf("failed to get secret %s/%s via api reader: %w", namespace, secretName, probeErr)
+		}
 	}
 
 	token, ok := secret.Data[SecretKeyAPIToken]

--- a/internal/cloudflare/client.go
+++ b/internal/cloudflare/client.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,6 +12,13 @@ import (
 	cfgo "github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/option"
 )
+
+// ErrSecretNotLabeled is returned by GetCredentials when the referenced
+// Secret exists in the API server but is missing the
+// cloudflare.io/managed=true label, so the operator's cache filter has
+// excluded it. Distinct from a genuine NotFound — see GetCredentials.
+var ErrSecretNotLabeled = errors.New(
+	"secret exists but is not labeled cloudflare.io/managed=true")
 
 // Secret data keys where Cloudflare credentials are expected.
 const (

--- a/internal/cloudflare/client_test.go
+++ b/internal/cloudflare/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -93,5 +94,85 @@ func TestNewClientFactory_AcceptsAPIReader(t *testing.T) {
 	factory := NewClientFactory(cached, apiReader)
 	if factory == nil {
 		t.Fatal("expected non-nil factory")
+	}
+}
+
+func TestGetCredentials_UnlabeledSecret_ReturnsErrSecretNotLabeled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	// Cached client: empty (simulates the label-filtered cache excluding the Secret).
+	cached := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// API reader: has the Secret, with the API token but no managed label.
+	unlabeled := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cf-token",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"apiToken": []byte("test-token"),
+		},
+	}
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unlabeled).Build()
+
+	factory := NewClientFactory(cached, apiReader)
+	_, err := factory.GetCredentials(context.Background(), "cf-token", "default")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrSecretNotLabeled) {
+		t.Fatalf("expected ErrSecretNotLabeled, got %v", err)
+	}
+}
+
+func TestGetCredentials_BothMiss_ReturnsNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	cached := fake.NewClientBuilder().WithScheme(scheme).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	factory := NewClientFactory(cached, apiReader)
+	_, err := factory.GetCredentials(context.Background(), "missing", "default")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrSecretNotLabeled) {
+		t.Fatalf("expected NotFound-flavored error, got ErrSecretNotLabeled")
+	}
+	if !apierrors.IsNotFound(err) {
+		// The wrapped error must satisfy IsNotFound for downstream callers
+		// (existing ReasonSecretNotFound path).
+		t.Fatalf("expected IsNotFound to match, got %v", err)
+	}
+}
+
+func TestGetCredentials_CacheHit_DoesNotCallAPIReader(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	labeled := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cf-token",
+			Namespace: "default",
+			Labels:    map[string]string{"cloudflare.io/managed": "true"},
+		},
+		Data: map[string][]byte{
+			"apiToken": []byte("steady-state-token"),
+		},
+	}
+	cached := fake.NewClientBuilder().WithScheme(scheme).WithObjects(labeled).Build()
+	// API reader empty: if the helper accidentally calls it on the steady-state
+	// path, it would return a misleading NotFound and the test would fail.
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	factory := NewClientFactory(cached, apiReader)
+	creds, err := factory.GetCredentials(context.Background(), "cf-token", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.APIToken != "steady-state-token" {
+		t.Errorf("expected steady-state-token, got %s", creds.APIToken)
 	}
 }

--- a/internal/cloudflare/client_test.go
+++ b/internal/cloudflare/client_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -27,7 +28,7 @@ func TestGetAPIToken_Success(t *testing.T) {
 	}
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
-	factory := NewClientFactory(k8sClient)
+	factory := NewClientFactory(k8sClient, k8sClient)
 
 	token, err := factory.GetAPIToken(context.Background(), "cf-token", "default")
 	if err != nil {
@@ -43,7 +44,7 @@ func TestGetAPIToken_SecretNotFound(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	factory := NewClientFactory(k8sClient)
+	factory := NewClientFactory(k8sClient, k8sClient)
 
 	_, err := factory.GetAPIToken(context.Background(), "missing", "default")
 	if err == nil {
@@ -66,7 +67,7 @@ func TestGetAPIToken_MissingKey(t *testing.T) {
 	}
 
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
-	factory := NewClientFactory(k8sClient)
+	factory := NewClientFactory(k8sClient, k8sClient)
 
 	_, err := factory.GetAPIToken(context.Background(), "cf-token", "default")
 	if err == nil {
@@ -78,5 +79,19 @@ func TestErrSecretNotLabeled_IsSentinel(t *testing.T) {
 	wrapped := fmt.Errorf("loading credentials: %w", ErrSecretNotLabeled)
 	if !errors.Is(wrapped, ErrSecretNotLabeled) {
 		t.Fatalf("errors.Is should match wrapped sentinel; got false")
+	}
+}
+
+func TestNewClientFactory_AcceptsAPIReader(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	cached := fake.NewClientBuilder().WithScheme(scheme).Build()
+	// API reader is conventionally a separate non-caching reader; the fake
+	// client implements client.Reader so we reuse it here for type-fit only.
+	var apiReader client.Reader = cached
+
+	factory := NewClientFactory(cached, apiReader)
+	if factory == nil {
+		t.Fatal("expected non-nil factory")
 	}
 }

--- a/internal/cloudflare/client_test.go
+++ b/internal/cloudflare/client_test.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -69,5 +71,12 @@ func TestGetAPIToken_MissingKey(t *testing.T) {
 	_, err := factory.GetAPIToken(context.Background(), "cf-token", "default")
 	if err == nil {
 		t.Error("expected error for missing apiToken key")
+	}
+}
+
+func TestErrSecretNotLabeled_IsSentinel(t *testing.T) {
+	wrapped := fmt.Errorf("loading credentials: %w", ErrSecretNotLabeled)
+	if !errors.Is(wrapped, ErrSecretNotLabeled) {
+		t.Fatalf("errors.Is should match wrapped sentinel; got false")
 	}
 }

--- a/internal/controller/cloudflarednsrecord_controller.go
+++ b/internal/controller/cloudflarednsrecord_controller.go
@@ -108,7 +108,7 @@ type CloudflareDNSRecordReconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
 	Recorder      record.EventRecorder
-	ClientFactory *cfclient.ClientFactory
+	ClientFactory CredentialFactory
 	IPResolver    *ipresolver.Resolver
 	DNSClientFn   func(apiToken string) cfclient.DNSClient
 	// Registry holds optional TXT-registry configuration. The zero value
@@ -170,12 +170,19 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	// 4. Get API token
 	secretNs := secretRefNamespace(dnsRecord.Spec.SecretRef, dnsRecord.Namespace)
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, dnsRecord.Spec.SecretRef.Name, secretNs)
-	if err != nil {
-		logger.Error(err, "failed to get API token")
-		return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+	creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+		dnsRecord.Spec.SecretRef.Name, secretNs,
+		r.Recorder, &dnsRecord, &dnsRecord.Status.Conditions, 30*time.Second)
+	if halt != nil {
+		if err == nil {
+			logger.V(1).Info("credential load failed; halting reconcile",
+				"secret", dnsRecord.Spec.SecretRef.Name, "namespace", secretNs)
+		} else {
+			logger.Error(err, "credential load failed")
+		}
+		return *halt, err
 	}
+	apiToken := creds.APIToken
 
 	// 5. Reconcile the DNS record
 	result, err := r.reconcileRecord(ctx, &dnsRecord, r.dnsClient(apiToken), resolvedZoneID)
@@ -391,12 +398,19 @@ func (r *CloudflareDNSRecordReconciler) reconcileDelete(ctx context.Context, dns
 		}
 
 		secretNs := secretRefNamespace(dnsRecord.Spec.SecretRef, dnsRecord.Namespace)
-		apiToken, err := r.ClientFactory.GetAPIToken(ctx, dnsRecord.Spec.SecretRef.Name, secretNs)
-		if err != nil {
-			logger.Error(err, "failed to get API token during deletion, will retry; remove the finalizer manually to force deletion")
-			return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,
-				cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
+		creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+			dnsRecord.Spec.SecretRef.Name, secretNs,
+			r.Recorder, dnsRecord, &dnsRecord.Status.Conditions, 30*time.Second)
+		if halt != nil {
+			if err == nil {
+				logger.V(1).Info("credential load failed during deletion; halting reconcile; remove the finalizer manually to force deletion",
+					"secret", dnsRecord.Spec.SecretRef.Name, "namespace", secretNs)
+			} else {
+				logger.Error(err, "credential load failed during deletion, will retry; remove the finalizer manually to force deletion")
+			}
+			return *halt, err
 		}
+		apiToken := creds.APIToken
 
 		if err := r.dnsClient(apiToken).DeleteRecord(ctx, resolvedZoneID, dnsRecord.Status.RecordID); err != nil {
 			if cfclient.IsNotFound(err) {

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -192,7 +192,7 @@ func buildReconciler(s *runtime.Scheme, mock *mockDNSClient, objs ...client.Obje
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		DNSClientFn: func(_ string) cfclient.DNSClient {
 			return mock
 		},
@@ -831,7 +831,7 @@ func buildReconcilerWithRegistry(s *runtime.Scheme, dnsClient cfclient.DNSClient
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		Registry:      reg,
 		DNSClientFn: func(_ string) cfclient.DNSClient {
 			return dnsClient
@@ -1922,7 +1922,7 @@ func TestCloudflareDNSRecordReconciler_BadRequest_EmitsInvalidSpecEvent(t *testi
 		Client:        fakeClient,
 		Scheme:        scheme,
 		Recorder:      fakeRec,
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		DNSClientFn: func(_ string) cfclient.DNSClient {
 			return mock
 		},

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -424,6 +424,59 @@ func TestReconcile_SecretNotFound(t *testing.T) {
 	}
 }
 
+// TestReconcile_SecretNotLabeled verifies that a credentials Secret which
+// exists in the API server but lacks the cloudflare.io/managed=true label
+// surfaces ReasonSecretNotLabeled (not the legacy ReasonSecretNotFound) on
+// the Ready condition and emits a recorder event with actionable guidance.
+func TestReconcile_SecretNotLabeled(t *testing.T) {
+	s := testScheme(t)
+	dnsRecord := newTestDNSRecord("test-rec", "default")
+	dnsRecord.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	mock := newMockDNSClient()
+
+	r := buildReconciler(s, mock, dnsRecord)
+	// Replace the real factory with a stub that signals SecretNotLabeled.
+	rec := record.NewFakeRecorder(8)
+	r.Recorder = rec
+	r.ClientFactory = &fakeCredFactory{err: cfclient.ErrSecretNotLabeled}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-rec", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected RequeueAfter=30s, got %v", result.RequeueAfter)
+	}
+
+	// Re-fetch via the client to confirm Status().Update round-tripped.
+	var got cloudflarev1alpha1.CloudflareDNSRecord
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-rec", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get updated record: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if cond.Reason != cloudflarev1alpha1.ReasonSecretNotLabeled {
+		t.Errorf("expected reason=%s, got %s", cloudflarev1alpha1.ReasonSecretNotLabeled, cond.Reason)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected Ready=False, got %s", cond.Status)
+	}
+
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, cloudflarev1alpha1.ReasonSecretNotLabeled) {
+			t.Errorf("expected event mentioning %s, got %q", cloudflarev1alpha1.ReasonSecretNotLabeled, ev)
+		}
+	default:
+		t.Error("expected at least one recorder event for SecretNotLabeled")
+	}
+}
+
 // TestReconcile_SecretRefCrossNamespace is a regression test for issue #70.
 // When the CloudflareDNSRecord lives in one namespace ("apps") but the
 // credentials Secret lives in another ("zones") — typical when an HTTPRoute or

--- a/internal/controller/cloudflareruleset_controller.go
+++ b/internal/controller/cloudflareruleset_controller.go
@@ -44,7 +44,7 @@ type CloudflareRulesetReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	Recorder        record.EventRecorder
-	ClientFactory   *cfclient.ClientFactory
+	ClientFactory   CredentialFactory
 	RulesetClientFn func(apiToken string) cfclient.RulesetClient
 }
 
@@ -102,12 +102,19 @@ func (r *CloudflareRulesetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// 4. Get API token
 	secretNs := secretRefNamespace(ruleset.Spec.SecretRef, ruleset.Namespace)
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, ruleset.Spec.SecretRef.Name, secretNs)
-	if err != nil {
-		logger.Error(err, "failed to get API token")
-		return failReconcile(ctx, r.Client, &ruleset, &ruleset.Status.Conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+	creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+		ruleset.Spec.SecretRef.Name, secretNs,
+		r.Recorder, &ruleset, &ruleset.Status.Conditions, 30*time.Second)
+	if halt != nil {
+		if err == nil {
+			logger.V(1).Info("credential load failed; halting reconcile",
+				"secret", ruleset.Spec.SecretRef.Name, "namespace", secretNs)
+		} else {
+			logger.Error(err, "credential load failed")
+		}
+		return *halt, err
 	}
+	apiToken := creds.APIToken
 
 	// 5. Reconcile the ruleset
 	result, err := r.reconcileRuleset(ctx, &ruleset, r.rulesetClient(apiToken), resolvedZoneID)

--- a/internal/controller/cloudflareruleset_controller_test.go
+++ b/internal/controller/cloudflareruleset_controller_test.go
@@ -148,7 +148,7 @@ func buildRulesetReconciler(mock *mockRulesetClient, objs ...client.Object) *Clo
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		RulesetClientFn: func(_ string) cfclient.RulesetClient {
 			return mock
 		},
@@ -439,7 +439,7 @@ func TestRulesetReconcile_ZoneRefResolvesFromCloudflareZone(t *testing.T) {
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		RulesetClientFn: func(_ string) cfclient.RulesetClient {
 			return mock
 		},
@@ -528,7 +528,7 @@ func TestRulesetReconcile_ZoneRefNotReady(t *testing.T) {
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		RulesetClientFn: func(_ string) cfclient.RulesetClient {
 			return mock
 		},
@@ -761,7 +761,7 @@ func TestRulesetReconcile_BadRequest_EmitsInvalidSpecEvent(t *testing.T) {
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      fakeRec,
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		RulesetClientFn: func(_ string) cfclient.RulesetClient {
 			return mock
 		},

--- a/internal/controller/cloudflareruleset_controller_test.go
+++ b/internal/controller/cloudflareruleset_controller_test.go
@@ -384,6 +384,56 @@ func TestRulesetReconcile_SecretNotFound(t *testing.T) {
 	}
 }
 
+// TestRulesetReconcile_SecretNotLabeled verifies that a credentials Secret
+// existing in the API server but lacking the cloudflare.io/managed=true
+// label surfaces ReasonSecretNotLabeled (not SecretNotFound) and emits a
+// recorder event with actionable guidance.
+func TestRulesetReconcile_SecretNotLabeled(t *testing.T) {
+	ruleset := newTestRuleset("test-ruleset", "default")
+	ruleset.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	mock := newMockRulesetClient()
+
+	r := buildRulesetReconciler(mock, ruleset)
+	rec := record.NewFakeRecorder(8)
+	r.Recorder = rec
+	r.ClientFactory = &fakeCredFactory{err: cfclient.ErrSecretNotLabeled}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ruleset", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected RequeueAfter=30s, got %v", result.RequeueAfter)
+	}
+
+	var got cloudflarev1alpha1.CloudflareRuleset
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-ruleset", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get updated ruleset: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if cond.Reason != cloudflarev1alpha1.ReasonSecretNotLabeled {
+		t.Errorf("expected reason=%s, got %s", cloudflarev1alpha1.ReasonSecretNotLabeled, cond.Reason)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected Ready=False, got %s", cond.Status)
+	}
+
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, cloudflarev1alpha1.ReasonSecretNotLabeled) {
+			t.Errorf("expected event mentioning %s, got %q", cloudflarev1alpha1.ReasonSecretNotLabeled, ev)
+		}
+	default:
+		t.Error("expected at least one recorder event for SecretNotLabeled")
+	}
+}
+
 func TestRulesetReconcile_ZoneRefResolvesFromCloudflareZone(t *testing.T) {
 	s := testScheme(t)
 	mock := newMockRulesetClient()

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -1088,6 +1088,7 @@ func TestCloudflareTunnel_PDBCreated(t *testing.T) {
 		"app.kubernetes.io/instance":   tun.Name,
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         tun.Name,
+		"cloudflare.io/managed":        "true",
 	}
 	if pdb.Spec.Selector == nil {
 		t.Fatal("PDB Spec.Selector is nil")
@@ -1187,12 +1188,13 @@ func TestCloudflareTunnel_PDBIdempotentUpdate(t *testing.T) {
 		t.Errorf("MinAvailable = %v, want 1", pdb.Spec.MinAvailable)
 	}
 
-	// Selector.MatchLabels must match the canonical four connectorLabels.
+	// Selector.MatchLabels must match the canonical five connectorLabels.
 	wantSelectorLabels := map[string]string{
 		"app.kubernetes.io/name":       "cloudflared",
 		"app.kubernetes.io/instance":   tun.Name,
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         tun.Name,
+		"cloudflare.io/managed":        "true",
 	}
 	if pdb.Spec.Selector == nil {
 		t.Fatal("PDB Spec.Selector is nil after update")

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -1083,12 +1083,15 @@ func TestCloudflareTunnel_PDBCreated(t *testing.T) {
 	if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
 		t.Errorf("OwnerReferences[0].BlockOwnerDeletion = %v, want true", ref.BlockOwnerDeletion)
 	}
+	// Selectors must NOT include cloudflare.io/managed=true: Deployment and PDB
+	// Spec.Selector are immutable on apps/v1 / policy/v1, so the selector set
+	// is fixed at the original four keys. Pod-template labels carry the full
+	// connectorLabels superset.
 	wantSelectorLabels := map[string]string{
 		"app.kubernetes.io/name":       "cloudflared",
 		"app.kubernetes.io/instance":   tun.Name,
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         tun.Name,
-		"cloudflare.io/managed":        "true",
 	}
 	if pdb.Spec.Selector == nil {
 		t.Fatal("PDB Spec.Selector is nil")
@@ -1189,12 +1192,15 @@ func TestCloudflareTunnel_PDBIdempotentUpdate(t *testing.T) {
 	}
 
 	// Selector.MatchLabels must match the canonical five connectorLabels.
+	// Selectors must NOT include cloudflare.io/managed=true: Deployment and PDB
+	// Spec.Selector are immutable on apps/v1 / policy/v1, so the selector set
+	// is fixed at the original four keys. Pod-template labels carry the full
+	// connectorLabels superset.
 	wantSelectorLabels := map[string]string{
 		"app.kubernetes.io/name":       "cloudflared",
 		"app.kubernetes.io/instance":   tun.Name,
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         tun.Name,
-		"cloudflare.io/managed":        "true",
 	}
 	if pdb.Spec.Selector == nil {
 		t.Fatal("PDB Spec.Selector is nil after update")

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -268,6 +268,12 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context
 		if err := controllerutil.SetControllerReference(tunnel, credSecret, r.Scheme); err != nil {
 			return err
 		}
+		if credSecret.Labels == nil {
+			credSecret.Labels = map[string]string{}
+		}
+		for k, v := range connectorLabels(tunnel) {
+			credSecret.Labels[k] = v
+		}
 		if credSecret.Data == nil {
 			credSecret.Data = make(map[string][]byte)
 		}

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -49,7 +49,7 @@ type CloudflareTunnelReconciler struct {
 	client.Client
 	Scheme         *runtime.Scheme
 	Recorder       record.EventRecorder
-	ClientFactory  *cfclient.ClientFactory
+	ClientFactory  CredentialFactory
 	TunnelClientFn func(apiToken string) cfclient.TunnelClient
 }
 
@@ -102,11 +102,17 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// 4. Get Cloudflare credentials (API token + Account ID)
 	secretNs := secretRefNamespace(tunnel.Spec.SecretRef, tunnel.Namespace)
-	creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, secretNs)
-	if err != nil {
-		logger.Error(err, "failed to get credentials")
-		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+	creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+		tunnel.Spec.SecretRef.Name, secretNs,
+		r.Recorder, &tunnel, &tunnel.Status.Conditions, 30*time.Second)
+	if halt != nil {
+		if err == nil {
+			logger.V(1).Info("credential load failed; halting reconcile",
+				"secret", tunnel.Spec.SecretRef.Name, "namespace", secretNs)
+		} else {
+			logger.Error(err, "credential load failed")
+		}
+		return *halt, err
 	}
 	if creds.AccountID == "" {
 		err := fmt.Errorf("secret %s/%s does not contain %q key",
@@ -336,11 +342,17 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 
 	if tunnel.Status.TunnelID != "" {
 		secretNs := secretRefNamespace(tunnel.Spec.SecretRef, tunnel.Namespace)
-		creds, err := r.ClientFactory.GetCredentials(ctx, tunnel.Spec.SecretRef.Name, secretNs)
-		if err != nil {
-			logger.Error(err, "failed to get credentials during deletion, will retry; remove the finalizer manually to force deletion")
-			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
-				cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
+		creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+			tunnel.Spec.SecretRef.Name, secretNs,
+			r.Recorder, tunnel, &tunnel.Status.Conditions, 30*time.Second)
+		if halt != nil {
+			if err == nil {
+				logger.V(1).Info("credential load failed during deletion; halting reconcile; remove the finalizer manually to force deletion",
+					"secret", tunnel.Spec.SecretRef.Name, "namespace", secretNs)
+			} else {
+				logger.Error(err, "credential load failed during deletion, will retry; remove the finalizer manually to force deletion")
+			}
+			return *halt, err
 		}
 		if creds.AccountID == "" {
 			err := fmt.Errorf("secret %s/%s does not contain %q key",

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -389,6 +389,56 @@ func TestTunnelReconcile_SecretNotFound(t *testing.T) {
 	}
 }
 
+// TestTunnelReconcile_SecretNotLabeled verifies that a credentials Secret
+// existing in the API server but lacking the cloudflare.io/managed=true
+// label surfaces ReasonSecretNotLabeled (not SecretNotFound) and emits a
+// recorder event.
+func TestTunnelReconcile_SecretNotLabeled(t *testing.T) {
+	tunnel := newTestTunnel("test-tunnel", "default")
+	tunnel.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	mock := newMockTunnelClient()
+
+	r := buildTunnelReconciler(t, mock, tunnel)
+	rec := record.NewFakeRecorder(8)
+	r.Recorder = rec
+	r.ClientFactory = &fakeCredFactory{err: cfclient.ErrSecretNotLabeled}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-tunnel", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected RequeueAfter=30s, got %v", result.RequeueAfter)
+	}
+
+	var got cloudflarev1alpha1.CloudflareTunnel
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-tunnel", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get updated tunnel: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if cond.Reason != cloudflarev1alpha1.ReasonSecretNotLabeled {
+		t.Errorf("expected reason=%s, got %s", cloudflarev1alpha1.ReasonSecretNotLabeled, cond.Reason)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected Ready=False, got %s", cond.Status)
+	}
+
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, cloudflarev1alpha1.ReasonSecretNotLabeled) {
+			t.Errorf("expected event mentioning %s, got %q", cloudflarev1alpha1.ReasonSecretNotLabeled, ev)
+		}
+	default:
+		t.Error("expected at least one recorder event for SecretNotLabeled")
+	}
+}
+
 // buildInterceptedTunnelReconciler is the same as buildTunnelReconciler
 // but wraps the fake client with the given interceptor.Funcs so individual
 // API calls can be intercepted (e.g. to inject conflict storms).

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -691,6 +691,64 @@ func TestEnsureCredentialsSecret_AppliesManagedLabel(t *testing.T) {
 	}
 }
 
+// TestEnsureCredentialsSecret_PreservesExternalLabels locks in the merge-form
+// contract: an external label applied to the credentials Secret (e.g. by a
+// platform GitOps tool) must coexist with the operator-managed keys after a
+// reconcile. A wholesale Labels-map replacement would regress this.
+func TestEnsureCredentialsSecret_PreservesExternalLabels(t *testing.T) {
+	s := testScheme(t)
+
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			GeneratedSecretName: "demo-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{TunnelID: "tid-1"},
+	}
+
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-creds",
+			Namespace: "default",
+			Labels: map[string]string{
+				"team":                  "infra",
+				"cloudflare.io/managed": "false", // operator must overwrite this
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun, preExisting).Build()
+	r := &CloudflareTunnelReconciler{
+		Client:   c,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	if err := r.ensureCredentialsSecret(context.Background(), tun, "acct-1", "tunnel-secret"); err != nil {
+		t.Fatalf("ensureCredentialsSecret: %v", err)
+	}
+
+	var got corev1.Secret
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Name: "demo-creds", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+
+	if v := got.Labels["team"]; v != "infra" {
+		t.Errorf("external label team=infra clobbered, got %q", v)
+	}
+	if v := got.Labels["cloudflare.io/managed"]; v != "true" {
+		t.Errorf("operator key cloudflare.io/managed should overwrite external value, got %q", v)
+	}
+	if v := got.Labels["app.kubernetes.io/managed-by"]; v != "cloudflare-operator" {
+		t.Errorf("operator key app.kubernetes.io/managed-by missing, got %q", v)
+	}
+}
+
 // TestCloudflareTunnelReconciler_DeleteTunnelNotFound_RemovesFinalizer mirrors
 // TestZoneReconcile_DeleteZoneNotFound_RemovesFinalizer. When DeleteTunnel
 // returns 404 the operator must treat it as success (the remote object is gone,

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -651,6 +651,46 @@ func TestCloudflareTunnelReconciler_BadRequest_EmitsInvalidSpecEvent(t *testing.
 	}
 }
 
+func TestEnsureCredentialsSecret_AppliesManagedLabel(t *testing.T) {
+	s := testScheme(t)
+
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			GeneratedSecretName: "demo-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{TunnelID: "tid-1"},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun).Build()
+	r := &CloudflareTunnelReconciler{
+		Client:   c,
+		Scheme:   s,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	if err := r.ensureCredentialsSecret(context.Background(), tun, "acct-1", "tunnel-secret"); err != nil {
+		t.Fatalf("ensureCredentialsSecret: %v", err)
+	}
+
+	var got corev1.Secret
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Name: "demo-creds", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if v, ok := got.Labels["cloudflare.io/managed"]; !ok || v != "true" {
+		t.Errorf(`expected cloudflare.io/managed=true on secret, got %q (present=%v)`, v, ok)
+	}
+	if got.Labels["app.kubernetes.io/managed-by"] != "cloudflare-operator" {
+		t.Errorf("expected app.kubernetes.io/managed-by=cloudflare-operator, got %q",
+			got.Labels["app.kubernetes.io/managed-by"])
+	}
+}
+
 // TestCloudflareTunnelReconciler_DeleteTunnelNotFound_RemovesFinalizer mirrors
 // TestZoneReconcile_DeleteZoneNotFound_RemovesFinalizer. When DeleteTunnel
 // returns 404 the operator must treat it as success (the remote object is gone,

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -136,7 +136,7 @@ func buildTunnelReconciler(t *testing.T, mock *mockTunnelClient, objs ...client.
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		TunnelClientFn: func(_ string) cfclient.TunnelClient {
 			return mock
 		},
@@ -414,7 +414,7 @@ func buildInterceptedTunnelReconciler(t *testing.T, mock *mockTunnelClient, func
 		Client:         wrapped,
 		Scheme:         s,
 		Recorder:       record.NewFakeRecorder(10),
-		ClientFactory:  cfclient.NewClientFactory(wrapped),
+		ClientFactory:  cfclient.NewClientFactory(wrapped, wrapped),
 		TunnelClientFn: func(_ string) cfclient.TunnelClient { return mock },
 	}
 }
@@ -623,7 +623,7 @@ func TestCloudflareTunnelReconciler_BadRequest_EmitsInvalidSpecEvent(t *testing.
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      fakeRec,
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		TunnelClientFn: func(_ string) cfclient.TunnelClient {
 			return mock
 		},

--- a/internal/controller/cloudflarezone_controller.go
+++ b/internal/controller/cloudflarezone_controller.go
@@ -44,7 +44,7 @@ type CloudflareZoneReconciler struct {
 	client.Client
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
-	ClientFactory         *cfclient.ClientFactory
+	ClientFactory         CredentialFactory
 	ZoneLifecycleClientFn func(apiToken string) cfclient.ZoneLifecycleClient
 }
 
@@ -86,11 +86,17 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// 4. Get Cloudflare credentials (API token + Account ID)
 	secretNs := secretRefNamespace(zone.Spec.SecretRef, zone.Namespace)
-	creds, err := r.ClientFactory.GetCredentials(ctx, zone.Spec.SecretRef.Name, secretNs)
-	if err != nil {
-		logger.Error(err, "failed to get credentials")
-		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+	creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+		zone.Spec.SecretRef.Name, secretNs,
+		r.Recorder, &zone, &zone.Status.Conditions, 30*time.Second)
+	if halt != nil {
+		if err == nil {
+			logger.V(1).Info("credential load failed; halting reconcile",
+				"secret", zone.Spec.SecretRef.Name, "namespace", secretNs)
+		} else {
+			logger.Error(err, "credential load failed")
+		}
+		return *halt, err
 	}
 	if creds.AccountID == "" {
 		err := fmt.Errorf("secret %s/%s does not contain %q key",
@@ -254,12 +260,19 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 
 	if zone.Spec.DeletionPolicy == cloudflarev1alpha1.DeletionPolicyDelete && zone.Status.ZoneID != "" {
 		secretNs := secretRefNamespace(zone.Spec.SecretRef, zone.Namespace)
-		apiToken, err := r.ClientFactory.GetAPIToken(ctx, zone.Spec.SecretRef.Name, secretNs)
-		if err != nil {
-			logger.Error(err, "failed to get API token during deletion, will retry; remove the finalizer manually to force deletion")
-			return failReconcile(ctx, r.Client, zone, &zone.Status.Conditions,
-				cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
+		creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+			zone.Spec.SecretRef.Name, secretNs,
+			r.Recorder, zone, &zone.Status.Conditions, 30*time.Second)
+		if halt != nil {
+			if err == nil {
+				logger.V(1).Info("credential load failed during deletion; halting reconcile; remove the finalizer manually to force deletion",
+					"secret", zone.Spec.SecretRef.Name, "namespace", secretNs)
+			} else {
+				logger.Error(err, "credential load failed during deletion, will retry; remove the finalizer manually to force deletion")
+			}
+			return *halt, err
 		}
+		apiToken := creds.APIToken
 
 		status.SetReady(&zone.Status.Conditions, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonDeletingResource, "Deleting zone from Cloudflare", zone.Generation)

--- a/internal/controller/cloudflarezone_controller_test.go
+++ b/internal/controller/cloudflarezone_controller_test.go
@@ -474,6 +474,56 @@ func TestZoneReconcile_SecretNotFound(t *testing.T) {
 	t.Error("expected Ready condition with SecretNotFound reason")
 }
 
+// TestZoneReconcile_SecretNotLabeled verifies that a credentials Secret
+// existing in the API server but lacking the cloudflare.io/managed=true
+// label surfaces ReasonSecretNotLabeled (not SecretNotFound) and emits a
+// recorder event.
+func TestZoneReconcile_SecretNotLabeled(t *testing.T) {
+	zone := newTestCloudflareZone("test-zone", "default")
+	zone.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	mock := newMockZoneLifecycleClient()
+
+	r := buildZoneReconciler(mock, zone)
+	rec := record.NewFakeRecorder(8)
+	r.Recorder = rec
+	r.ClientFactory = &fakeCredFactory{err: cfclient.ErrSecretNotLabeled}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected RequeueAfter=30s, got %v", result.RequeueAfter)
+	}
+
+	var got cloudflarev1alpha1.CloudflareZone
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get updated zone: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if cond.Reason != cloudflarev1alpha1.ReasonSecretNotLabeled {
+		t.Errorf("expected reason=%s, got %s", cloudflarev1alpha1.ReasonSecretNotLabeled, cond.Reason)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected Ready=False, got %s", cond.Status)
+	}
+
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, cloudflarev1alpha1.ReasonSecretNotLabeled) {
+			t.Errorf("expected event mentioning %s, got %q", cloudflarev1alpha1.ReasonSecretNotLabeled, ev)
+		}
+	default:
+		t.Error("expected at least one recorder event for SecretNotLabeled")
+	}
+}
+
 func TestZoneReconcile_CloudflareAPIError(t *testing.T) {
 	zone := newTestCloudflareZone("test-zone", "default")
 	zone.Finalizers = []string{cloudflarev1alpha1.FinalizerName}

--- a/internal/controller/cloudflarezone_controller_test.go
+++ b/internal/controller/cloudflarezone_controller_test.go
@@ -153,7 +153,7 @@ func buildZoneReconciler(mock *mockZoneLifecycleClient, objs ...client.Object) *
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		ZoneLifecycleClientFn: func(_ string) cfclient.ZoneLifecycleClient {
 			return mock
 		},
@@ -638,7 +638,7 @@ func TestZoneReconcile_BadRequest_EmitsInvalidSpecEvent(t *testing.T) {
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      fakeRec,
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		ZoneLifecycleClientFn: func(_ string) cfclient.ZoneLifecycleClient {
 			return mock
 		},
@@ -708,7 +708,7 @@ func TestZoneReconcile_DeleteZoneNotFound_RemovesFinalizer(t *testing.T) {
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      fakeRec,
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		ZoneLifecycleClientFn: func(_ string) cfclient.ZoneLifecycleClient {
 			return mock
 		},

--- a/internal/controller/cloudflarezoneconfig_controller.go
+++ b/internal/controller/cloudflarezoneconfig_controller.go
@@ -47,7 +47,7 @@ type CloudflareZoneConfigReconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
 	Recorder      record.EventRecorder
-	ClientFactory *cfclient.ClientFactory
+	ClientFactory CredentialFactory
 	ZoneClientFn  func(apiToken string) cfclient.ZoneClient
 }
 
@@ -106,12 +106,19 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// 4. Get API token
 	secretNs := secretRefNamespace(zoneConfig.Spec.SecretRef, zoneConfig.Namespace)
-	apiToken, err := r.ClientFactory.GetAPIToken(ctx, zoneConfig.Spec.SecretRef.Name, secretNs)
-	if err != nil {
-		logger.Error(err, "failed to get API token")
-		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+	creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
+		zoneConfig.Spec.SecretRef.Name, secretNs,
+		r.Recorder, &zoneConfig, &zoneConfig.Status.Conditions, 30*time.Second)
+	if halt != nil {
+		if err == nil {
+			logger.V(1).Info("credential load failed; halting reconcile",
+				"secret", zoneConfig.Spec.SecretRef.Name, "namespace", secretNs)
+		} else {
+			logger.Error(err, "credential load failed")
+		}
+		return *halt, err
 	}
+	apiToken := creds.APIToken
 
 	// 5. Reconcile the zone config.
 	// Per-group conditions set inside reconcileZoneConfig (via status.SetCondition)

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -138,7 +138,7 @@ func buildZoneConfigReconciler(mock *mockZoneClient, objs ...client.Object) *Clo
 		Client:        fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
-		ClientFactory: cfclient.NewClientFactory(fakeClient),
+		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
 		ZoneClientFn: func(_ string) cfclient.ZoneClient {
 			return mock
 		},

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -14,6 +14,7 @@ import (
 	cfclient "github.com/jacaudi/cloudflare-operator/internal/cloudflare"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -436,6 +437,56 @@ func TestZoneConfigReconcile_SecretNotFound(t *testing.T) {
 	}
 	if !foundCondition {
 		t.Error("expected Ready condition to be set")
+	}
+}
+
+// TestZoneConfigReconcile_SecretNotLabeled verifies that a credentials
+// Secret existing in the API server but lacking the
+// cloudflare.io/managed=true label surfaces ReasonSecretNotLabeled (not
+// SecretNotFound) and emits a recorder event.
+func TestZoneConfigReconcile_SecretNotLabeled(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	mock := newMockZoneClient()
+
+	r := buildZoneConfigReconciler(mock, zoneConfig)
+	rec := record.NewFakeRecorder(8)
+	r.Recorder = rec
+	r.ClientFactory = &fakeCredFactory{err: cfclient.ErrSecretNotLabeled}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected RequeueAfter=30s, got %v", result.RequeueAfter)
+	}
+
+	var got cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("failed to get updated zone config: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("expected Ready condition to be set")
+	}
+	if cond.Reason != cloudflarev1alpha1.ReasonSecretNotLabeled {
+		t.Errorf("expected reason=%s, got %s", cloudflarev1alpha1.ReasonSecretNotLabeled, cond.Reason)
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected Ready=False, got %s", cond.Status)
+	}
+
+	select {
+	case ev := <-rec.Events:
+		if !strings.Contains(ev, cloudflarev1alpha1.ReasonSecretNotLabeled) {
+			t.Errorf("expected event mentioning %s, got %q", cloudflarev1alpha1.ReasonSecretNotLabeled, ev)
+		}
+	default:
+		t.Error("expected at least one recorder event for SecretNotLabeled")
 	}
 }
 

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -79,6 +79,7 @@ func connectorLabels(tun *cloudflarev1alpha1.CloudflareTunnel) map[string]string
 		"app.kubernetes.io/instance":   tun.Name,
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         tun.Name,
+		"cloudflare.io/managed":        "true",
 	}
 }
 

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -73,14 +73,33 @@ func ConnectorNames(tun *cloudflarev1alpha1.CloudflareTunnel) ConnectorResourceN
 	}
 }
 
-func connectorLabels(tun *cloudflarev1alpha1.CloudflareTunnel) map[string]string {
+// connectorSelectorLabels returns the label set used as
+// Spec.Selector.MatchLabels on Deployment and PDB. Selectors are
+// immutable on apps/v1 Deployment and policy/v1 PDB, so this set must
+// stay stable across upgrades — adding a key here on an existing
+// cluster fails every reconcile with "field is immutable."
+//
+// Use connectorLabels for everything else (ObjectMeta.Labels, pod
+// template Labels): it is a superset of connectorSelectorLabels and
+// MAY grow over time.
+func connectorSelectorLabels(tun *cloudflarev1alpha1.CloudflareTunnel) map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":       "cloudflared",
 		"app.kubernetes.io/instance":   tun.Name,
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         tun.Name,
-		"cloudflare.io/managed":        "true",
 	}
+}
+
+// connectorLabels returns the full label set applied to ObjectMeta and
+// pod template. It is a superset of connectorSelectorLabels — additions
+// here are safe because metadata labels are mutable. Includes
+// cloudflare.io/managed=true so operator-owned Secrets pass the
+// label-gated cache filter.
+func connectorLabels(tun *cloudflarev1alpha1.CloudflareTunnel) map[string]string {
+	l := connectorSelectorLabels(tun)
+	l["cloudflare.io/managed"] = "true"
+	return l
 }
 
 func connectorOwnerRef(tun *cloudflarev1alpha1.CloudflareTunnel) []metav1.OwnerReference {
@@ -182,7 +201,7 @@ func BuildConnectorPodDisruptionBudget(tun *cloudflarev1alpha1.CloudflareTunnel)
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvail,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: connectorLabels(tun),
+				MatchLabels: connectorSelectorLabels(tun),
 			},
 		},
 	}
@@ -378,7 +397,7 @@ func BuildConnectorDeployment(tun *cloudflarev1alpha1.CloudflareTunnel, configHa
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Selector: &metav1.LabelSelector{MatchLabels: connectorSelectorLabels(tun)},
 			// 10s grace before kubelet flips the new replica to Ready. cloudflared
 			// reports /ready as soon as the first edge connection is registered,
 			// but the tunnel only becomes truly redundant after multiple

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -677,6 +677,9 @@ func TestConnectorLabels_IncludesManagedKey(t *testing.T) {
 			t.Errorf("expected key %s to remain in connectorLabels", key)
 		}
 	}
+	if want := 5; len(got) != want {
+		t.Errorf("connectorLabels returned %d keys, want %d (got %v)", len(got), want, got)
+	}
 }
 
 // TestBuildConnectorDeployment_ArgsExact pins the cloudflared Args. The

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -535,7 +535,9 @@ func TestBuildConnectorPodDisruptionBudget_AtReplicasTwo(t *testing.T) {
 	if pdb.Spec.MaxUnavailable != nil {
 		t.Errorf("MaxUnavailable = %v, want nil (we set MinAvailable)", pdb.Spec.MaxUnavailable)
 	}
-	wantSelector := connectorLabels(tun)
+	// PDB Spec.Selector is immutable, so it uses the 4-key
+	// connectorSelectorLabels (NOT the full connectorLabels superset).
+	wantSelector := connectorSelectorLabels(tun)
 	if !reflect.DeepEqual(pdb.Spec.Selector.MatchLabels, wantSelector) {
 		t.Errorf("Selector.MatchLabels = %v, want %v", pdb.Spec.Selector.MatchLabels, wantSelector)
 	}
@@ -655,6 +657,57 @@ func TestBuildConnectorDeployment_DefaultTSC_RespectUserTSC(t *testing.T) {
 	got := dep.Spec.Template.Spec.TopologySpreadConstraints
 	if !reflect.DeepEqual(got, userTSC) {
 		t.Errorf("user TSC altered: got %+v, want %+v", got, userTSC)
+	}
+}
+
+// TestConnectorSelectorLabels_IsImmutableSubset pins the selector label set
+// to the four pre-existing keys. Deployment.Spec.Selector and PDB.Spec.Selector
+// are immutable on apps/v1 / policy/v1, so adding a key here would break
+// every reconcile on cluster upgrade with "field is immutable." This test is
+// the canary: if you ever need to add a key to selectors, you must also
+// rename / migrate the Deployment, which is far beyond a label tweak.
+func TestConnectorSelectorLabels_IsImmutableSubset(t *testing.T) {
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "ns"},
+	}
+	got := connectorSelectorLabels(tun)
+	want := map[string]string{
+		"app.kubernetes.io/name":       "cloudflared",
+		"app.kubernetes.io/instance":   "demo",
+		"app.kubernetes.io/managed-by": "cloudflare-operator",
+		"cloudflare.io/tunnel":         "demo",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("connectorSelectorLabels = %v, want %v", got, want)
+	}
+	// Selector must NOT contain cloudflare.io/managed.
+	if _, ok := got["cloudflare.io/managed"]; ok {
+		t.Error("selector unexpectedly contains cloudflare.io/managed; selectors are immutable, this would break upgrades")
+	}
+	// connectorLabels MUST be a strict superset.
+	full := connectorLabels(tun)
+	for k, v := range got {
+		if full[k] != v {
+			t.Errorf("connectorLabels missing or differs at key %q: got %q, want %q", k, full[k], v)
+		}
+	}
+	if len(full) <= len(got) {
+		t.Errorf("connectorLabels (%d keys) must be a strict superset of connectorSelectorLabels (%d keys)", len(full), len(got))
+	}
+}
+
+// TestBuildConnectorDeployment_SelectorImmutability pins Deployment.Spec.Selector
+// to the 4-key selector set. Spec.Selector is immutable; a regression here
+// fails reconciliation forever on cluster upgrade.
+func TestBuildConnectorDeployment_SelectorImmutability(t *testing.T) {
+	tun := tunnelFixture(true)
+	dep := BuildConnectorDeployment(tun, "h")
+	if dep.Spec.Selector == nil {
+		t.Fatal("Spec.Selector is nil")
+	}
+	want := connectorSelectorLabels(tun)
+	if !reflect.DeepEqual(dep.Spec.Selector.MatchLabels, want) {
+		t.Errorf("Deployment Spec.Selector.MatchLabels = %v, want %v (4-key immutable subset)", dep.Spec.Selector.MatchLabels, want)
 	}
 }
 

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -257,6 +257,7 @@ func TestBuildConnectorDeployment_OwnerRefAndLabels(t *testing.T) {
 		"app.kubernetes.io/instance":   "home",
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         "home",
+		"cloudflare.io/managed":        "true",
 	}
 	got := dep.Labels
 	// Pattern #6: assert total map length to catch label-bleed regressions.
@@ -543,6 +544,7 @@ func TestBuildConnectorPodDisruptionBudget_AtReplicasTwo(t *testing.T) {
 		"app.kubernetes.io/instance":   tun.Name,
 		"app.kubernetes.io/managed-by": "cloudflare-operator",
 		"cloudflare.io/tunnel":         tun.Name,
+		"cloudflare.io/managed":        "true",
 	}
 	gotLabels := pdb.Labels
 	// Pattern #6: assert total map length to catch label-bleed regressions.
@@ -653,6 +655,27 @@ func TestBuildConnectorDeployment_DefaultTSC_RespectUserTSC(t *testing.T) {
 	got := dep.Spec.Template.Spec.TopologySpreadConstraints
 	if !reflect.DeepEqual(got, userTSC) {
 		t.Errorf("user TSC altered: got %+v, want %+v", got, userTSC)
+	}
+}
+
+func TestConnectorLabels_IncludesManagedKey(t *testing.T) {
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "ns"},
+	}
+	got := connectorLabels(tun)
+	if v, ok := got["cloudflare.io/managed"]; !ok || v != "true" {
+		t.Fatalf(`expected cloudflare.io/managed=true, got %q (present=%v)`, v, ok)
+	}
+	// Pre-existing keys must still be present (regression guard).
+	for _, key := range []string{
+		"app.kubernetes.io/name",
+		"app.kubernetes.io/instance",
+		"app.kubernetes.io/managed-by",
+		"cloudflare.io/tunnel",
+	} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("expected key %s to remain in connectorLabels", key)
+		}
 	}
 }
 

--- a/internal/controller/credential_load.go
+++ b/internal/controller/credential_load.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	cfclient "github.com/jacaudi/cloudflare-operator/internal/cloudflare"
+)
+
+// CredentialFactory is the subset of cfclient.ClientFactory that
+// LoadCredentials needs. Defined as an interface so reconciler tests can
+// substitute a stub without standing up a real ClientFactory.
+type CredentialFactory interface {
+	GetCredentials(ctx context.Context, secretName, namespace string) (cfclient.Credentials, error)
+}
+
+// LoadCredentials fetches Cloudflare credentials for a CR and centralizes
+// the failure-mode plumbing every reconciler would otherwise duplicate.
+//
+// Returns:
+//
+//   - creds: populated on the success path; zero value on any error.
+//
+//   - halt: non-nil when the caller MUST return immediately. Reconcilers
+//     use the pattern:
+//
+//     creds, halt, err := LoadCredentials(...)
+//     if halt != nil {
+//     return *halt, err
+//     }
+//
+//   - err: surfaced from failReconcile. Always nil on the success path.
+//     Always nil on the SecretNotFound and SecretNotLabeled paths
+//     (failReconcile swallows status-write errors and returns a timed
+//     requeue, matching existing controller behavior).
+//
+// Failure-mode mapping:
+//   - cfclient.ErrSecretNotLabeled → ReasonSecretNotLabeled, recorder
+//     event with the actionable label-the-Secret guidance, requeue.
+//   - apierrors.IsNotFound (wrapped) → ReasonSecretNotFound, requeue.
+//   - any other error → ReasonReconcileError, requeue.
+func LoadCredentials(
+	ctx context.Context,
+	c client.Client,
+	factory CredentialFactory,
+	secretName, namespace string,
+	recorder record.EventRecorder,
+	obj client.Object,
+	conditions *[]metav1.Condition,
+	requeue time.Duration,
+) (cfclient.Credentials, *ctrl.Result, error) {
+	creds, err := factory.GetCredentials(ctx, secretName, namespace)
+	if err == nil {
+		return creds, nil, nil
+	}
+
+	switch {
+	case errors.Is(err, cfclient.ErrSecretNotLabeled):
+		if recorder != nil {
+			recorder.Eventf(obj, corev1.EventTypeWarning,
+				cloudflarev1alpha1.ReasonSecretNotLabeled,
+				"Secret %s/%s exists but is missing label cloudflare.io/managed=true; "+
+					"add the label to allow the operator to read it",
+				namespace, secretName)
+		}
+		halt, herr := failReconcile(ctx, c, obj, conditions,
+			cloudflarev1alpha1.ReasonSecretNotLabeled, err, requeue)
+		return cfclient.Credentials{}, &halt, herr
+
+	case apierrors.IsNotFound(err):
+		halt, herr := failReconcile(ctx, c, obj, conditions,
+			cloudflarev1alpha1.ReasonSecretNotFound, err, requeue)
+		return cfclient.Credentials{}, &halt, herr
+
+	default:
+		halt, herr := failReconcile(ctx, c, obj, conditions,
+			cloudflarev1alpha1.ReasonReconcileError,
+			fmt.Errorf("load credentials: %w", err), requeue)
+		return cfclient.Credentials{}, &halt, herr
+	}
+}

--- a/internal/controller/credential_load.go
+++ b/internal/controller/credential_load.go
@@ -65,6 +65,10 @@ type CredentialFactory interface {
 //     event with the actionable label-the-Secret guidance, requeue.
 //   - apierrors.IsNotFound (wrapped) → ReasonSecretNotFound, requeue.
 //   - any other error → ReasonReconcileError, requeue.
+//
+// recorder may be nil; the helper silently skips event emission in that
+// case. In production every reconciler MUST provide a non-nil recorder
+// — the guard exists for tests and out-of-tree callers.
 func LoadCredentials(
 	ctx context.Context,
 	c client.Client,

--- a/internal/controller/credential_load_test.go
+++ b/internal/controller/credential_load_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	cfclient "github.com/jacaudi/cloudflare-operator/internal/cloudflare"
+)
+
+// fakeCredFactory implements the LoadCredentials factory contract by
+// returning a preconfigured Credentials/error pair regardless of inputs.
+type fakeCredFactory struct {
+	creds cfclient.Credentials
+	err   error
+}
+
+func (f *fakeCredFactory) GetCredentials(_ context.Context, _, _ string) (cfclient.Credentials, error) {
+	return f.creds, f.err
+}
+
+func newTestZone() *cloudflarev1alpha1.CloudflareZone {
+	return &cloudflarev1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "z", Namespace: "ns", Generation: 1},
+	}
+}
+
+func TestLoadCredentials_Success(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = cloudflarev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newTestZone()).Build()
+	rec := record.NewFakeRecorder(8)
+
+	factory := &fakeCredFactory{creds: cfclient.Credentials{APIToken: "tok"}}
+	obj := newTestZone()
+	var conditions []metav1.Condition
+
+	creds, halt, err := LoadCredentials(context.Background(), c, factory,
+		"my-secret", "ns", rec, obj, &conditions, time.Hour)
+
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if halt != nil {
+		t.Fatalf("expected halt=nil on success, got %+v", halt)
+	}
+	if creds.APIToken != "tok" {
+		t.Errorf("expected token tok, got %s", creds.APIToken)
+	}
+	if len(conditions) != 0 {
+		t.Errorf("expected no condition writes on success, got %+v", conditions)
+	}
+}
+
+func TestLoadCredentials_NotLabeled_SetsReasonAndHalts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = cloudflarev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newTestZone()).Build()
+	rec := record.NewFakeRecorder(8)
+
+	factory := &fakeCredFactory{err: cfclient.ErrSecretNotLabeled}
+	obj := newTestZone()
+	var conditions []metav1.Condition
+
+	_, halt, err := LoadCredentials(context.Background(), c, factory,
+		"my-secret", "ns", rec, obj, &conditions, time.Hour)
+
+	if err != nil {
+		t.Fatalf("expected nil err (failReconcile semantics), got %v", err)
+	}
+	if halt == nil {
+		t.Fatal("expected non-nil halt result, got nil")
+	}
+	if halt.RequeueAfter != time.Hour {
+		t.Errorf("expected RequeueAfter=1h, got %v", halt.RequeueAfter)
+	}
+	if len(conditions) != 1 || conditions[0].Reason != cloudflarev1alpha1.ReasonSecretNotLabeled {
+		t.Errorf("expected ReasonSecretNotLabeled, got %+v", conditions)
+	}
+	select {
+	case got := <-rec.Events:
+		if !containsSubstr(got, "SecretNotLabeled") {
+			t.Errorf("expected event mentioning SecretNotLabeled, got %q", got)
+		}
+	default:
+		t.Error("expected at least one recorder event")
+	}
+}
+
+func TestLoadCredentials_NotFound_SetsReasonSecretNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = cloudflarev1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newTestZone()).Build()
+	rec := record.NewFakeRecorder(8)
+
+	notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "missing")
+	factory := &fakeCredFactory{err: fmt.Errorf("failed to get secret ns/missing: %w", notFound)}
+	obj := newTestZone()
+	var conditions []metav1.Condition
+
+	_, halt, err := LoadCredentials(context.Background(), c, factory,
+		"missing", "ns", rec, obj, &conditions, time.Hour)
+
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if halt == nil {
+		t.Fatal("expected non-nil halt result")
+	}
+	if len(conditions) != 1 || conditions[0].Reason != cloudflarev1alpha1.ReasonSecretNotFound {
+		t.Errorf("expected ReasonSecretNotFound, got %+v", conditions)
+	}
+}
+
+// containsSubstr is a tiny substring helper local to this test file (the
+// package already has a slice-based `contains` defined elsewhere, so we use
+// a distinct name to avoid the collision).
+func containsSubstr(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/credential_load_test.go
+++ b/internal/controller/credential_load_test.go
@@ -9,6 +9,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -97,7 +98,7 @@ func TestLoadCredentials_NotLabeled_SetsReasonAndHalts(t *testing.T) {
 	}
 	select {
 	case got := <-rec.Events:
-		if !containsSubstr(got, "SecretNotLabeled") {
+		if !strings.Contains(got, "SecretNotLabeled") {
 			t.Errorf("expected event mentioning SecretNotLabeled, got %q", got)
 		}
 	default:
@@ -131,14 +132,3 @@ func TestLoadCredentials_NotFound_SetsReasonSecretNotFound(t *testing.T) {
 	}
 }
 
-// containsSubstr is a tiny substring helper local to this test file (the
-// package already has a slice-based `contains` defined elsewhere, so we use
-// a distinct name to avoid the collision).
-func containsSubstr(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
-}

--- a/test/cache_filter_test.go
+++ b/test/cache_filter_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package test contains integration tests that exercise behavior the
+// operator depends on from the manager runtime (cache, client, API
+// reader). These tests stand up an envtest control plane and require
+// the kubebuilder envtest binaries to be available via KUBEBUILDER_ASSETS.
+//
+// Run via `make test`, which downloads the binaries through setup-envtest
+// and exports KUBEBUILDER_ASSETS automatically. Running `go test ./...`
+// directly will skip these tests when KUBEBUILDER_ASSETS is unset, so
+// contributors without setup-envtest installed are not blocked.
+package test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// TestSecretLabelFilter_CacheVsAPIReader stands up an envtest control
+// plane, configures a manager whose cache filters Secrets by
+// cloudflare.io/managed=true, then asserts that:
+//
+//  1. A labeled Secret IS visible via the cached client.
+//  2. An unlabeled Secret is NOT visible via the cached client.
+//  3. The unlabeled Secret IS visible via the manager's API reader (uncached).
+//
+// This is the foundational behavior the GetCredentials disambiguation
+// path depends on: a cache miss on a Secret means either "doesn't exist"
+// or "exists but unlabeled", and we rely on the API reader to tell them
+// apart.
+func TestSecretLabelFilter_CacheVsAPIReader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("envtest is slow; skipped in -short mode")
+	}
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; run via `make test` or `setup-envtest use <ver> -p env`")
+	}
+
+	te := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+	}
+	cfg, err := te.Start()
+	if err != nil {
+		t.Fatalf("envtest start: %v", err)
+	}
+	t.Cleanup(func() { _ = te.Stop() })
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	selector, err := labels.Parse("cloudflare.io/managed=true")
+	if err != nil {
+		t.Fatalf("parse selector: %v", err)
+	}
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme,
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {Label: selector},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = mgr.Start(ctx) }()
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		t.Fatal("cache failed to sync")
+	}
+
+	api := mgr.GetAPIReader()
+	cached := mgr.GetClient()
+
+	// Use a non-cached client for setup writes so we don't race the cache.
+	directClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("direct client: %v", err)
+	}
+
+	labeled := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeled",
+			Namespace: "default",
+			Labels:    map[string]string{"cloudflare.io/managed": "true"},
+		},
+	}
+	unlabeled := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "unlabeled", Namespace: "default"},
+	}
+	if err := directClient.Create(ctx, labeled); err != nil {
+		t.Fatalf("create labeled: %v", err)
+	}
+	if err := directClient.Create(ctx, unlabeled); err != nil {
+		t.Fatalf("create unlabeled: %v", err)
+	}
+
+	// Give the cache a beat to observe the labeled write.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var probe corev1.Secret
+		if err := cached.Get(ctx, client.ObjectKey{Name: "labeled", Namespace: "default"}, &probe); err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// 1. Labeled visible via cached client.
+	var gotLabeled corev1.Secret
+	if err := cached.Get(ctx, client.ObjectKey{Name: "labeled", Namespace: "default"}, &gotLabeled); err != nil {
+		t.Errorf("cached Get(labeled) unexpected error: %v", err)
+	}
+
+	// 2. Unlabeled NOT visible via cached client (filtered by selector,
+	//    so it surfaces as IsNotFound).
+	var gotUnlabeled corev1.Secret
+	err = cached.Get(ctx, client.ObjectKey{Name: "unlabeled", Namespace: "default"}, &gotUnlabeled)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("cached Get(unlabeled) expected IsNotFound, got %v", err)
+	}
+
+	// 3. Unlabeled IS visible via API reader (uncached path).
+	var probeUnlabeled corev1.Secret
+	if err := api.Get(ctx, client.ObjectKey{Name: "unlabeled", Namespace: "default"}, &probeUnlabeled); err != nil {
+		t.Errorf("apiReader Get(unlabeled) unexpected error: %v", err)
+	}
+}

--- a/test/cache_filter_test.go
+++ b/test/cache_filter_test.go
@@ -128,7 +128,13 @@ func TestSecretLabelFilter_CacheVsAPIReader(t *testing.T) {
 		t.Fatalf("create unlabeled: %v", err)
 	}
 
-	// Give the cache a beat to observe the labeled write.
+	// Give the cache a beat to observe the labeled write. Polling on the
+	// labeled Secret is sufficient to serialize against the unlabeled
+	// observation too: both writes share the same client, so the apiserver
+	// assigns monotonically-increasing resourceVersions and the informer
+	// observes them in order. Once the labeled Secret is visible, the
+	// earlier unlabeled write has already been processed (and filtered out)
+	// by the same informer.
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		var probe corev1.Secret


### PR DESCRIPTION
Part 2 of 3 in the post-v0.11 usability arc. Part 1 (error-classification-predicates) shipped as v0.12.0; Part 3 (status-phase-field) is queued.

## Summary

- **Manager cache is now label-gated.** `cmd/main.go` enumerates every type the operator watches in a `cache.Options.ByObject` map and applies a label selector (`cloudflare.io/managed=true`) to `corev1.Secret`. Memory footprint scales with managed resources, not cluster-wide Secret count; auditors can read `cmd/main.go` to see exactly which Secrets the operator caches.
- **`ErrSecretNotLabeled` disambiguates the cache-miss path.** `(*ClientFactory).GetCredentials` now does a one-shot uncached probe via the manager's API reader on cache `IsNotFound`, returning a distinct sentinel when the Secret exists but is missing the label. Surfaces as `Reason=SecretNotLabeled` on the CR's `Ready` condition with an actionable Warning event.
- **`LoadCredentials` helper** (new `internal/controller/credential_load.go`) centralizes the credential-load + classify + recorder-event + `failReconcile` flow. 8 call sites across 5 reconcilers refactored through it.
- **Operator-owned Secrets auto-labeled.** `connectorLabels` gains `cloudflare.io/managed=true`; `ensureCredentialsSecret` merges the connector label set onto the tunnel credentials Secret on every `CreateOrUpdate` (preserving externally-applied labels).
- **Migration knobs.** `--secret-cache-label-selector=""` flag / `SECRET_CACHE_LABEL_SELECTOR=""` env / chart value `secretCacheLabelSelector: ""` disable the filter for staged migrations.
- **First envtest in the repo.** `test/cache_filter_test.go` brings up a real apiserver and proves the label filter actually drops unlabeled Secrets from `mgr.GetClient()` while leaving them visible via `mgr.GetAPIReader()`. New Makefile `envtest` target plumbs `setup-envtest` (pinned to release-0.21).

## Selector immutability fix

The independent review caught a critical upgrade hazard: the connector Deployment and PDB use `Spec.Selector.MatchLabels` (immutable on apps/v1 / policy/v1). Adding the new key to `connectorLabels` would have broken every reconcile on existing v0.12.0 clusters with `field is immutable`. Fix: split into `connectorSelectorLabels` (4-key immutable subset, used at Spec.Selector sites only) and `connectorLabels` (5-key superset, used everywhere else). Two regression tests pin the contract.

## Breaking change

User-supplied credential Secrets referenced via `secretRef` MUST carry the `cloudflare.io/managed=true` label or the operator surfaces `Ready=False` with `Reason=SecretNotLabeled`. The operator-owned tunnel credentials Secret is auto-labeled.

Migration:

```bash
kubectl label secret -n <namespace> <name> cloudflare.io/managed=true
```

Or stage the migration: set `secretCacheLabelSelector: ""` (chart) or `SECRET_CACHE_LABEL_SELECTOR=""` (env) to disable the filter, label all Secrets, then restore the default. The `BREAKING CHANGE:` footer on commit `8ef4136` will surface this as a major bump via semantic-release.

Secondary behavior change: on the delete-reconcile path, credential-load failures no longer carry `wrapDeleteErr`'s "remove the finalizer manually" guidance in `Condition.Message` (preserved in operator logs). README troubleshooting section updated.

## Test plan

- [x] `make manifests generate fmt vet test` green across all 7 packages (controller coverage 84.8%, cloudflare 85.1%, status 100%).
- [x] New envtest passes: `KUBEBUILDER_ASSETS=$(./bin/setup-envtest use 1.30.0 -p path) go test ./test/ -run TestSecretLabelFilter -v` (~4s).
- [x] `helm lint chart/` clean.
- [x] `helm template testname chart/` shows `SECRET_CACHE_LABEL_SELECTOR: cloudflare.io/managed=true`.
- [x] `helm template testname chart/ --set secretCacheLabelSelector=""` shows the env var with empty value.
- [x] 5 new per-reconciler `*_SecretNotLabeled` tests + 2 connector selector-immutability regression tests + 3 GetCredentials disambiguation tests + 1 external-label-preservation test.
- [ ] Smoke test: deploy v0.12.0 → upgrade to this branch → confirm connector Deployment/PDB reconciles cleanly without "field is immutable" errors.
- [ ] Smoke test: apply a `CloudflareDNSRecord` with an unlabeled `secretRef` → confirm `Ready=False` with `Reason=SecretNotLabeled` and a Warning event with the actionable message.

## Tasks completed

13 plan tasks (Task 12 skipped — premise was extending an existing tunnel reconcile e2e, but the e2e suite only validates manager deployment; the label property is covered by Task 5's `TestEnsureCredentialsSecret_AppliesManagedLabel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)