### PR TITLE
feat: add Status.Phase enum field to all six CRDs

### DIFF
--- a/api/v1alpha1/cloudflarednsrecord_types.go
+++ b/api/v1alpha1/cloudflarednsrecord_types.go
@@ -122,6 +122,12 @@ type CloudflareDNSRecordStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// Phase is a coarse summary of the reconciliation state. See
+	// cloudflarev1alpha1.Phase for the enum values.
+	// +optional
+	// +kubebuilder:default=Pending
+	Phase Phase `json:"phase,omitempty"`
+
 	// RecordID is the Cloudflare DNS record ID.
 	// +optional
 	RecordID string `json:"recordID,omitempty"`
@@ -145,6 +151,7 @@ type CloudflareDNSRecordStatus struct {
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`
 // +kubebuilder:printcolumn:name="Content",type=string,JSONPath=`.status.currentContent`
 // +kubebuilder:printcolumn:name="Proxied",type=boolean,JSONPath=`.spec.proxied`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="has(self.spec.zoneID) || has(self.spec.zoneRef)",message="one of zoneID or zoneRef is required"

--- a/api/v1alpha1/cloudflareruleset_types.go
+++ b/api/v1alpha1/cloudflareruleset_types.go
@@ -137,13 +137,20 @@ type CloudflareRulesetStatus struct {
 	// ObservedGeneration is the most recently observed generation of the CR.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// Phase is a coarse summary of the reconciliation state. See
+	// cloudflarev1alpha1.Phase for the enum values.
+	// +optional
+	// +kubebuilder:default=Pending
+	Phase Phase `json:"phase,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ruleset Name",type=string,JSONPath=`.spec.name`
-// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.spec.phase`
+// +kubebuilder:printcolumn:name="Ruleset Phase",type=string,JSONPath=`.spec.phase`
 // +kubebuilder:printcolumn:name="Rules",type=integer,JSONPath=`.status.ruleCount`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="has(self.spec.zoneID) || has(self.spec.zoneRef)",message="one of zoneID or zoneRef is required"

--- a/api/v1alpha1/cloudflaretunnel_types.go
+++ b/api/v1alpha1/cloudflaretunnel_types.go
@@ -143,6 +143,12 @@ type CloudflareTunnelStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// Phase is a coarse summary of the reconciliation state. See
+	// cloudflarev1alpha1.Phase for the enum values.
+	// +optional
+	// +kubebuilder:default=Pending
+	Phase Phase `json:"phase,omitempty"`
+
 	// TunnelID is the Cloudflare Tunnel ID.
 	// +optional
 	TunnelID string `json:"tunnelID,omitempty"`
@@ -193,6 +199,7 @@ type ConnectorStatus struct {
 // +kubebuilder:printcolumn:name="Tunnel Name",type=string,JSONPath=`.spec.name`
 // +kubebuilder:printcolumn:name="Tunnel ID",type=string,JSONPath=`.status.tunnelID`
 // +kubebuilder:printcolumn:name="CNAME",type=string,JSONPath=`.status.tunnelCNAME`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.routing) || !has(self.spec.routing.defaultBackend) || (has(self.spec.routing.defaultBackend.serviceRef) ? 1 : 0) + (has(self.spec.routing.defaultBackend.url) ? 1 : 0) + (has(self.spec.routing.defaultBackend.httpStatus) ? 1 : 0) == 1",message="routing.defaultBackend: exactly one of serviceRef, url, httpStatus must be set"

--- a/api/v1alpha1/cloudflaretunnelrule_types.go
+++ b/api/v1alpha1/cloudflaretunnelrule_types.go
@@ -175,7 +175,6 @@ type CloudflareTunnelRuleStatus struct {
 // +kubebuilder:printcolumn:name="Tunnel",type=string,JSONPath=`.spec.tunnelRef.name`
 // +kubebuilder:printcolumn:name="Hostnames",type=string,JSONPath=`.spec.hostnames`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
-// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="TunnelAccepted")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="(has(self.spec.backend.serviceRef) ? 1 : 0) + (has(self.spec.backend.url) ? 1 : 0) + (has(self.spec.backend.httpStatus) ? 1 : 0) == 1",message="exactly one of backend.serviceRef, backend.url, backend.httpStatus must be set"

--- a/api/v1alpha1/cloudflaretunnelrule_types.go
+++ b/api/v1alpha1/cloudflaretunnelrule_types.go
@@ -149,6 +149,12 @@ type CloudflareTunnelRuleStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// Phase is a coarse summary of the reconciliation state. See
+	// cloudflarev1alpha1.Phase for the enum values.
+	// +optional
+	// +kubebuilder:default=Pending
+	Phase Phase `json:"phase,omitempty"`
+
 	// ResolvedBackend is the URL cloudflared was configured with for this
 	// rule. Populated after the tunnel controller renders a config.
 	// +optional
@@ -168,6 +174,8 @@ type CloudflareTunnelRuleStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Tunnel",type=string,JSONPath=`.spec.tunnelRef.name`
 // +kubebuilder:printcolumn:name="Hostnames",type=string,JSONPath=`.spec.hostnames`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="TunnelAccepted")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="(has(self.spec.backend.serviceRef) ? 1 : 0) + (has(self.spec.backend.url) ? 1 : 0) + (has(self.spec.backend.httpStatus) ? 1 : 0) == 1",message="exactly one of backend.serviceRef, backend.url, backend.httpStatus must be set"

--- a/api/v1alpha1/cloudflarezone_types.go
+++ b/api/v1alpha1/cloudflarezone_types.go
@@ -96,6 +96,12 @@ type CloudflareZoneStatus struct {
 	// ObservedGeneration is the most recently observed generation.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// Phase is a coarse summary of the reconciliation state. See
+	// cloudflarev1alpha1.Phase for the enum values.
+	// +optional
+	// +kubebuilder:default=Pending
+	Phase Phase `json:"phase,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -103,6 +109,7 @@ type CloudflareZoneStatus struct {
 // +kubebuilder:printcolumn:name="Domain",type=string,JSONPath=`.spec.name`
 // +kubebuilder:printcolumn:name="Zone ID",type=string,JSONPath=`.status.zoneID`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/api/v1alpha1/cloudflarezoneconfig_types.go
+++ b/api/v1alpha1/cloudflarezoneconfig_types.go
@@ -303,6 +303,12 @@ type CloudflareZoneConfigStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// Phase is a coarse summary of the reconciliation state. See
+	// cloudflarev1alpha1.Phase for the enum values.
+	// +optional
+	// +kubebuilder:default=Pending
+	Phase Phase `json:"phase,omitempty"`
+
 	// ZoneID is the resolved Cloudflare Zone ID, populated regardless of
 	// whether the spec used zoneID or zoneRef.
 	// +optional
@@ -326,6 +332,7 @@ type CloudflareZoneConfigStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Zone ID",type=string,JSONPath=`.status.zoneID`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Last Synced",type=date,JSONPath=`.status.lastSyncedAt`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -96,3 +96,36 @@ const (
 
 // FinalizerName is the finalizer used by all cloudflare-operator controllers.
 const FinalizerName = "cloudflare.io/finalizer"
+
+// Phase is a coarse, human-friendly summary of a CR's reconciliation
+// state. It is set atomically with the Ready condition by the
+// internal/status package; reconcilers do not set Phase directly.
+//
+// +kubebuilder:validation:Enum=Pending;Reconciling;Ready;Deleting;Error
+type Phase string
+
+const (
+	PhasePending     Phase = "Pending"
+	PhaseReconciling Phase = "Reconciling"
+	PhaseReady       Phase = "Ready"
+	PhaseDeleting    Phase = "Deleting"
+	PhaseError       Phase = "Error"
+)
+
+// InProgressReasons enumerates the Reason* constants that represent
+// "work is happening or waiting on a precondition" rather than "this CR
+// has failed and the user must intervene." derivePhase (in
+// internal/status) checks membership via slices.Contains.
+//
+// If you add a Ready=False reason that represents waiting on a
+// precondition, add it here. Anything not listed is mapped to
+// PhaseError by derivePhase, including v0.12.0 (Part 1) classification
+// reasons (InvalidSpec, RemoteGone, PermissionDenied, PlanTierRequired)
+// and Part 2's SecretNotLabeled.
+var InProgressReasons = []string{
+	ReasonReconciling,
+	ReasonZoneRefNotReady,
+	ReasonZonePending,
+	ReasonGatewayAddressNotReady,
+	ReasonTunnelNotReady,
+}

--- a/api/v1alpha1/phase_test.go
+++ b/api/v1alpha1/phase_test.go
@@ -1,0 +1,54 @@
+package v1alpha1
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestInProgressReasons_KnownInProgressMembers(t *testing.T) {
+	wantIn := []string{
+		ReasonReconciling,
+		ReasonZoneRefNotReady,
+		ReasonZonePending,
+		ReasonGatewayAddressNotReady,
+		ReasonTunnelNotReady,
+	}
+	for _, r := range wantIn {
+		if !slices.Contains(InProgressReasons, r) {
+			t.Errorf("InProgressReasons missing in-progress reason %q", r)
+		}
+	}
+}
+
+func TestInProgressReasons_ErrorReasonsAreNotMembers(t *testing.T) {
+	wantOut := []string{
+		ReasonInvalidSpec,
+		ReasonRemoteGone,
+		ReasonPermissionDenied,
+		ReasonPlanTierRequired,
+		ReasonSecretNotLabeled, // Part 2 reason; assumes Part 2 has merged.
+		ReasonReconcileError,
+		ReasonCloudflareError,
+		ReasonSecretNotFound,
+	}
+	for _, r := range wantOut {
+		if slices.Contains(InProgressReasons, r) {
+			t.Errorf("InProgressReasons unexpectedly contains error reason %q", r)
+		}
+	}
+}
+
+func TestPhase_ConstantValues(t *testing.T) {
+	cases := map[Phase]string{
+		PhasePending:     "Pending",
+		PhaseReconciling: "Reconciling",
+		PhaseReady:       "Ready",
+		PhaseDeleting:    "Deleting",
+		PhaseError:       "Error",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("Phase constant string mismatch: got %q want %q", string(got), want)
+		}
+	}
+}

--- a/api/v1alpha1/phase_test.go
+++ b/api/v1alpha1/phase_test.go
@@ -18,6 +18,10 @@ func TestInProgressReasons_KnownInProgressMembers(t *testing.T) {
 			t.Errorf("InProgressReasons missing in-progress reason %q", r)
 		}
 	}
+	if len(InProgressReasons) != len(wantIn) {
+		t.Errorf("InProgressReasons length = %d, want %d; slice may contain unexpected entries",
+			len(InProgressReasons), len(wantIn))
+	}
 }
 
 func TestInProgressReasons_ErrorReasonsAreNotMembers(t *testing.T) {
@@ -30,6 +34,8 @@ func TestInProgressReasons_ErrorReasonsAreNotMembers(t *testing.T) {
 		ReasonReconcileError,
 		ReasonCloudflareError,
 		ReasonSecretNotFound,
+		ReasonZoneNotActive,
+		ReasonIPResolutionError,
 	}
 	for _, r := range wantOut {
 		if slices.Contains(InProgressReasons, r) {

--- a/chart/crds/cloudflare.io_cloudflarednsrecords.yaml
+++ b/chart/crds/cloudflare.io_cloudflarednsrecords.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .spec.proxied
       name: Proxied
       type: boolean
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -265,6 +268,18 @@ spec:
                   of the CR.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               recordID:
                 description: RecordID is the Cloudflare DNS record ID.
                 type: string

--- a/chart/crds/cloudflare.io_cloudflarerulesets.yaml
+++ b/chart/crds/cloudflare.io_cloudflarerulesets.yaml
@@ -19,11 +19,14 @@ spec:
       name: Ruleset Name
       type: string
     - jsonPath: .spec.phase
-      name: Phase
+      name: Ruleset Phase
       type: string
     - jsonPath: .status.ruleCount
       name: Rules
       type: integer
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -264,6 +267,18 @@ spec:
                   of the CR.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               ruleCount:
                 description: RuleCount is the number of rules in the ruleset.
                 type: integer

--- a/chart/crds/cloudflare.io_cloudflaretunnelrules.yaml
+++ b/chart/crds/cloudflare.io_cloudflaretunnelrules.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .spec.hostnames
       name: Hostnames
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .status.conditions[?(@.type=="TunnelAccepted")].status
       name: Accepted
       type: string
@@ -240,6 +246,18 @@ spec:
                 description: ObservedGeneration is the most recently observed generation.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               resolvedBackend:
                 description: |-
                   ResolvedBackend is the URL cloudflared was configured with for this

--- a/chart/crds/cloudflare.io_cloudflaretunnelrules.yaml
+++ b/chart/crds/cloudflare.io_cloudflaretunnelrules.yaml
@@ -24,9 +24,6 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
     - jsonPath: .status.conditions[?(@.type=="TunnelAccepted")].status
       name: Accepted
       type: string

--- a/chart/crds/cloudflare.io_cloudflaretunnels.yaml
+++ b/chart/crds/cloudflare.io_cloudflaretunnels.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.tunnelCNAME
       name: CNAME
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -1504,6 +1507,18 @@ spec:
                 description: ObservedGeneration is the most recently observed generation.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               tunnelCNAME:
                 description: TunnelCNAME is the CNAME for the tunnel (tunnelID.cfargotunnel.com).
                 type: string

--- a/chart/crds/cloudflare.io_cloudflarezoneconfigs.yaml
+++ b/chart/crds/cloudflare.io_cloudflarezoneconfigs.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.zoneID
       name: Zone ID
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -449,6 +452,18 @@ spec:
                   of the CR.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               zoneID:
                 description: |-
                   ZoneID is the resolved Cloudflare Zone ID, populated regardless of

--- a/chart/crds/cloudflare.io_cloudflarezones.yaml
+++ b/chart/crds/cloudflare.io_cloudflarezones.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.status
       name: Status
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -198,6 +201,18 @@ spec:
                 type: array
               originalRegistrar:
                 description: OriginalRegistrar is the registrar at the time of onboarding.
+                type: string
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
                 type: string
               status:
                 description: Status is the zone status in Cloudflare (initializing,

--- a/config/crd/bases/cloudflare.io_cloudflarednsrecords.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarednsrecords.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .spec.proxied
       name: Proxied
       type: boolean
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -265,6 +268,18 @@ spec:
                   of the CR.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               recordID:
                 description: RecordID is the Cloudflare DNS record ID.
                 type: string

--- a/config/crd/bases/cloudflare.io_cloudflarerulesets.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarerulesets.yaml
@@ -19,11 +19,14 @@ spec:
       name: Ruleset Name
       type: string
     - jsonPath: .spec.phase
-      name: Phase
+      name: Ruleset Phase
       type: string
     - jsonPath: .status.ruleCount
       name: Rules
       type: integer
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -264,6 +267,18 @@ spec:
                   of the CR.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               ruleCount:
                 description: RuleCount is the number of rules in the ruleset.
                 type: integer

--- a/config/crd/bases/cloudflare.io_cloudflaretunnelrules.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflaretunnelrules.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .spec.hostnames
       name: Hostnames
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     - jsonPath: .status.conditions[?(@.type=="TunnelAccepted")].status
       name: Accepted
       type: string
@@ -240,6 +246,18 @@ spec:
                 description: ObservedGeneration is the most recently observed generation.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               resolvedBackend:
                 description: |-
                   ResolvedBackend is the URL cloudflared was configured with for this

--- a/config/crd/bases/cloudflare.io_cloudflaretunnelrules.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflaretunnelrules.yaml
@@ -24,9 +24,6 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
     - jsonPath: .status.conditions[?(@.type=="TunnelAccepted")].status
       name: Accepted
       type: string

--- a/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.tunnelCNAME
       name: CNAME
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -1504,6 +1507,18 @@ spec:
                 description: ObservedGeneration is the most recently observed generation.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               tunnelCNAME:
                 description: TunnelCNAME is the CNAME for the tunnel (tunnelID.cfargotunnel.com).
                 type: string

--- a/config/crd/bases/cloudflare.io_cloudflarezoneconfigs.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarezoneconfigs.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.zoneID
       name: Zone ID
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -449,6 +452,18 @@ spec:
                   of the CR.
                 format: int64
                 type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
+                type: string
               zoneID:
                 description: |-
                   ZoneID is the resolved Cloudflare Zone ID, populated regardless of

--- a/config/crd/bases/cloudflare.io_cloudflarezones.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflarezones.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .status.status
       name: Status
       type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -198,6 +201,18 @@ spec:
                 type: array
               originalRegistrar:
                 description: OriginalRegistrar is the registrar at the time of onboarding.
+                type: string
+              phase:
+                default: Pending
+                description: |-
+                  Phase is a coarse summary of the reconciliation state. See
+                  cloudflarev1alpha1.Phase for the enum values.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Deleting
+                - Error
                 type: string
               status:
                 description: Status is the zone status in Cloudflare (initializing,

--- a/internal/controller/cloudflarednsrecord_controller.go
+++ b/internal/controller/cloudflarednsrecord_controller.go
@@ -165,7 +165,7 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 			logger.Error(err, "failed to resolve zone ID")
 		}
 		return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-			cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
+			nil, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}
 
 	// 4. Get API token
@@ -192,11 +192,11 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 		case stderrors.Is(err, ErrForeignTXTOwner):
 			r.Recorder.Event(&dnsRecord, corev1.EventTypeWarning, cloudflarev1alpha1.ReasonRecordOwnershipConflict, err.Error())
 			return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-				cloudflarev1alpha1.ReasonRecordOwnershipConflict, err, result.RequeueAfter)
+				nil, cloudflarev1alpha1.ReasonRecordOwnershipConflict, err, result.RequeueAfter)
 		case stderrors.Is(err, ErrTXTRegistryGap):
 			r.Recorder.Event(&dnsRecord, corev1.EventTypeWarning, cloudflarev1alpha1.ReasonTxtRegistryGap, err.Error())
 			return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-				cloudflarev1alpha1.ReasonTxtRegistryGap, err, result.RequeueAfter)
+				nil, cloudflarev1alpha1.ReasonTxtRegistryGap, err, result.RequeueAfter)
 		default:
 			routing := ClassifyCloudflareError(err)
 			if routing.ResetRemoteID {
@@ -214,14 +214,14 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 				requeue = time.Minute
 			}
 			return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-				routing.Reason, err, requeue)
+				nil, routing.Reason, err, requeue)
 		}
 	}
 
 	// 7. Persist status only if anything materially changed. LastSyncedAt is
 	// bumped only on a real write to keep it meaningful as a liveness signal.
 	dnsRecord.Status.ObservedGeneration = dnsRecord.Generation
-	status.SetReady(&dnsRecord.Status.Conditions, metav1.ConditionTrue,
+	status.SetReady(&dnsRecord.Status.Conditions, nil, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "DNS record synced", dnsRecord.Generation)
 	if !reflect.DeepEqual(preStatus, &dnsRecord.Status) {
 		now := metav1.Now()
@@ -241,7 +241,7 @@ func (r *CloudflareDNSRecordReconciler) reconcileRecord(ctx context.Context, dns
 	desiredContent, err := r.resolveContent(ctx, dnsRecord)
 	if err != nil {
 		return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,
-			cloudflarev1alpha1.ReasonIPResolutionError, err, time.Minute)
+			nil, cloudflarev1alpha1.ReasonIPResolutionError, err, time.Minute)
 	}
 
 	// Check if record exists by ID
@@ -394,7 +394,7 @@ func (r *CloudflareDNSRecordReconciler) reconcileDelete(ctx context.Context, dns
 		if err != nil {
 			logger.Error(err, "failed to resolve zone ID during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,
-				cloudflarev1alpha1.ReasonZoneRefNotReady, wrapDeleteErr(err), 30*time.Second)
+				nil, cloudflarev1alpha1.ReasonZoneRefNotReady, wrapDeleteErr(err), 30*time.Second)
 		}
 
 		secretNs := secretRefNamespace(dnsRecord.Spec.SecretRef, dnsRecord.Namespace)
@@ -428,7 +428,7 @@ func (r *CloudflareDNSRecordReconciler) reconcileDelete(ctx context.Context, dns
 					requeue = 30 * time.Second
 				}
 				return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,
-					routing.Reason, wrapDeleteErr(err), requeue)
+					nil, routing.Reason, wrapDeleteErr(err), requeue)
 			}
 		} else {
 			logger.Info("deleted DNS record from Cloudflare", "recordID", dnsRecord.Status.RecordID)

--- a/internal/controller/cloudflarednsrecord_controller.go
+++ b/internal/controller/cloudflarednsrecord_controller.go
@@ -165,7 +165,7 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 			logger.Error(err, "failed to resolve zone ID")
 		}
 		return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-			nil, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
+			&dnsRecord.Status.Phase, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}
 
 	// 4. Get API token
@@ -192,11 +192,11 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 		case stderrors.Is(err, ErrForeignTXTOwner):
 			r.Recorder.Event(&dnsRecord, corev1.EventTypeWarning, cloudflarev1alpha1.ReasonRecordOwnershipConflict, err.Error())
 			return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-				nil, cloudflarev1alpha1.ReasonRecordOwnershipConflict, err, result.RequeueAfter)
+				&dnsRecord.Status.Phase, cloudflarev1alpha1.ReasonRecordOwnershipConflict, err, result.RequeueAfter)
 		case stderrors.Is(err, ErrTXTRegistryGap):
 			r.Recorder.Event(&dnsRecord, corev1.EventTypeWarning, cloudflarev1alpha1.ReasonTxtRegistryGap, err.Error())
 			return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-				nil, cloudflarev1alpha1.ReasonTxtRegistryGap, err, result.RequeueAfter)
+				&dnsRecord.Status.Phase, cloudflarev1alpha1.ReasonTxtRegistryGap, err, result.RequeueAfter)
 		default:
 			routing := ClassifyCloudflareError(err)
 			if routing.ResetRemoteID {
@@ -214,14 +214,14 @@ func (r *CloudflareDNSRecordReconciler) Reconcile(ctx context.Context, req ctrl.
 				requeue = time.Minute
 			}
 			return failReconcile(ctx, r.Client, &dnsRecord, &dnsRecord.Status.Conditions,
-				nil, routing.Reason, err, requeue)
+				&dnsRecord.Status.Phase, routing.Reason, err, requeue)
 		}
 	}
 
 	// 7. Persist status only if anything materially changed. LastSyncedAt is
 	// bumped only on a real write to keep it meaningful as a liveness signal.
 	dnsRecord.Status.ObservedGeneration = dnsRecord.Generation
-	status.SetReady(&dnsRecord.Status.Conditions, nil, metav1.ConditionTrue,
+	status.SetReady(&dnsRecord.Status.Conditions, &dnsRecord.Status.Phase, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "DNS record synced", dnsRecord.Generation)
 	if !reflect.DeepEqual(preStatus, &dnsRecord.Status) {
 		now := metav1.Now()
@@ -241,7 +241,7 @@ func (r *CloudflareDNSRecordReconciler) reconcileRecord(ctx context.Context, dns
 	desiredContent, err := r.resolveContent(ctx, dnsRecord)
 	if err != nil {
 		return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,
-			nil, cloudflarev1alpha1.ReasonIPResolutionError, err, time.Minute)
+			&dnsRecord.Status.Phase, cloudflarev1alpha1.ReasonIPResolutionError, err, time.Minute)
 	}
 
 	// Check if record exists by ID
@@ -394,7 +394,7 @@ func (r *CloudflareDNSRecordReconciler) reconcileDelete(ctx context.Context, dns
 		if err != nil {
 			logger.Error(err, "failed to resolve zone ID during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,
-				nil, cloudflarev1alpha1.ReasonZoneRefNotReady, wrapDeleteErr(err), 30*time.Second)
+				&dnsRecord.Status.Phase, cloudflarev1alpha1.ReasonZoneRefNotReady, wrapDeleteErr(err), 30*time.Second)
 		}
 
 		secretNs := secretRefNamespace(dnsRecord.Spec.SecretRef, dnsRecord.Namespace)
@@ -428,7 +428,7 @@ func (r *CloudflareDNSRecordReconciler) reconcileDelete(ctx context.Context, dns
 					requeue = 30 * time.Second
 				}
 				return failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions,
-					nil, routing.Reason, wrapDeleteErr(err), requeue)
+					&dnsRecord.Status.Phase, routing.Reason, wrapDeleteErr(err), requeue)
 			}
 		} else {
 			logger.Info("deleted DNS record from Cloudflare", "recordID", dnsRecord.Status.RecordID)

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -2098,11 +2098,14 @@ func TestCloudflareDNSRecord_PhaseError(t *testing.T) {
 
 	r := buildReconciler(s, mock, dnsRecord, secret)
 
-	_, err := r.Reconcile(context.Background(), reconcile.Request{
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "phase-err-rec", Namespace: "default"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Errorf("expected RequeueAfter > 0 for failReconcile path, got %v", result.RequeueAfter)
 	}
 
 	var fetched cloudflarev1alpha1.CloudflareDNSRecord
@@ -2156,11 +2159,14 @@ func TestCloudflareDNSRecord_PhaseReconciling(t *testing.T) {
 	secret := newTestSecret("default")
 	r := buildReconciler(s, mock, zone, dnsRecord, secret)
 
-	_, err := r.Reconcile(context.Background(), reconcile.Request{
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
 		NamespacedName: types.NamespacedName{Name: "phase-wait-rec", Namespace: "default"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+	if result.RequeueAfter <= 0 {
+		t.Errorf("expected RequeueAfter > 0 for failReconcile path, got %v", result.RequeueAfter)
 	}
 
 	var fetched cloudflarev1alpha1.CloudflareDNSRecord

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -2056,3 +2056,118 @@ func TestCloudflareDNSRecordReconciler_DeleteRecordNotFound_RemovesFinalizer(t *
 		t.Fatalf("unexpected error: %v", getErr)
 	}
 }
+
+// TestCloudflareDNSRecord_PhaseReady verifies that after a successful reconcile
+// the Phase field is persisted as PhaseReady via c.Status().Update.
+func TestCloudflareDNSRecord_PhaseReady(t *testing.T) {
+	s := testScheme(t)
+	dnsRecord := newTestDNSRecord("phase-rec", "default")
+	dnsRecord.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	secret := newTestSecret("default")
+	mock := newMockDNSClient()
+
+	r := buildReconciler(s, mock, dnsRecord, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "phase-rec", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareDNSRecord
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "phase-rec", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("get after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReady {
+		t.Errorf("Phase = %q, want %q", fetched.Status.Phase, cloudflarev1alpha1.PhaseReady)
+	}
+}
+
+// TestCloudflareDNSRecord_PhaseError verifies that a Cloudflare API failure
+// sets Phase to PhaseError via c.Status().Update.
+func TestCloudflareDNSRecord_PhaseError(t *testing.T) {
+	s := testScheme(t)
+	dnsRecord := newTestDNSRecord("phase-err-rec", "default")
+	dnsRecord.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	secret := newTestSecret("default")
+	mock := newMockDNSClient()
+	// Inject a generic Cloudflare error on create — routes through
+	// ClassifyCloudflareError → ReasonCloudflareError → derivePhase → PhaseError.
+	mock.createErr = fmt.Errorf("simulated cloudflare error")
+
+	r := buildReconciler(s, mock, dnsRecord, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "phase-err-rec", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareDNSRecord
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "phase-err-rec", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("get after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseError {
+		t.Errorf("Phase = %q, want %q", fetched.Status.Phase, cloudflarev1alpha1.PhaseError)
+	}
+}
+
+// TestCloudflareDNSRecord_PhaseReconciling verifies that when a dependency
+// (zone ref) is not ready, Phase is set to PhaseReconciling via c.Status().Update.
+func TestCloudflareDNSRecord_PhaseReconciling(t *testing.T) {
+	s := testScheme(t)
+	mock := newMockDNSClient()
+
+	// Zone exists but has no resolved ZoneID (pending)
+	zone := &cloudflarev1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-zone",
+			Namespace: "default",
+		},
+		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
+			Name:      "pending.com",
+			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
+		},
+	}
+
+	content := testDNSContent
+	proxied := false
+	dnsRecord := &cloudflarev1alpha1.CloudflareDNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "phase-wait-rec",
+			Namespace:  "default",
+			Generation: 1,
+			Finalizers: []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
+			ZoneRef:   &cloudflarev1alpha1.ZoneReference{Name: "pending-zone"},
+			Name:      "test.example.com",
+			Type:      "A",
+			Content:   &content,
+			TTL:       1,
+			Proxied:   &proxied,
+			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
+			Interval:  &metav1.Duration{Duration: 5 * time.Minute},
+		},
+	}
+
+	secret := newTestSecret("default")
+	r := buildReconciler(s, mock, zone, dnsRecord, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "phase-wait-rec", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareDNSRecord
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "phase-wait-rec", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("get after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReconciling {
+		t.Errorf("Phase = %q, want %q", fetched.Status.Phase, cloudflarev1alpha1.PhaseReconciling)
+	}
+}

--- a/internal/controller/cloudflareruleset_controller.go
+++ b/internal/controller/cloudflareruleset_controller.go
@@ -97,7 +97,7 @@ func (r *CloudflareRulesetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			logger.Error(err, "failed to resolve zone ID")
 		}
 		return failReconcile(ctx, r.Client, &ruleset, &ruleset.Status.Conditions,
-			nil, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
+			&ruleset.Status.Phase, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}
 
 	// 4. Get API token
@@ -136,12 +136,12 @@ func (r *CloudflareRulesetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			requeue = time.Minute
 		}
 		return failReconcile(ctx, r.Client, &ruleset, &ruleset.Status.Conditions,
-			nil, routing.Reason, err, requeue)
+			&ruleset.Status.Phase, routing.Reason, err, requeue)
 	}
 
 	// 7. Persist status only if anything materially changed.
 	ruleset.Status.ObservedGeneration = ruleset.Generation
-	status.SetReady(&ruleset.Status.Conditions, nil, metav1.ConditionTrue,
+	status.SetReady(&ruleset.Status.Conditions, &ruleset.Status.Phase, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "Ruleset synced", ruleset.Generation)
 	if !reflect.DeepEqual(preStatus, &ruleset.Status) {
 		now := metav1.Now()

--- a/internal/controller/cloudflareruleset_controller.go
+++ b/internal/controller/cloudflareruleset_controller.go
@@ -97,7 +97,7 @@ func (r *CloudflareRulesetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			logger.Error(err, "failed to resolve zone ID")
 		}
 		return failReconcile(ctx, r.Client, &ruleset, &ruleset.Status.Conditions,
-			cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
+			nil, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}
 
 	// 4. Get API token
@@ -136,12 +136,12 @@ func (r *CloudflareRulesetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			requeue = time.Minute
 		}
 		return failReconcile(ctx, r.Client, &ruleset, &ruleset.Status.Conditions,
-			routing.Reason, err, requeue)
+			nil, routing.Reason, err, requeue)
 	}
 
 	// 7. Persist status only if anything materially changed.
 	ruleset.Status.ObservedGeneration = ruleset.Generation
-	status.SetReady(&ruleset.Status.Conditions, metav1.ConditionTrue,
+	status.SetReady(&ruleset.Status.Conditions, nil, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "Ruleset synced", ruleset.Generation)
 	if !reflect.DeepEqual(preStatus, &ruleset.Status) {
 		now := metav1.Now()

--- a/internal/controller/cloudflareruleset_controller_test.go
+++ b/internal/controller/cloudflareruleset_controller_test.go
@@ -838,3 +838,57 @@ func TestRulesetReconcile_BadRequest_EmitsInvalidSpecEvent(t *testing.T) {
 		t.Error("expected InvalidSpec event from classifier")
 	}
 }
+
+// TestRulesetReconcile_HappyPath_PhaseReady verifies that a successful reconcile
+// sets Status.Phase to PhaseReady on the persisted object.
+func TestRulesetReconcile_HappyPath_PhaseReady(t *testing.T) {
+	ruleset := newTestRuleset("test-ruleset", "default")
+	ruleset.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	secret := newTestRulesetSecret("default")
+	mock := newMockRulesetClient()
+
+	r := buildRulesetReconciler(mock, ruleset, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ruleset", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareRuleset
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-ruleset", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get ruleset after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReady {
+		t.Errorf("expected Status.Phase=%q, got %q", cloudflarev1alpha1.PhaseReady, fetched.Status.Phase)
+	}
+}
+
+// TestRulesetReconcile_CloudflareAPIError_PhaseError verifies that a Cloudflare
+// API error during reconciliation sets Status.Phase to PhaseError.
+func TestRulesetReconcile_CloudflareAPIError_PhaseError(t *testing.T) {
+	ruleset := newTestRuleset("test-ruleset", "default")
+	ruleset.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	secret := newTestRulesetSecret("default")
+
+	mock := newMockRulesetClient()
+	mock.upsertErr = fmt.Errorf("cloudflare API unavailable")
+
+	r := buildRulesetReconciler(mock, ruleset, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-ruleset", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error (should be handled gracefully): %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareRuleset
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-ruleset", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get ruleset after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseError {
+		t.Errorf("expected Status.Phase=%q, got %q", cloudflarev1alpha1.PhaseError, fetched.Status.Phase)
+	}
+}

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -287,6 +287,11 @@ func writeRuleStatus(ctx context.Context, c client.Client, r *cloudflarev1alpha1
 		status.SetCondition(&conds, cloudflarev1alpha1.ConditionTypeConflict,
 			metav1.ConditionFalse, cloudflarev1alpha1.ReasonReconcileSuccess, "no conflict", r.Generation)
 		r.Status.Phase = cloudflarev1alpha1.PhaseError
+
+	// Fail loud on unknown RuleDecision.Status — adding a new value
+	// without updating this switch would otherwise leave Phase stale.
+	default:
+		r.Status.Phase = cloudflarev1alpha1.PhaseError
 	}
 
 	r.Status.Conditions = conds

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -266,6 +266,7 @@ func writeRuleStatus(ctx context.Context, c client.Client, r *cloudflarev1alpha1
 			metav1.ConditionTrue, cloudflarev1alpha1.ReasonReconcileSuccess, "rule included in tunnel config", r.Generation)
 		status.SetCondition(&conds, cloudflarev1alpha1.ConditionTypeConflict,
 			metav1.ConditionFalse, cloudflarev1alpha1.ReasonReconcileSuccess, "no conflict", r.Generation)
+		r.Status.Phase = cloudflarev1alpha1.PhaseReady
 
 	case RuleDuplicateHostname:
 		// Valid=True, TunnelAccepted=False, Conflict=True.
@@ -275,6 +276,7 @@ func writeRuleStatus(ctx context.Context, c client.Client, r *cloudflarev1alpha1
 			metav1.ConditionFalse, cloudflarev1alpha1.ReasonDuplicateHostname, decision.Message, r.Generation)
 		status.SetCondition(&conds, cloudflarev1alpha1.ConditionTypeConflict,
 			metav1.ConditionTrue, cloudflarev1alpha1.ReasonDuplicateHostname, decision.Message, r.Generation)
+		r.Status.Phase = cloudflarev1alpha1.PhaseError
 
 	case RuleInvalid:
 		// Valid=False, TunnelAccepted=False, Conflict=False.
@@ -284,6 +286,7 @@ func writeRuleStatus(ctx context.Context, c client.Client, r *cloudflarev1alpha1
 			metav1.ConditionFalse, cloudflarev1alpha1.ReasonInvalidSpec, decision.Message, r.Generation)
 		status.SetCondition(&conds, cloudflarev1alpha1.ConditionTypeConflict,
 			metav1.ConditionFalse, cloudflarev1alpha1.ReasonReconcileSuccess, "no conflict", r.Generation)
+		r.Status.Phase = cloudflarev1alpha1.PhaseError
 	}
 
 	r.Status.Conditions = conds

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -804,6 +804,98 @@ func TestReconcileAggregation_AppliedToConfigHash_EmptyForNonIncluded(t *testing
 	}
 }
 
+// ---- writeRuleStatus Phase mapping tests ------------------------------------
+
+// TestWriteRuleStatus_RuleIncluded_SetsPhaseReady verifies that a RuleIncluded
+// decision causes Status.Phase=PhaseReady on the CloudflareTunnelRule.
+func TestWriteRuleStatus_RuleIncluded_SetsPhaseReady(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", false)
+	rule := newRuleForTunnel("r-included", "network", "home", "network")
+	c := buildAggFakeClient(tun, rule)
+
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("ReconcileConnectorAndRules: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareTunnelRule
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: rule.Namespace, Name: rule.Name}, &fetched); err != nil {
+		t.Fatalf("get rule after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReady {
+		t.Errorf("Status.Phase = %q, want %q (RuleIncluded)", fetched.Status.Phase, cloudflarev1alpha1.PhaseReady)
+	}
+}
+
+// TestWriteRuleStatus_RuleDuplicateHostname_SetsPhaseError verifies that a
+// RuleDuplicateHostname decision causes Status.Phase=PhaseError.
+func TestWriteRuleStatus_RuleDuplicateHostname_SetsPhaseError(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", false)
+	goodURL := strPtr("http://svc:8080")
+	// r1 wins with higher priority.
+	r1 := &cloudflarev1alpha1.CloudflareTunnelRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1-dup", Namespace: "network", Generation: 1},
+		Spec: cloudflarev1alpha1.CloudflareTunnelRuleSpec{
+			TunnelRef: cloudflarev1alpha1.TunnelReference{Name: "home", Namespace: "network"},
+			Hostnames: []string{"dup.example.com"},
+			Backend:   cloudflarev1alpha1.TunnelRuleBackend{URL: goodURL},
+			Priority:  200,
+		},
+	}
+	// r2 loses: same hostname, lower priority → DuplicateHostname.
+	r2 := &cloudflarev1alpha1.CloudflareTunnelRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "r2-dup", Namespace: "network", Generation: 1},
+		Spec: cloudflarev1alpha1.CloudflareTunnelRuleSpec{
+			TunnelRef: cloudflarev1alpha1.TunnelReference{Name: "home", Namespace: "network"},
+			Hostnames: []string{"dup.example.com"},
+			Backend:   cloudflarev1alpha1.TunnelRuleBackend{URL: goodURL},
+			Priority:  100,
+		},
+	}
+	c := buildAggFakeClient(tun, r1, r2)
+
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("ReconcileConnectorAndRules: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareTunnelRule
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "network", Name: "r2-dup"}, &fetched); err != nil {
+		t.Fatalf("get r2-dup after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseError {
+		t.Errorf("Status.Phase = %q, want %q (RuleDuplicateHostname)", fetched.Status.Phase, cloudflarev1alpha1.PhaseError)
+	}
+}
+
+// TestWriteRuleStatus_RuleInvalid_SetsPhaseError verifies that a RuleInvalid
+// decision causes Status.Phase=PhaseError.
+func TestWriteRuleStatus_RuleInvalid_SetsPhaseError(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", false)
+	goodURL := strPtr("http://svc:8080")
+	// A rule with no hostnames → Invalid.
+	r := &cloudflarev1alpha1.CloudflareTunnelRule{
+		ObjectMeta: metav1.ObjectMeta{Name: "r-invalid", Namespace: "network", Generation: 1},
+		Spec: cloudflarev1alpha1.CloudflareTunnelRuleSpec{
+			TunnelRef: cloudflarev1alpha1.TunnelReference{Name: "home", Namespace: "network"},
+			Hostnames: []string{},
+			Backend:   cloudflarev1alpha1.TunnelRuleBackend{URL: goodURL},
+			Priority:  100,
+		},
+	}
+	c := buildAggFakeClient(tun, r)
+
+	if err := ReconcileConnectorAndRules(context.Background(), c, tun, nil); err != nil {
+		t.Fatalf("ReconcileConnectorAndRules: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareTunnelRule
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "network", Name: "r-invalid"}, &fetched); err != nil {
+		t.Fatalf("get r-invalid after reconcile: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseError {
+		t.Errorf("Status.Phase = %q, want %q (RuleInvalid)", fetched.Status.Phase, cloudflarev1alpha1.PhaseError)
+	}
+}
+
 // ---- assertion helpers ------------------------------------------------------
 
 func assertCondition(t *testing.T, conds []metav1.Condition, condType string, wantStatus metav1.ConditionStatus) {

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -119,7 +119,7 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			secretNs, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+			nil, cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
 	}
 
 	// 5. Reconcile the tunnel
@@ -143,7 +143,7 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			requeue = time.Minute
 		}
 		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
-			routing.Reason, err, requeue)
+			nil, routing.Reason, err, requeue)
 	}
 
 	// 7. Set Ready and ObservedGeneration in-memory. If aggregation is not
@@ -151,7 +151,7 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// (called inside ReconcileConnectorAndRules) perform the single terminal write
 	// so there is only one Status().Update per successful reconcile.
 	tunnel.Status.ObservedGeneration = tunnel.Generation
-	status.SetReady(&tunnel.Status.Conditions, metav1.ConditionTrue,
+	status.SetReady(&tunnel.Status.Conditions, nil, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "Tunnel synced", tunnel.Generation)
 
 	// 8. Aggregate rules and reconcile connector — only once the tunnel has a
@@ -359,7 +359,7 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 				secretNs, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 			logger.Error(err, "missing Account ID during deletion, will retry; remove the finalizer manually to force deletion")
 			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
-				cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
+				nil, cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
 		}
 
 		if err := r.tunnelClient(creds.APIToken).DeleteTunnel(ctx, creds.AccountID, tunnel.Status.TunnelID); err != nil {
@@ -378,7 +378,7 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 					requeue = 30 * time.Second
 				}
 				return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
-					routing.Reason, wrapDeleteErr(err), requeue)
+					nil, routing.Reason, wrapDeleteErr(err), requeue)
 			}
 		} else {
 			logger.Info("deleted tunnel from Cloudflare", "tunnelID", tunnel.Status.TunnelID)

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -119,7 +119,7 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			secretNs, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
-			nil, cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+			&tunnel.Status.Phase, cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
 	}
 
 	// 5. Reconcile the tunnel
@@ -143,7 +143,7 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			requeue = time.Minute
 		}
 		return failReconcile(ctx, r.Client, &tunnel, &tunnel.Status.Conditions,
-			nil, routing.Reason, err, requeue)
+			&tunnel.Status.Phase, routing.Reason, err, requeue)
 	}
 
 	// 7. Set Ready and ObservedGeneration in-memory. If aggregation is not
@@ -151,7 +151,7 @@ func (r *CloudflareTunnelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// (called inside ReconcileConnectorAndRules) perform the single terminal write
 	// so there is only one Status().Update per successful reconcile.
 	tunnel.Status.ObservedGeneration = tunnel.Generation
-	status.SetReady(&tunnel.Status.Conditions, nil, metav1.ConditionTrue,
+	status.SetReady(&tunnel.Status.Conditions, &tunnel.Status.Phase, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "Tunnel synced", tunnel.Generation)
 
 	// 8. Aggregate rules and reconcile connector — only once the tunnel has a
@@ -340,6 +340,12 @@ func generateTunnelSecret() (string, error) {
 func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	status.SetPhase(&tunnel.Status.Phase, cloudflarev1alpha1.PhaseDeleting)
+	if err := r.Status().Update(ctx, tunnel); err != nil {
+		logger.Error(err, "failed to update status to Deleting")
+		// Continue — don't block deletion on a status-write failure.
+	}
+
 	if tunnel.Status.TunnelID != "" {
 		secretNs := secretRefNamespace(tunnel.Spec.SecretRef, tunnel.Namespace)
 		creds, halt, err := LoadCredentials(ctx, r.Client, r.ClientFactory,
@@ -358,6 +364,9 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 			err := fmt.Errorf("secret %s/%s does not contain %q key",
 				secretNs, tunnel.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 			logger.Error(err, "missing Account ID during deletion, will retry; remove the finalizer manually to force deletion")
+			// Phase intentionally nil: SetPhase(Deleting) at reconcileDelete entry is the
+			// source of truth during deletion; derivePhase would route the deletion reason
+			// to PhaseError.
 			return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
 				nil, cloudflarev1alpha1.ReasonSecretNotFound, wrapDeleteErr(err), 30*time.Second)
 		}
@@ -377,6 +386,9 @@ func (r *CloudflareTunnelReconciler) reconcileDelete(ctx context.Context, tunnel
 				if requeue == 0 && !routing.ResetRemoteID {
 					requeue = 30 * time.Second
 				}
+				// Phase intentionally nil: SetPhase(Deleting) at reconcileDelete entry is the
+				// source of truth during deletion; derivePhase would route the deletion reason
+				// to PhaseError.
 				return failReconcile(ctx, r.Client, tunnel, &tunnel.Status.Conditions,
 					nil, routing.Reason, wrapDeleteErr(err), requeue)
 			}

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -853,3 +853,184 @@ func TestCloudflareTunnelReconciler_DeleteTunnelNotFound_RemovesFinalizer(t *tes
 		t.Fatalf("unexpected error: %v", getErr)
 	}
 }
+
+// TestCloudflareTunnelReconcile_Phase_HappyPath_PhaseReady asserts that a
+// successful reconcile of a CloudflareTunnel sets Status.Phase=PhaseReady.
+func TestCloudflareTunnelReconcile_Phase_HappyPath_PhaseReady(t *testing.T) {
+	tunnel := newTestTunnel("test-tunnel", "default")
+	tunnel.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	secret := newTestSecret("default")
+	mock := newMockTunnelClient()
+
+	r := buildTunnelReconciler(t, mock, tunnel, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-tunnel", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareTunnel
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-tunnel", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get tunnel: %v", err)
+	}
+
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReady {
+		t.Errorf("expected Phase=%s, got %s", cloudflarev1alpha1.PhaseReady, fetched.Status.Phase)
+	}
+}
+
+// TestCloudflareTunnelReconcile_Phase_MidDeletion_PhaseDeleting asserts that
+// when reconcileDelete is entered the tunnel's Phase is set to PhaseDeleting.
+// We use a missing secret to cause LoadCredentials to fail after SetPhase(Deleting)
+// runs, so the object remains in the fake client (the finalizer is not removed)
+// and we can assert the persisted Phase.
+func TestCloudflareTunnelReconcile_Phase_MidDeletion_PhaseDeleting(t *testing.T) {
+	now := metav1.Now()
+	tunnel := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "tun-deleting",
+			Namespace:         "default",
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			Name:                "my-tunnel",
+			SecretRef:           cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
+			GeneratedSecretName: "tunnel-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{
+			TunnelID: "tun-deleting-id",
+		},
+	}
+	// No secret registered — LoadCredentials will fail and return a halt,
+	// leaving the object in the fake client so we can assert Phase=Deleting.
+	mock := newMockTunnelClient()
+
+	r := buildTunnelReconciler(t, mock, tunnel) // intentionally no secret
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "tun-deleting", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareTunnel
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "tun-deleting", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get tunnel: %v", err)
+	}
+
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseDeleting {
+		t.Errorf("expected Phase=%s, got %s", cloudflarev1alpha1.PhaseDeleting, fetched.Status.Phase)
+	}
+}
+
+// TestCloudflareTunnelReconcile_Phase_InProgress_PhaseReconciling verifies that
+// CloudflareTunnelStatus.Phase correctly stores PhaseReconciling when the Ready
+// condition is set to False with an InProgressReasons member. The tunnel controller
+// does not naturally emit an InProgressReasons reason on the Ready condition in its
+// normal flow, so this test exercises the Phase field plumbing directly by writing
+// the status condition via the fake client's status subresource, then verifying the
+// persisted value via c.Get. It confirms the field is wired and retrievable.
+func TestCloudflareTunnelReconcile_Phase_InProgress_PhaseReconciling(t *testing.T) {
+	s := testScheme(t)
+	tunnel := newTestTunnel("test-tunnel", "default")
+	tunnel.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(tunnel).
+		WithStatusSubresource(&cloudflarev1alpha1.CloudflareTunnel{}).
+		Build()
+
+	// Directly write a status with Ready=False, Reason=ReasonReconciling to
+	// establish Phase=PhaseReconciling via the status subresource path.
+	tunnel.Status.Phase = cloudflarev1alpha1.PhaseReconciling
+	tunnel.Status.Conditions = []metav1.Condition{
+		{
+			Type:               cloudflarev1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             cloudflarev1alpha1.ReasonReconciling,
+			Message:            "reconciling",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	if err := fakeClient.Status().Update(context.Background(), tunnel); err != nil {
+		t.Fatalf("failed to write status: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareTunnel
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-tunnel", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get tunnel: %v", err)
+	}
+
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReconciling {
+		t.Errorf("expected Phase=%s, got %s", cloudflarev1alpha1.PhaseReconciling, fetched.Status.Phase)
+	}
+}
+
+// TestCloudflareTunnelReconcile_DeletionPath_PhasePreserved is a regression
+// test that asserts Phase stays PhaseDeleting even when the Cloudflare DELETE
+// API call fails transiently (reaching the failReconcile call inside
+// reconcileDelete). Prior to the fix, both failReconcile sites inside
+// reconcileDelete passed &tunnel.Status.Phase, causing derivePhase to overwrite
+// PhaseDeleting with PhaseError (deletion reasons are not in InProgressReasons).
+// After the fix those sites pass nil, so SetPhase(Deleting) at reconcileDelete
+// entry remains the authoritative Phase setter.
+func TestCloudflareTunnelReconcile_DeletionPath_PhasePreserved(t *testing.T) {
+	now := metav1.Now()
+	tunnel := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "tun-delete-fail",
+			Namespace:         "default",
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			Name:                "my-tunnel",
+			SecretRef:           cloudflarev1alpha1.SecretReference{Name: "creds"},
+			GeneratedSecretName: "tunnel-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{
+			TunnelID: "tun-delete-fail-id",
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+		Data: map[string][]byte{
+			cfclient.SecretKeyAPIToken:  []byte("token"),
+			cfclient.SecretKeyAccountID: []byte("acct"),
+		},
+	}
+
+	mock := newMockTunnelClient()
+	// Inject a transient Cloudflare error so the DELETE fails and failReconcile
+	// fires inside reconcileDelete. The object remains in the fake client.
+	mock.deleteErr = fmt.Errorf("simulated transient deletion error")
+
+	r := buildTunnelReconciler(t, mock, tunnel, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "tun-delete-fail", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareTunnel
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "tun-delete-fail", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get tunnel after reconcile: %v", err)
+	}
+
+	// Phase must remain PhaseDeleting; PhaseError would indicate the bug is present
+	// (i.e., the nil was accidentally changed to &tunnel.Status.Phase at one of the
+	// failReconcile call sites inside reconcileDelete).
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseDeleting {
+		t.Errorf("expected Phase=%s, got %s — failReconcile inside reconcileDelete is overwriting Phase via derivePhase",
+			cloudflarev1alpha1.PhaseDeleting, fetched.Status.Phase)
+	}
+}

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -928,14 +928,14 @@ func TestCloudflareTunnelReconcile_Phase_MidDeletion_PhaseDeleting(t *testing.T)
 	}
 }
 
-// TestCloudflareTunnelReconcile_Phase_InProgress_PhaseReconciling verifies that
+// TestCloudflareTunnel_Phase_FieldRoundTrip verifies that
 // CloudflareTunnelStatus.Phase correctly stores PhaseReconciling when the Ready
 // condition is set to False with an InProgressReasons member. The tunnel controller
 // does not naturally emit an InProgressReasons reason on the Ready condition in its
 // normal flow, so this test exercises the Phase field plumbing directly by writing
 // the status condition via the fake client's status subresource, then verifying the
 // persisted value via c.Get. It confirms the field is wired and retrievable.
-func TestCloudflareTunnelReconcile_Phase_InProgress_PhaseReconciling(t *testing.T) {
+func TestCloudflareTunnel_Phase_FieldRoundTrip(t *testing.T) {
 	s := testScheme(t)
 	tunnel := newTestTunnel("test-tunnel", "default")
 	tunnel.Finalizers = []string{cloudflarev1alpha1.FinalizerName}

--- a/internal/controller/cloudflarezone_controller.go
+++ b/internal/controller/cloudflarezone_controller.go
@@ -280,7 +280,10 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 		}
 		apiToken := creds.APIToken
 
-		status.SetReady(&zone.Status.Conditions, &zone.Status.Phase, metav1.ConditionFalse,
+		// Phase intentionally nil here: SetPhase(Deleting) at reconcileDelete entry is
+		// the source of truth during deletion; derivePhase would route
+		// ReasonDeletingResource to PhaseError.
+		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonDeletingResource, "Deleting zone from Cloudflare", zone.Generation)
 		if statusErr := r.Status().Update(ctx, zone); statusErr != nil {
 			logger.Error(statusErr, "failed to update status before deletion")
@@ -301,8 +304,10 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 				if requeue == 0 && !routing.ResetRemoteID {
 					requeue = 30 * time.Second
 				}
+				// Phase intentionally nil: see comment above; reconcileDelete's Phase is owned
+				// by SetPhase(Deleting) at entry.
 				return failReconcile(ctx, r.Client, zone, &zone.Status.Conditions,
-					&zone.Status.Phase, routing.Reason, wrapDeleteErr(err), requeue)
+					nil, routing.Reason, wrapDeleteErr(err), requeue)
 			}
 		} else {
 			logger.Info("deleted zone from Cloudflare", "zoneID", zone.Status.ZoneID)

--- a/internal/controller/cloudflarezone_controller.go
+++ b/internal/controller/cloudflarezone_controller.go
@@ -103,7 +103,7 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			secretNs, zone.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+			nil, cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
 	}
 
 	// 5. Reconcile the zone
@@ -126,7 +126,7 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			requeue = time.Minute
 		}
 		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
-			routing.Reason, err, requeue)
+			nil, routing.Reason, err, requeue)
 	}
 
 	// 7. Persist status only if anything materially changed.
@@ -227,7 +227,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 
 	switch existing.Status {
 	case cloudflarev1alpha1.ZoneStatusActive:
-		status.SetReady(&zone.Status.Conditions, metav1.ConditionTrue,
+		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionTrue,
 			cloudflarev1alpha1.ReasonReconcileSuccess, "Zone is active", zone.Generation)
 
 	case cloudflarev1alpha1.ZoneStatusPending:
@@ -238,7 +238,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 
 		nsMsg := fmt.Sprintf("Zone pending activation. Update your registrar NS records to: %s",
 			strings.Join(existing.NameServers, ", "))
-		status.SetReady(&zone.Status.Conditions, metav1.ConditionFalse,
+		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonZonePending, nsMsg, zone.Generation)
 
 		// Shorter requeue when pending for faster activation detection
@@ -247,7 +247,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 		}
 
 	default:
-		status.SetReady(&zone.Status.Conditions, metav1.ConditionFalse,
+		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonZoneNotActive,
 			fmt.Sprintf("Zone status is %q", existing.Status), zone.Generation)
 	}
@@ -274,7 +274,7 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 		}
 		apiToken := creds.APIToken
 
-		status.SetReady(&zone.Status.Conditions, metav1.ConditionFalse,
+		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonDeletingResource, "Deleting zone from Cloudflare", zone.Generation)
 		if statusErr := r.Status().Update(ctx, zone); statusErr != nil {
 			logger.Error(statusErr, "failed to update status before deletion")
@@ -296,7 +296,7 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 					requeue = 30 * time.Second
 				}
 				return failReconcile(ctx, r.Client, zone, &zone.Status.Conditions,
-					routing.Reason, wrapDeleteErr(err), requeue)
+					nil, routing.Reason, wrapDeleteErr(err), requeue)
 			}
 		} else {
 			logger.Info("deleted zone from Cloudflare", "zoneID", zone.Status.ZoneID)

--- a/internal/controller/cloudflarezone_controller.go
+++ b/internal/controller/cloudflarezone_controller.go
@@ -103,7 +103,7 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			secretNs, zone.Spec.SecretRef.Name, cfclient.SecretKeyAccountID)
 		logger.Error(err, "missing Account ID")
 		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
-			nil, cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
+			&zone.Status.Phase, cloudflarev1alpha1.ReasonSecretNotFound, err, 30*time.Second)
 	}
 
 	// 5. Reconcile the zone
@@ -126,7 +126,7 @@ func (r *CloudflareZoneReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			requeue = time.Minute
 		}
 		return failReconcile(ctx, r.Client, &zone, &zone.Status.Conditions,
-			nil, routing.Reason, err, requeue)
+			&zone.Status.Phase, routing.Reason, err, requeue)
 	}
 
 	// 7. Persist status only if anything materially changed.
@@ -227,7 +227,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 
 	switch existing.Status {
 	case cloudflarev1alpha1.ZoneStatusActive:
-		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionTrue,
+		status.SetReady(&zone.Status.Conditions, &zone.Status.Phase, metav1.ConditionTrue,
 			cloudflarev1alpha1.ReasonReconcileSuccess, "Zone is active", zone.Generation)
 
 	case cloudflarev1alpha1.ZoneStatusPending:
@@ -238,7 +238,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 
 		nsMsg := fmt.Sprintf("Zone pending activation. Update your registrar NS records to: %s",
 			strings.Join(existing.NameServers, ", "))
-		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionFalse,
+		status.SetReady(&zone.Status.Conditions, &zone.Status.Phase, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonZonePending, nsMsg, zone.Generation)
 
 		// Shorter requeue when pending for faster activation detection
@@ -247,7 +247,7 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 		}
 
 	default:
-		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionFalse,
+		status.SetReady(&zone.Status.Conditions, &zone.Status.Phase, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonZoneNotActive,
 			fmt.Sprintf("Zone status is %q", existing.Status), zone.Generation)
 	}
@@ -257,6 +257,12 @@ func (r *CloudflareZoneReconciler) reconcileZone(ctx context.Context, zone *clou
 
 func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cloudflarev1alpha1.CloudflareZone) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+
+	status.SetPhase(&zone.Status.Phase, cloudflarev1alpha1.PhaseDeleting)
+	if err := r.Status().Update(ctx, zone); err != nil {
+		logger.Error(err, "failed to update status to Deleting")
+		// Continue — don't block deletion on a status-write failure.
+	}
 
 	if zone.Spec.DeletionPolicy == cloudflarev1alpha1.DeletionPolicyDelete && zone.Status.ZoneID != "" {
 		secretNs := secretRefNamespace(zone.Spec.SecretRef, zone.Namespace)
@@ -274,7 +280,7 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 		}
 		apiToken := creds.APIToken
 
-		status.SetReady(&zone.Status.Conditions, nil, metav1.ConditionFalse,
+		status.SetReady(&zone.Status.Conditions, &zone.Status.Phase, metav1.ConditionFalse,
 			cloudflarev1alpha1.ReasonDeletingResource, "Deleting zone from Cloudflare", zone.Generation)
 		if statusErr := r.Status().Update(ctx, zone); statusErr != nil {
 			logger.Error(statusErr, "failed to update status before deletion")
@@ -296,7 +302,7 @@ func (r *CloudflareZoneReconciler) reconcileDelete(ctx context.Context, zone *cl
 					requeue = 30 * time.Second
 				}
 				return failReconcile(ctx, r.Client, zone, &zone.Status.Conditions,
-					nil, routing.Reason, wrapDeleteErr(err), requeue)
+					&zone.Status.Phase, routing.Reason, wrapDeleteErr(err), requeue)
 			}
 		} else {
 			logger.Info("deleted zone from Cloudflare", "zoneID", zone.Status.ZoneID)

--- a/internal/controller/cloudflarezone_controller_test.go
+++ b/internal/controller/cloudflarezone_controller_test.go
@@ -716,6 +716,125 @@ func TestZoneReconcile_BadRequest_EmitsInvalidSpecEvent(t *testing.T) {
 	}
 }
 
+// --- Phase field tests (Task 7) ---
+
+func TestZoneReconcile_Phase_ActiveZone_PhaseReady(t *testing.T) {
+	zone := newTestCloudflareZone("test-zone", "default")
+	zone.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	zone.Status.ZoneID = "zone-active-phase"
+	secret := newTestSecret("default")
+
+	mock := newMockZoneLifecycleClient()
+	mock.zones["zone-active-phase"] = &cfclient.Zone{
+		ID:          "zone-active-phase",
+		Name:        "example.com",
+		Status:      "active",
+		Type:        "full",
+		NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
+	}
+
+	r := buildZoneReconciler(mock, zone, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareZone
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get zone: %v", err)
+	}
+
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReady {
+		t.Errorf("expected Phase=%s, got %s", cloudflarev1alpha1.PhaseReady, fetched.Status.Phase)
+	}
+}
+
+func TestZoneReconcile_Phase_PendingZone_PhaseReconciling(t *testing.T) {
+	zone := newTestCloudflareZone("test-zone", "default")
+	zone.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	zone.Status.ZoneID = "zone-pending-phase"
+	secret := newTestSecret("default")
+
+	mock := newMockZoneLifecycleClient()
+	mock.zones["zone-pending-phase"] = &cfclient.Zone{
+		ID:          "zone-pending-phase",
+		Name:        "example.com",
+		Status:      "pending",
+		Type:        "full",
+		NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
+	}
+
+	r := buildZoneReconciler(mock, zone, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareZone
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get zone: %v", err)
+	}
+
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReconciling {
+		t.Errorf("expected Phase=%s, got %s", cloudflarev1alpha1.PhaseReconciling, fetched.Status.Phase)
+	}
+}
+
+func TestZoneReconcile_Phase_MidDeletion_PhaseDeleting(t *testing.T) {
+	// Use DeletionPolicy=Delete with ZoneID set but no secret so that
+	// LoadCredentials fails, returns a halt, and reconcileDelete exits early
+	// WITHOUT removing the finalizer. This keeps the object in the fake client
+	// so we can assert Phase=Deleting after the reconcile.
+	now := metav1.Now()
+	zone := &cloudflarev1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-zone",
+			Namespace:         "default",
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
+			Name:           "example.com",
+			Type:           "full",
+			DeletionPolicy: cloudflarev1alpha1.DeletionPolicyDelete,
+			SecretRef: cloudflarev1alpha1.SecretReference{
+				Name: "cf-secret",
+			},
+		},
+		Status: cloudflarev1alpha1.CloudflareZoneStatus{
+			ZoneID: "zone-deleting",
+		},
+	}
+	// No secret registered — LoadCredentials will fail, halt will be returned
+	// before finalizer removal, leaving the object accessible for assertion.
+	mock := newMockZoneLifecycleClient()
+
+	r := buildZoneReconciler(mock, zone) // intentionally no secret
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareZone
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get zone: %v", err)
+	}
+
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseDeleting {
+		t.Errorf("expected Phase=%s, got %s", cloudflarev1alpha1.PhaseDeleting, fetched.Status.Phase)
+	}
+}
+
 func TestZoneReconcile_DeleteZoneNotFound_RemovesFinalizer(t *testing.T) {
 	now := metav1.Now()
 	zone := &cloudflarev1alpha1.CloudflareZone{

--- a/internal/controller/cloudflarezone_controller_test.go
+++ b/internal/controller/cloudflarezone_controller_test.go
@@ -835,6 +835,64 @@ func TestZoneReconcile_Phase_MidDeletion_PhaseDeleting(t *testing.T) {
 	}
 }
 
+// TestZoneReconcile_Phase_HappyDeletion_PhaseDeletingPreservedThroughAPICall asserts
+// that Phase stays PhaseDeleting even when the Cloudflare DELETE API call fails
+// transiently. Prior to the fix, SetReady(DeletingResource) and failReconcile both
+// threaded &zone.Status.Phase, causing derivePhase to overwrite PhaseDeleting with
+// PhaseError (DeletingResource is not in InProgressReasons). After the fix both sites
+// pass nil for phase, so SetPhase(Deleting) at reconcileDelete entry remains the
+// authoritative Phase setter.
+func TestZoneReconcile_Phase_HappyDeletion_PhaseDeletingPreservedThroughAPICall(t *testing.T) {
+	now := metav1.Now()
+	zone := &cloudflarev1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-zone",
+			Namespace:         "default",
+			Generation:        1,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
+			Name:           "example.com",
+			Type:           "full",
+			DeletionPolicy: cloudflarev1alpha1.DeletionPolicyDelete,
+			SecretRef: cloudflarev1alpha1.SecretReference{
+				Name: "cf-secret",
+			},
+		},
+		Status: cloudflarev1alpha1.CloudflareZoneStatus{
+			ZoneID: "zone-deleting-transient",
+		},
+	}
+
+	secret := newTestSecret("default")
+
+	// Simulate a transient Cloudflare API error so failReconcile fires (line 304-305)
+	// and the object remains in the fake client for assertion.
+	mock := newMockZoneLifecycleClient()
+	mock.deleteErr = fmt.Errorf("simulated transient deletion error")
+
+	r := buildZoneReconciler(mock, zone, secret)
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone", Namespace: "default"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareZone
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get zone after reconcile: %v", err)
+	}
+
+	// Phase must remain PhaseDeleting; PhaseError would indicate the bug is present.
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseDeleting {
+		t.Errorf("expected Phase=%s, got %s — SetReady(DeletingResource) or failReconcile is overwriting Phase via derivePhase",
+			cloudflarev1alpha1.PhaseDeleting, fetched.Status.Phase)
+	}
+}
+
 func TestZoneReconcile_DeleteZoneNotFound_RemovesFinalizer(t *testing.T) {
 	now := metav1.Now()
 	zone := &cloudflarev1alpha1.CloudflareZone{

--- a/internal/controller/cloudflarezoneconfig_controller.go
+++ b/internal/controller/cloudflarezoneconfig_controller.go
@@ -100,7 +100,7 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 			logger.Error(err, "failed to resolve zone ID")
 		}
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
-			nil, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
+			&zoneConfig.Status.Phase, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}
 	zoneConfig.Status.ZoneID = resolvedZoneID
 
@@ -128,12 +128,12 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	if err != nil {
 		logger.Error(err, "reconciliation failed")
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
-			nil, cloudflarev1alpha1.ReasonPartialApply, err, time.Minute)
+			&zoneConfig.Status.Phase, cloudflarev1alpha1.ReasonPartialApply, err, time.Minute)
 	}
 
 	// 7. Persist status only if anything materially changed.
 	zoneConfig.Status.ObservedGeneration = zoneConfig.Generation
-	status.SetReady(&zoneConfig.Status.Conditions, nil, metav1.ConditionTrue,
+	status.SetReady(&zoneConfig.Status.Conditions, &zoneConfig.Status.Phase, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "Zone config synced", zoneConfig.Generation)
 	if !reflect.DeepEqual(preStatus, &zoneConfig.Status) {
 		now := metav1.Now()

--- a/internal/controller/cloudflarezoneconfig_controller.go
+++ b/internal/controller/cloudflarezoneconfig_controller.go
@@ -100,7 +100,7 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 			logger.Error(err, "failed to resolve zone ID")
 		}
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
-			cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
+			nil, cloudflarev1alpha1.ReasonZoneRefNotReady, err, 30*time.Second)
 	}
 	zoneConfig.Status.ZoneID = resolvedZoneID
 
@@ -128,12 +128,12 @@ func (r *CloudflareZoneConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	if err != nil {
 		logger.Error(err, "reconciliation failed")
 		return failReconcile(ctx, r.Client, &zoneConfig, &zoneConfig.Status.Conditions,
-			cloudflarev1alpha1.ReasonPartialApply, err, time.Minute)
+			nil, cloudflarev1alpha1.ReasonPartialApply, err, time.Minute)
 	}
 
 	// 7. Persist status only if anything materially changed.
 	zoneConfig.Status.ObservedGeneration = zoneConfig.Generation
-	status.SetReady(&zoneConfig.Status.Conditions, metav1.ConditionTrue,
+	status.SetReady(&zoneConfig.Status.Conditions, nil, metav1.ConditionTrue,
 		cloudflarev1alpha1.ReasonReconcileSuccess, "Zone config synced", zoneConfig.Generation)
 	if !reflect.DeepEqual(preStatus, &zoneConfig.Status) {
 		now := metav1.Now()

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -1444,3 +1444,39 @@ func TestZoneConfigReconcile_BotManagement_PlanTier_Distinct(t *testing.T) {
 			cond.Reason, cloudflarev1alpha1.ReasonPlanTierRequired)
 	}
 }
+
+// TestZoneConfigReconcile_PartialApply_SetsPhaseError verifies that when
+// reconcileZoneConfig returns an error (e.g. a BotManagement 403 causing
+// ReasonPartialApply on the aggregate Ready condition), derivePhase maps
+// the non-in-progress reason to PhaseError.
+// ReasonPartialApply is intentionally absent from InProgressReasons.
+func TestZoneConfigReconcile_PartialApply_SetsPhaseError(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+	enableJS := true
+	zoneConfig.Spec.BotManagement = &cloudflarev1alpha1.BotManagementSettings{EnableJS: &enableJS}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	// Inject a 403 on bot management — causes ReasonPartialApply on Ready,
+	// which is not in InProgressReasons, so derivePhase must return PhaseError.
+	mock.botUpdateErr = &cfgov6.Error{StatusCode: http.StatusForbidden}
+
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get updated zone config: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseError {
+		t.Errorf("expected Phase=%q, got %q", cloudflarev1alpha1.PhaseError, fetched.Status.Phase)
+	}
+}

--- a/internal/controller/cloudflarezoneconfig_controller_test.go
+++ b/internal/controller/cloudflarezoneconfig_controller_test.go
@@ -1325,6 +1325,86 @@ func TestHashZoneConfigSpec_ChangesOnNewFields(t *testing.T) {
 	}
 }
 
+func TestZoneConfigReconcile_FullSuccess_SetsPhaseReady(t *testing.T) {
+	zoneConfig := newTestZoneConfig("test-zone-config", "default")
+	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+
+	sslMode := testSSLModeFull
+	zoneConfig.Spec.SSL = &cloudflarev1alpha1.SSLSettings{Mode: &sslMode}
+
+	secret := newTestZoneConfigSecret("default")
+	mock := newMockZoneClient()
+	r := buildZoneConfigReconciler(mock, zoneConfig, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get updated zone config: %v", err)
+	}
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReady {
+		t.Errorf("expected Phase=%q, got %q", cloudflarev1alpha1.PhaseReady, fetched.Status.Phase)
+	}
+}
+
+func TestZoneConfigReconcile_ZoneRefNotReady_SetsPhaseReconciling(t *testing.T) {
+	mock := newMockZoneClient()
+
+	// CloudflareZone with no status.zoneID set.
+	zone := &cloudflarev1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-zone",
+			Namespace: "default",
+		},
+		Spec: cloudflarev1alpha1.CloudflareZoneSpec{
+			Name:      "pending.com",
+			SecretRef: cloudflarev1alpha1.SecretReference{Name: "cf-secret"},
+		},
+	}
+
+	sslMode := testSSLModeFull
+	zoneConfig := &cloudflarev1alpha1.CloudflareZoneConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-zone-config",
+			Namespace:  "default",
+			Generation: 1,
+			Finalizers: []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareZoneConfigSpec{
+			ZoneRef: &cloudflarev1alpha1.ZoneReference{Name: "pending-zone"},
+			SecretRef: cloudflarev1alpha1.SecretReference{
+				Name: "cf-secret",
+			},
+			Interval: &metav1.Duration{Duration: 30 * time.Minute},
+			SSL: &cloudflarev1alpha1.SSLSettings{
+				Mode: &sslMode,
+			},
+		},
+	}
+
+	secret := newTestZoneConfigSecret("default")
+	r := buildZoneConfigReconciler(mock, zone, zoneConfig, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "test-zone-config", Namespace: "default"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var fetched cloudflarev1alpha1.CloudflareZoneConfig
+	if err := r.Get(context.Background(), types.NamespacedName{Name: "test-zone-config", Namespace: "default"}, &fetched); err != nil {
+		t.Fatalf("failed to get updated zone config: %v", err)
+	}
+	// ZoneRefNotReady maps to PhaseReconciling via derivePhase.
+	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReconciling {
+		t.Errorf("expected Phase=%q, got %q", cloudflarev1alpha1.PhaseReconciling, fetched.Status.Phase)
+	}
+}
+
 func TestZoneConfigReconcile_BotManagement_PlanTier_Distinct(t *testing.T) {
 	zoneConfig := newTestZoneConfig("test-zone-config", "default")
 	zoneConfig.Finalizers = []string{cloudflarev1alpha1.FinalizerName}

--- a/internal/controller/credential_load.go
+++ b/internal/controller/credential_load.go
@@ -94,17 +94,17 @@ func LoadCredentials(
 				namespace, secretName)
 		}
 		halt, herr := failReconcile(ctx, c, obj, conditions,
-			cloudflarev1alpha1.ReasonSecretNotLabeled, err, requeue)
+			nil, cloudflarev1alpha1.ReasonSecretNotLabeled, err, requeue)
 		return cfclient.Credentials{}, &halt, herr
 
 	case apierrors.IsNotFound(err):
 		halt, herr := failReconcile(ctx, c, obj, conditions,
-			cloudflarev1alpha1.ReasonSecretNotFound, err, requeue)
+			nil, cloudflarev1alpha1.ReasonSecretNotFound, err, requeue)
 		return cfclient.Credentials{}, &halt, herr
 
 	default:
 		halt, herr := failReconcile(ctx, c, obj, conditions,
-			cloudflarev1alpha1.ReasonReconcileError,
+			nil, cloudflarev1alpha1.ReasonReconcileError,
 			fmt.Errorf("load credentials: %w", err), requeue)
 		return cfclient.Credentials{}, &halt, herr
 	}

--- a/internal/controller/credential_load_test.go
+++ b/internal/controller/credential_load_test.go
@@ -131,4 +131,3 @@ func TestLoadCredentials_NotFound_SetsReasonSecretNotFound(t *testing.T) {
 		t.Errorf("expected ReasonSecretNotFound, got %+v", conditions)
 	}
 }
-

--- a/internal/controller/dns_registry_decision.go
+++ b/internal/controller/dns_registry_decision.go
@@ -142,13 +142,13 @@ func (r *CloudflareDNSRecordReconciler) applyRegistryDecision(
 	case RegistryActionRefuseForeignOwner:
 		refuseErr := fmt.Errorf("%w: %s", ErrForeignTXTOwner, dnsRecord.Spec.Name)
 		failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions, //nolint:errcheck
-			cloudflarev1alpha1.ReasonRecordOwnershipConflict, refuseErr, 5*time.Minute)
+			nil, cloudflarev1alpha1.ReasonRecordOwnershipConflict, refuseErr, 5*time.Minute)
 		return true, verdict, ctrl.Result{RequeueAfter: 5 * time.Minute}, refuseErr
 
 	case RegistryActionRefuseNoTXT:
 		refuseErr := fmt.Errorf("%w: %s", ErrTXTRegistryGap, dnsRecord.Spec.Name)
 		failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions, //nolint:errcheck
-			cloudflarev1alpha1.ReasonTxtRegistryGap, refuseErr, 5*time.Minute)
+			nil, cloudflarev1alpha1.ReasonTxtRegistryGap, refuseErr, 5*time.Minute)
 		return true, verdict, ctrl.Result{RequeueAfter: 5 * time.Minute}, refuseErr
 
 	case RegistryActionAdopt, RegistryActionAdoptOrphan:

--- a/internal/controller/dns_registry_decision.go
+++ b/internal/controller/dns_registry_decision.go
@@ -142,13 +142,13 @@ func (r *CloudflareDNSRecordReconciler) applyRegistryDecision(
 	case RegistryActionRefuseForeignOwner:
 		refuseErr := fmt.Errorf("%w: %s", ErrForeignTXTOwner, dnsRecord.Spec.Name)
 		failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions, //nolint:errcheck
-			nil, cloudflarev1alpha1.ReasonRecordOwnershipConflict, refuseErr, 5*time.Minute)
+			&dnsRecord.Status.Phase, cloudflarev1alpha1.ReasonRecordOwnershipConflict, refuseErr, 5*time.Minute)
 		return true, verdict, ctrl.Result{RequeueAfter: 5 * time.Minute}, refuseErr
 
 	case RegistryActionRefuseNoTXT:
 		refuseErr := fmt.Errorf("%w: %s", ErrTXTRegistryGap, dnsRecord.Spec.Name)
 		failReconcile(ctx, r.Client, dnsRecord, &dnsRecord.Status.Conditions, //nolint:errcheck
-			nil, cloudflarev1alpha1.ReasonTxtRegistryGap, refuseErr, 5*time.Minute)
+			&dnsRecord.Status.Phase, cloudflarev1alpha1.ReasonTxtRegistryGap, refuseErr, 5*time.Minute)
 		return true, verdict, ctrl.Result{RequeueAfter: 5 * time.Minute}, refuseErr
 
 	case RegistryActionAdopt, RegistryActionAdoptOrphan:

--- a/internal/controller/httproute_source_controller.go
+++ b/internal/controller/httproute_source_controller.go
@@ -408,11 +408,11 @@ func (r *HTTPRouteSourceReconciler) emitDNSPair(
 			OwnerReferences: ownerRefs,
 		},
 		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
-			Name:      hostname,
-			Type:      recordType,
-			Content:   strPtr(content),
-			Proxied:   boolPtr(proxied),
-			TTL:       ttl,
+			Name:    hostname,
+			Type:    recordType,
+			Content: strPtr(content),
+			Proxied: boolPtr(proxied),
+			TTL:     ttl,
 			SecretRef: cloudflarev1alpha1.SecretReference{
 				Name:      zone.Spec.SecretRef.Name,
 				Namespace: zone.Namespace,
@@ -446,10 +446,10 @@ func (r *HTTPRouteSourceReconciler) emitDNSPair(
 			OwnerReferences: ownerRefs,
 		},
 		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
-			Name:      txtFQDN,
-			Type:      "TXT",
-			Content:   strPtr(txtContent),
-			TTL:       120,
+			Name:    txtFQDN,
+			Type:    "TXT",
+			Content: strPtr(txtContent),
+			TTL:     120,
 			SecretRef: cloudflarev1alpha1.SecretReference{
 				Name:      zone.Spec.SecretRef.Name,
 				Namespace: zone.Namespace,

--- a/internal/controller/reconcile_helpers.go
+++ b/internal/controller/reconcile_helpers.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/status"
 )
 
@@ -36,20 +37,20 @@ func wrapDeleteErr(err error) error {
 	return fmt.Errorf("cannot delete Cloudflare resource: %w. Remove the finalizer manually to force deletion", err)
 }
 
-// failReconcile marks obj's Ready condition False with the given reason and error,
-// persists status (logging but not surfacing status-write errors), and returns a
-// timed requeue. Centralizes the repeated "set-status, log, requeue" tail found
-// across every controller's error paths.
+// failReconcile marks obj's Ready condition False with the given reason and
+// error, derives Phase (when phase is non-nil), persists status (logging but
+// not surfacing status-write errors), and returns a timed requeue.
 func failReconcile(
 	ctx context.Context,
 	c client.Client,
 	obj client.Object,
 	conditions *[]metav1.Condition,
+	phase *cloudflarev1alpha1.Phase,
 	reason string,
 	err error,
 	requeue time.Duration,
 ) (ctrl.Result, error) {
-	status.SetReady(conditions, metav1.ConditionFalse, reason, err.Error(), obj.GetGeneration())
+	status.SetReady(conditions, phase, metav1.ConditionFalse, reason, err.Error(), obj.GetGeneration())
 	if statusErr := c.Status().Update(ctx, obj); statusErr != nil {
 		log.FromContext(ctx).Error(statusErr, "failed to update status")
 	}

--- a/internal/controller/service_source_controller.go
+++ b/internal/controller/service_source_controller.go
@@ -298,11 +298,11 @@ func (r *ServiceSourceReconciler) emitDNSPair(
 			OwnerReferences: ownerRefs,
 		},
 		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
-			Name:      hostname,
-			Type:      recordType,
-			Content:   strPtr(content),
-			Proxied:   boolPtr(proxied),
-			TTL:       ttl,
+			Name:    hostname,
+			Type:    recordType,
+			Content: strPtr(content),
+			Proxied: boolPtr(proxied),
+			TTL:     ttl,
 			SecretRef: cloudflarev1alpha1.SecretReference{
 				Name:      zone.Spec.SecretRef.Name,
 				Namespace: zone.Namespace,
@@ -336,10 +336,10 @@ func (r *ServiceSourceReconciler) emitDNSPair(
 			OwnerReferences: ownerRefs,
 		},
 		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
-			Name:      txtFQDN,
-			Type:      "TXT",
-			Content:   strPtr(txtContent),
-			TTL:       120,
+			Name:    txtFQDN,
+			Type:    "TXT",
+			Content: strPtr(txtContent),
+			TTL:     120,
 			SecretRef: cloudflarev1alpha1.SecretReference{
 				Name:      zone.Spec.SecretRef.Name,
 				Namespace: zone.Namespace,

--- a/internal/crdschema/crd_schema_test.go
+++ b/internal/crdschema/crd_schema_test.go
@@ -1,0 +1,123 @@
+package crdschema
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// loadCRDFiles returns every YAML file in the given directory parsed as a CRD.
+func loadCRDFiles(t *testing.T, dir string) map[string]*apiextv1.CustomResourceDefinition {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	out := map[string]*apiextv1.CustomResourceDefinition{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		var crd apiextv1.CustomResourceDefinition
+		if err := yaml.Unmarshal(raw, &crd); err != nil {
+			t.Fatalf("unmarshal %s: %v", p, err)
+		}
+		out[e.Name()] = &crd
+	}
+	return out
+}
+
+func TestCRDs_HavePhasePrinterColumn(t *testing.T) {
+	crds := loadCRDFiles(t, "../../config/crd/bases")
+	if len(crds) != 6 {
+		t.Fatalf("expected 6 CRDs in config/crd/bases, found %d", len(crds))
+	}
+	for name, crd := range crds {
+		t.Run(name, func(t *testing.T) {
+			for _, v := range crd.Spec.Versions {
+				var hasPhase bool
+				for _, col := range v.AdditionalPrinterColumns {
+					if col.Name == "Phase" && col.JSONPath == ".status.phase" {
+						hasPhase = true
+						break
+					}
+				}
+				if !hasPhase {
+					t.Errorf("CRD %s version %s missing 'Phase' printer column with JSONPath=.status.phase",
+						crd.Name, v.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestCRDs_PhaseEnumOnStatus(t *testing.T) {
+	want := []string{"Pending", "Reconciling", "Ready", "Deleting", "Error"}
+	sort.Strings(want)
+	crds := loadCRDFiles(t, "../../config/crd/bases")
+	for name, crd := range crds {
+		t.Run(name, func(t *testing.T) {
+			for _, v := range crd.Spec.Versions {
+				schema := v.Schema.OpenAPIV3Schema
+				status, ok := schema.Properties["status"]
+				if !ok {
+					t.Fatalf("CRD %s version %s has no status schema", crd.Name, v.Name)
+				}
+				phase, ok := status.Properties["phase"]
+				if !ok {
+					t.Fatalf("CRD %s version %s status.phase missing", crd.Name, v.Name)
+				}
+				got := []string{}
+				for _, e := range phase.Enum {
+					got = append(got, strings.Trim(string(e.Raw), `"`))
+				}
+				sort.Strings(got)
+				if strings.Join(got, ",") != strings.Join(want, ",") {
+					t.Errorf("CRD %s phase enum = %v, want %v", crd.Name, got, want)
+				}
+				if phase.Default == nil || strings.Trim(string(phase.Default.Raw), `"`) != "Pending" {
+					t.Errorf("CRD %s phase default missing or != Pending", crd.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestCRDs_ChartVendorParity(t *testing.T) {
+	base := loadCRDFiles(t, "../../config/crd/bases")
+	chart := loadCRDFiles(t, "../../chart/crds")
+	if len(base) != len(chart) {
+		t.Fatalf("base CRD count %d != chart CRD count %d — run `make sync-helm-crds`",
+			len(base), len(chart))
+	}
+	for name, b := range base {
+		c, ok := chart[name]
+		if !ok {
+			t.Errorf("chart/crds/%s missing — run `make sync-helm-crds`", name)
+			continue
+		}
+		baseRaw, err := os.ReadFile(filepath.Join("../../config/crd/bases", name))
+		if err != nil {
+			t.Fatalf("read base %s: %v", name, err)
+		}
+		chartRaw, err := os.ReadFile(filepath.Join("../../chart/crds", name))
+		if err != nil {
+			t.Fatalf("read chart %s: %v", name, err)
+		}
+		if string(baseRaw) != string(chartRaw) {
+			t.Errorf("CRD %s differs between config/crd/bases and chart/crds — run `make sync-helm-crds`", name)
+		}
+		_ = b
+		_ = c
+	}
+}

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -26,6 +26,16 @@ func SetReady(conditions *[]metav1.Condition, status metav1.ConditionStatus, rea
 	SetCondition(conditions, cloudflarev1alpha1.ConditionTypeReady, status, reason, message, generation)
 }
 
+// SetPhase sets *phase to p. A nil phase pointer is a no-op (used by
+// callers that do not yet have a Status.Phase field, and by tests that
+// don't care about Phase).
+func SetPhase(phase *cloudflarev1alpha1.Phase, p cloudflarev1alpha1.Phase) {
+	if phase == nil {
+		return
+	}
+	*phase = p
+}
+
 func derivePhase(status metav1.ConditionStatus, reason string) cloudflarev1alpha1.Phase {
 	switch status {
 	case metav1.ConditionTrue:

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -22,8 +22,23 @@ func SetCondition(conditions *[]metav1.Condition, conditionType string, status m
 	meta.SetStatusCondition(conditions, condition)
 }
 
-func SetReady(conditions *[]metav1.Condition, status metav1.ConditionStatus, reason, message string, generation int64) {
-	SetCondition(conditions, cloudflarev1alpha1.ConditionTypeReady, status, reason, message, generation)
+// SetReady sets the Ready condition AND derives Phase from the
+// (status, reason) pair when phase is non-nil. Callers that don't yet
+// have a Status.Phase field pass nil — the function is a strict
+// superset of the previous SetReady.
+func SetReady(
+	conditions *[]metav1.Condition,
+	phase *cloudflarev1alpha1.Phase,
+	status metav1.ConditionStatus,
+	reason, message string,
+	generation int64,
+) {
+	SetCondition(conditions, cloudflarev1alpha1.ConditionTypeReady,
+		status, reason, message, generation)
+	if phase == nil {
+		return
+	}
+	*phase = derivePhase(status, reason)
 }
 
 // SetPhase sets *phase to p. A nil phase pointer is a no-op (used by

--- a/internal/status/conditions.go
+++ b/internal/status/conditions.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -23,4 +24,20 @@ func SetCondition(conditions *[]metav1.Condition, conditionType string, status m
 
 func SetReady(conditions *[]metav1.Condition, status metav1.ConditionStatus, reason, message string, generation int64) {
 	SetCondition(conditions, cloudflarev1alpha1.ConditionTypeReady, status, reason, message, generation)
+}
+
+func derivePhase(status metav1.ConditionStatus, reason string) cloudflarev1alpha1.Phase {
+	switch status {
+	case metav1.ConditionTrue:
+		return cloudflarev1alpha1.PhaseReady
+	case metav1.ConditionFalse:
+		if slices.Contains(cloudflarev1alpha1.InProgressReasons, reason) {
+			return cloudflarev1alpha1.PhaseReconciling
+		}
+		return cloudflarev1alpha1.PhaseError
+	case metav1.ConditionUnknown:
+		return cloudflarev1alpha1.PhasePending
+	default:
+		return cloudflarev1alpha1.PhasePending
+	}
 }

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -115,3 +115,28 @@ func TestDerivePhase(t *testing.T) {
 		})
 	}
 }
+
+func TestSetPhase_NilPointer_DoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("SetPhase(nil, ...) panicked: %v", r)
+		}
+	}()
+	SetPhase(nil, cloudflarev1alpha1.PhaseDeleting)
+}
+
+func TestSetPhase_SetsPointerValue(t *testing.T) {
+	var p cloudflarev1alpha1.Phase
+	SetPhase(&p, cloudflarev1alpha1.PhaseDeleting)
+	if p != cloudflarev1alpha1.PhaseDeleting {
+		t.Errorf("SetPhase: got %q, want %q", p, cloudflarev1alpha1.PhaseDeleting)
+	}
+}
+
+func TestSetPhase_OverwritesExisting(t *testing.T) {
+	p := cloudflarev1alpha1.PhaseReady
+	SetPhase(&p, cloudflarev1alpha1.PhaseDeleting)
+	if p != cloudflarev1alpha1.PhaseDeleting {
+		t.Errorf("SetPhase did not overwrite: got %q", p)
+	}
+}

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
@@ -55,7 +56,7 @@ func TestSetCondition_UpdatesExisting(t *testing.T) {
 
 func TestSetReady(t *testing.T) {
 	var conditions []metav1.Condition
-	SetReady(&conditions, metav1.ConditionTrue, "Success", "synced", 1)
+	SetReady(&conditions, nil, metav1.ConditionTrue, "Success", "synced", 1)
 
 	if len(conditions) != 1 {
 		t.Fatalf("expected 1 condition, got %d", len(conditions))
@@ -138,5 +139,56 @@ func TestSetPhase_OverwritesExisting(t *testing.T) {
 	SetPhase(&p, cloudflarev1alpha1.PhaseDeleting)
 	if p != cloudflarev1alpha1.PhaseDeleting {
 		t.Errorf("SetPhase did not overwrite: got %q", p)
+	}
+}
+
+func TestSetReady_NilPhasePointer_OnlyWritesCondition(t *testing.T) {
+	conds := []metav1.Condition{}
+	SetReady(&conds, nil, metav1.ConditionTrue,
+		cloudflarev1alpha1.ReasonReconcileSuccess, "ok", 1)
+	got := meta.FindStatusCondition(conds, cloudflarev1alpha1.ConditionTypeReady)
+	if got == nil || got.Status != metav1.ConditionTrue {
+		t.Fatalf("Ready condition not set correctly")
+	}
+	// No panic and no observable phase write — phase is nil.
+}
+
+func TestSetReady_NonNilPhase_DerivesPhase(t *testing.T) {
+	conds := []metav1.Condition{}
+	var p cloudflarev1alpha1.Phase
+	SetReady(&conds, &p, metav1.ConditionTrue,
+		cloudflarev1alpha1.ReasonReconcileSuccess, "ok", 1)
+	if p != cloudflarev1alpha1.PhaseReady {
+		t.Errorf("phase = %q, want %q", p, cloudflarev1alpha1.PhaseReady)
+	}
+}
+
+func TestSetReady_NonNilPhase_FalseInProgress_SetsReconciling(t *testing.T) {
+	conds := []metav1.Condition{}
+	var p cloudflarev1alpha1.Phase
+	SetReady(&conds, &p, metav1.ConditionFalse,
+		cloudflarev1alpha1.ReasonZoneRefNotReady, "waiting", 2)
+	if p != cloudflarev1alpha1.PhaseReconciling {
+		t.Errorf("phase = %q, want %q", p, cloudflarev1alpha1.PhaseReconciling)
+	}
+}
+
+func TestSetReady_NonNilPhase_FalseError_SetsError(t *testing.T) {
+	conds := []metav1.Condition{}
+	var p cloudflarev1alpha1.Phase
+	SetReady(&conds, &p, metav1.ConditionFalse,
+		cloudflarev1alpha1.ReasonInvalidSpec, "bad spec", 3)
+	if p != cloudflarev1alpha1.PhaseError {
+		t.Errorf("phase = %q, want %q", p, cloudflarev1alpha1.PhaseError)
+	}
+}
+
+func TestSetReady_NonNilPhase_Unknown_SetsPending(t *testing.T) {
+	conds := []metav1.Condition{}
+	p := cloudflarev1alpha1.PhaseReady // pre-existing
+	SetReady(&conds, &p, metav1.ConditionUnknown,
+		cloudflarev1alpha1.ReasonReconciling, "starting", 0)
+	if p != cloudflarev1alpha1.PhasePending {
+		t.Errorf("phase = %q, want %q", p, cloudflarev1alpha1.PhasePending)
 	}
 }

--- a/internal/status/conditions_test.go
+++ b/internal/status/conditions_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cloudflarev1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 )
 
 func TestSetCondition_AddsNew(t *testing.T) {
@@ -60,5 +62,56 @@ func TestSetReady(t *testing.T) {
 	}
 	if conditions[0].Type != "Ready" {
 		t.Errorf("expected type Ready, got %s", conditions[0].Type)
+	}
+}
+
+func TestDerivePhase(t *testing.T) {
+	cases := []struct {
+		name   string
+		status metav1.ConditionStatus
+		reason string
+		want   cloudflarev1alpha1.Phase
+	}{
+		// True → always Ready, regardless of reason.
+		{"true_with_success_reason", metav1.ConditionTrue, cloudflarev1alpha1.ReasonReconcileSuccess, cloudflarev1alpha1.PhaseReady},
+		{"true_with_unrelated_reason", metav1.ConditionTrue, "AnythingElse", cloudflarev1alpha1.PhaseReady},
+
+		// False + in-progress reason → Reconciling.
+		{"false_reconciling", metav1.ConditionFalse, cloudflarev1alpha1.ReasonReconciling, cloudflarev1alpha1.PhaseReconciling},
+		{"false_zone_ref_not_ready", metav1.ConditionFalse, cloudflarev1alpha1.ReasonZoneRefNotReady, cloudflarev1alpha1.PhaseReconciling},
+		{"false_zone_pending", metav1.ConditionFalse, cloudflarev1alpha1.ReasonZonePending, cloudflarev1alpha1.PhaseReconciling},
+		{"false_gateway_not_ready", metav1.ConditionFalse, cloudflarev1alpha1.ReasonGatewayAddressNotReady, cloudflarev1alpha1.PhaseReconciling},
+		{"false_tunnel_not_ready", metav1.ConditionFalse, cloudflarev1alpha1.ReasonTunnelNotReady, cloudflarev1alpha1.PhaseReconciling},
+
+		// False + error reason → Error. Includes v0.12.0 (Part 1) reasons.
+		{"false_invalid_spec", metav1.ConditionFalse, cloudflarev1alpha1.ReasonInvalidSpec, cloudflarev1alpha1.PhaseError},
+		{"false_remote_gone", metav1.ConditionFalse, cloudflarev1alpha1.ReasonRemoteGone, cloudflarev1alpha1.PhaseError},
+		{"false_permission_denied", metav1.ConditionFalse, cloudflarev1alpha1.ReasonPermissionDenied, cloudflarev1alpha1.PhaseError},
+		{"false_plan_tier_required", metav1.ConditionFalse, cloudflarev1alpha1.ReasonPlanTierRequired, cloudflarev1alpha1.PhaseError},
+
+		// Part 2 reason — Part 2 has merged.
+		{"false_secret_not_labeled", metav1.ConditionFalse, cloudflarev1alpha1.ReasonSecretNotLabeled, cloudflarev1alpha1.PhaseError},
+
+		// False + pre-existing failure reasons → Error.
+		{"false_reconcile_error", metav1.ConditionFalse, cloudflarev1alpha1.ReasonReconcileError, cloudflarev1alpha1.PhaseError},
+		{"false_cloudflare_error", metav1.ConditionFalse, cloudflarev1alpha1.ReasonCloudflareError, cloudflarev1alpha1.PhaseError},
+		{"false_secret_not_found", metav1.ConditionFalse, cloudflarev1alpha1.ReasonSecretNotFound, cloudflarev1alpha1.PhaseError},
+		{"false_unknown_string", metav1.ConditionFalse, "TotallyUnknownReason", cloudflarev1alpha1.PhaseError},
+		{"false_empty_reason", metav1.ConditionFalse, "", cloudflarev1alpha1.PhaseError},
+
+		// Unknown → Pending.
+		{"unknown", metav1.ConditionUnknown, cloudflarev1alpha1.ReasonReconciling, cloudflarev1alpha1.PhasePending},
+		{"unknown_empty_reason", metav1.ConditionUnknown, "", cloudflarev1alpha1.PhasePending},
+
+		// Default arm — bogus status value falls through to PhasePending.
+		{"bogus_status", metav1.ConditionStatus("Bogus"), "Anything", cloudflarev1alpha1.PhasePending},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := derivePhase(tc.status, tc.reason)
+			if got != tc.want {
+				t.Errorf("derivePhase(%q, %q) = %q, want %q", tc.status, tc.reason, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `Status.Phase` enum (`Pending`/`Reconciling`/`Ready`/`Deleting`/`Error`) and `Phase` printer column to all six CRDs (`CloudflareDNSRecord`, `CloudflareRuleset`, `CloudflareZone`, `CloudflareZoneConfig`, `CloudflareTunnel`, `CloudflareTunnelRule`), set atomically with the `Ready` condition through the existing `internal/status` write seam. Phase is a pure read-model — no reconciler picks it directly; every terminal status write picks it up by passing `&obj.Status.Phase` instead of `nil`.

This is Part 3 of 3 in the status-classification arc (Part 1 = v0.12.0 error reasons; Part 2 = #87 SecretNotLabeled; Part 3 = this PR).

## How it works

- **`derivePhase(status, reason)`** maps `(metav1.ConditionStatus, reason)` → Phase via an `InProgressReasons` allow-list (`Reconciling`, `ZoneRefNotReady`, `ZonePending`, `GatewayAddressNotReady`, `TunnelNotReady`). `True` → `Ready`; `False` + in-progress → `Reconciling`; `False` + anything else → `Error`; `Unknown`/default → `Pending`.
- **`SetReady` and `failReconcile` gain a `phase *Phase` parameter.** All 33 production call sites were swept with `nil` first (one signature-ripple commit), then per-CRD swaps replaced `nil` with `&obj.Status.Phase`.
- **`SetPhase(&obj.Status.Phase, PhaseDeleting)`** is set at the entry of `reconcileDelete` for `CloudflareZone` and `CloudflareTunnel`. Subsequent `SetReady`/`failReconcile` calls inside `reconcileDelete` intentionally pass `nil` for phase (with explanatory comments) — `derivePhase` would otherwise route deletion reasons like `ReasonDeletingResource` to `PhaseError`, silently overwriting `PhaseDeleting`. This bug was caught during T7 review and applied as a pre-flag to T9.
- **`writeRuleStatus`** sets `r.Status.Phase` inline per `RuleDecision.Status` (`RuleIncluded` → `Ready`; `RuleDuplicateHostname`/`RuleInvalid` → `Error`; default → `Error` for fail-loud on future additions).
- **`CloudflareRuleset`'s pre-existing `Phase` printer column** (pointing at `.spec.phase` — the Cloudflare ruleset phase like `http_request_firewall_custom`) was renamed to `Ruleset Phase` to avoid header collision with the new `Phase` column.
- **`internal/crdschema/crd_schema_test.go`** is a new schema-level regression guard with three tests: every CRD has the `Phase` printer column, every CRD's `phase` schema property has the full enum + `default: Pending`, and `chart/crds/` is byte-identical to `config/crd/bases/`.

## Notable points

- **`ConnectorStatus` does NOT get a Phase field** — it's a sub-struct embedded in `CloudflareTunnelStatus`, not its own CRD.
- **`credential_load.go`'s 3 `failReconcile` calls remain `nil`** for phase. It's a shared helper used by all reconcilers; threading a per-CRD pointer through it would require a refactor outside this plan's scope. Can be revisited if any reconciler benefits.
- **e2e Phase smoke check (originally Task 12) was descoped.** The plan assumed an existing CR-lifecycle e2e to extend; `test/e2e/e2e_test.go` is operator-pod-readiness-only with no CR lifecycle test. The schema-verification test (T11) plus per-controller reconciler tests cover the regression surface adequately. Future e2e expansion is orthogonal.
- **Two non-blocking minor findings from the final review left as-is:** (M2) `TestCloudflareTunnel_Phase_FieldRoundTrip` is a fake-client round-trip tautology — kept because it's harmless and the rename made the scope honest; (M3) is implicitly resolved by removing the orphan Ready column on TunnelRule.

## Test plan

- [x] `make test` green across all 9 packages (controller 85.8% coverage; status 100%).
- [x] `go build ./...` clean.
- [x] `internal/crdschema/crd_schema_test.go` green (3 tests × 6 CRDs).
- [x] `make sync-helm-crds` is a no-op (chart in sync with bases).
- [x] All 6 reconciler test files use `WithStatusSubresource` + `c.Get`-after-Reconcile.
- [x] Zone and Tunnel each have a regression test that drives their `reconcileDelete` through a transient delete error and asserts `Phase=Deleting` (NOT Error) — guards the deletion-path nil-pass pattern.
- [ ] Manual smoke: `kubectl get cloudflaredns -o jsonpath='{.status.phase}'` returns `Ready` after a real DNSRecord reconcile (not part of CI; verify in your cluster if convenient).

## Commits (16)

Implementation tasks T1–T11 plus follow-up fixes:

```
3689742 fix(api): remove orphan Ready printer column from CloudflareTunnelRule
2c9ad7b test,refactor: address deferred review findings on Phase tests and switch
22c2896 test(crd): verify Phase printer column, enum, and chart-vendor parity
db4e2e3 feat(api): add Status.Phase to CloudflareTunnelRule
3b6337c feat(api): add Status.Phase to CloudflareTunnel
044a0cd test(zoneconfig): assert Phase=Error on Ready=False error path
1f9233b feat(api): add Status.Phase to CloudflareZoneConfig
4bf0b87 fix(zone): preserve PhaseDeleting through reconcileDelete status writes
eac2841 feat(api): add Status.Phase to CloudflareZone
4ff907b feat(api): add Status.Phase to CloudflareRuleset
4a376e1 feat(api): add Status.Phase to CloudflareDNSRecord
dcf3674 refactor(status): extend SetReady/failReconcile with phase pointer
0bc40de feat(status): add SetPhase helper for explicit Phase writes
94f21fe feat(status): add derivePhase helper for Phase mapping
aa95afb test(api): tighten InProgressReasons membership coverage
8519dca feat(api): add Phase enum and InProgressReasons constants
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)