### PR TITLE
fix: tunnel adoption secret collision and chart rollout strategy default

### DIFF
--- a/chart/templates/_values-controllers.tpl
+++ b/chart/templates/_values-controllers.tpl
@@ -10,6 +10,11 @@ controllers:
     type: deployment
     replicas: {{ .Values.controller.replicas }}
     strategy: {{ .Values.controller.strategy }}
+    {{- with .Values.controller.rollingUpdate }}
+    rollingUpdate:
+      surge: {{ .maxSurge }}
+      unavailable: {{ .maxUnavailable | quote }}
+    {{- end }}
     {{- if .Values.serviceAccount.create }}
     serviceAccount:
       identifier: main

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,7 +16,21 @@ image:
 controller:
   # -- Number of replicas (for HA, use 2+ with leader election)
   replicas: 1
-  strategy: Recreate
+
+  # -- Deployment rollout strategy. RollingUpdate with maxUnavailable:0 +
+  # maxSurge:1 is safe at any replica count: at replicas=1 a new pod
+  # comes up before the old terminates (briefly 2 pods, leader
+  # election picks one); at replicas>1 it provides zero-downtime
+  # upgrades. Override to 'Recreate' only if you have a specific
+  # reason (e.g., shared exclusive storage).
+  strategy: RollingUpdate
+
+  # -- RollingUpdate parameters. Only applied when strategy is RollingUpdate.
+  # maxUnavailable is quoted as a string so that the value 0 is not treated
+  # as falsy by the Helm template engine (Go templates: 0 == false).
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: "0"
 
   # -- Default soft per-hostname topologySpreadConstraints applied when
   # replicas > 1 AND neither controller.affinity nor

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -194,8 +194,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err := (&controller.CloudflareTunnelReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor( //nolint:staticcheck // TODO: migrate to events.EventRecorder
 			"cloudflaretunnel-controller"),
 		ClientFactory: clientFactory,

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -269,6 +269,23 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context
 		return fmt.Errorf("marshal credentials: %w", err)
 	}
 
+	mutate := func(s *corev1.Secret) error {
+		if err := controllerutil.SetControllerReference(tunnel, s, r.Scheme); err != nil {
+			return err
+		}
+		if s.Labels == nil {
+			s.Labels = map[string]string{}
+		}
+		for k, v := range connectorLabels(tunnel) {
+			s.Labels[k] = v
+		}
+		if s.Data == nil {
+			s.Data = make(map[string][]byte)
+		}
+		s.Data["credentials.json"] = credsJSON
+		return nil
+	}
+
 	credSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tunnel.Spec.GeneratedSecretName,
@@ -277,22 +294,32 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context
 	}
 
 	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, credSecret, func() error {
-		if err := controllerutil.SetControllerReference(tunnel, credSecret, r.Scheme); err != nil {
-			return err
-		}
-		if credSecret.Labels == nil {
-			credSecret.Labels = map[string]string{}
-		}
-		for k, v := range connectorLabels(tunnel) {
-			credSecret.Labels[k] = v
-		}
-		if credSecret.Data == nil {
-			credSecret.Data = make(map[string][]byte)
-		}
-		credSecret.Data["credentials.json"] = credsJSON
-		return nil
+		return mutate(credSecret)
 	})
-	return err
+	if err == nil {
+		return nil
+	}
+
+	// Recovery: the cached client missed a pre-existing Secret (label-
+	// filtered out by the manager cache, see PR #87) and the underlying
+	// Create surfaced IsAlreadyExists from the API server. Re-read via
+	// APIReader (uncached), re-apply the mutation, and persist via
+	// Update on the cached client.
+	if !errors.IsAlreadyExists(err) {
+		return err
+	}
+	key := client.ObjectKey{Name: tunnel.Spec.GeneratedSecretName, Namespace: tunnel.Namespace}
+	var fresh corev1.Secret
+	if getErr := r.APIReader.Get(ctx, key, &fresh); getErr != nil {
+		return fmt.Errorf("recover credentials secret after IsAlreadyExists: %w", getErr)
+	}
+	if mErr := mutate(&fresh); mErr != nil {
+		return mErr
+	}
+	if updErr := r.Update(ctx, &fresh); updErr != nil {
+		return fmt.Errorf("update credentials secret after IsAlreadyExists recovery: %w", updErr)
+	}
+	return nil
 }
 
 // ensureCredentialsSecretExists ensures a credentials Secret exists for an
@@ -304,7 +331,11 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecretExists(ctx context.C
 	logger := log.FromContext(ctx)
 
 	var existing corev1.Secret
-	err := r.Get(ctx, client.ObjectKey{Name: tunnel.Spec.GeneratedSecretName, Namespace: tunnel.Namespace}, &existing)
+	// Use APIReader (uncached) because the manager cache filters
+	// Secrets by cloudflare.io/managed=true. A pre-existing unlabeled
+	// Secret would otherwise return NotFound here even though it is
+	// present on the API server.
+	err := r.APIReader.Get(ctx, client.ObjectKey{Name: tunnel.Spec.GeneratedSecretName, Namespace: tunnel.Namespace}, &existing)
 	switch {
 	case errors.IsNotFound(err):
 		logger.Info("creating credentials Secret for adopted tunnel with empty TunnelSecret; user must provide TunnelSecret manually",

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -314,7 +314,7 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context
 		return fmt.Errorf("recover credentials secret after IsAlreadyExists: %w", getErr)
 	}
 	if mErr := mutate(&fresh); mErr != nil {
-		return mErr
+		return fmt.Errorf("mutate credentials secret after IsAlreadyExists recovery: %w", mErr)
 	}
 	if updErr := r.Update(ctx, &fresh); updErr != nil {
 		return fmt.Errorf("update credentials secret after IsAlreadyExists recovery: %w", updErr)

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -47,6 +47,12 @@ import (
 // CloudflareTunnelReconciler reconciles a CloudflareTunnel object
 type CloudflareTunnelReconciler struct {
 	client.Client
+	// APIReader bypasses the manager's label-filtered cache for reads
+	// that need to see the actual API-server state regardless of the
+	// cloudflare.io/managed=true label gate (introduced in PR #87).
+	// Used by ensureCredentialsSecretExists to detect pre-existing
+	// unlabeled Secrets that the cache would otherwise hide.
+	APIReader      client.Reader
 	Scheme         *runtime.Scheme
 	Recorder       record.EventRecorder
 	ClientFactory  CredentialFactory

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -325,8 +325,14 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecret(ctx context.Context
 // ensureCredentialsSecretExists ensures a credentials Secret exists for an
 // adopted tunnel. Cloudflare doesn't return the original TunnelSecret on
 // adoption, so the Secret is created with an empty TunnelSecret and the user
-// must fill it in manually. If a Secret already exists with a matching TunnelID
-// it is preserved; otherwise it is (over)written with the empty template.
+// must fill it in manually.
+//
+// Decision tree:
+//  1. NotFound → create with empty TunnelSecret template.
+//  2. Already operator-owned AND secretMatchesTunnel → no-op (steady-state).
+//  3. Owned by a different controller → actionable error (wrapped AlreadyOwnedError).
+//  4. Unowned/not operator-labeled → adopt (label-merge + OwnerRef, no Data touch),
+//     then either return nil (data matches) or overwrite with empty template (stale data).
 func (r *CloudflareTunnelReconciler) ensureCredentialsSecretExists(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel, accountID string) error {
 	logger := log.FromContext(ctx)
 
@@ -340,16 +346,85 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecretExists(ctx context.C
 	case errors.IsNotFound(err):
 		logger.Info("creating credentials Secret for adopted tunnel with empty TunnelSecret; user must provide TunnelSecret manually",
 			"secretName", tunnel.Spec.GeneratedSecretName)
+		return r.ensureCredentialsSecret(ctx, tunnel, accountID, "")
 	case err != nil:
 		return fmt.Errorf("get credentials secret: %w", err)
-	case secretMatchesTunnel(&existing, tunnel.Status.TunnelID):
-		return nil
-	default:
-		logger.Info("credentials Secret does not match adopted tunnel; overwriting with empty TunnelSecret, user must refill",
-			"secretName", tunnel.Spec.GeneratedSecretName, "tunnelID", tunnel.Status.TunnelID)
 	}
 
+	// Existing Secret found. Three branches:
+	//   1. Already operator-owned and matches the tunnel    → no-op.
+	//   2. Owned by a different controller                  → actionable error.
+	//   3. Unowned (or only operator-owned mismatch)        → adopt, then
+	//      either return (data matches) or fall through to overwrite.
+	if controlledByThisTunnel(&existing, tunnel) && secretMatchesTunnel(&existing, tunnel.Status.TunnelID) {
+		return nil
+	}
+	if otherCtrl := controlledByOther(&existing, tunnel); otherCtrl != nil {
+		return fmt.Errorf(
+			"credentials Secret %q is already owned by %s/%s (UID %s); "+
+				"rename spec.generatedSecretName or remove the conflicting owner to allow adoption: %w",
+			tunnel.Spec.GeneratedSecretName, otherCtrl.Kind, otherCtrl.Name, otherCtrl.UID,
+			&controllerutil.AlreadyOwnedError{Object: &existing, Owner: *otherCtrl},
+		)
+	}
+
+	if err := r.adoptCredentialsSecret(ctx, tunnel, &existing); err != nil {
+		return err
+	}
+
+	if secretMatchesTunnel(&existing, tunnel.Status.TunnelID) {
+		logger.Info("adopted pre-existing credentials Secret; data preserved",
+			"secretName", tunnel.Spec.GeneratedSecretName, "tunnelID", tunnel.Status.TunnelID)
+		return nil
+	}
+	logger.Info("adopted pre-existing credentials Secret but data does not match adopted tunnel; overwriting with empty TunnelSecret, user must refill",
+		"secretName", tunnel.Spec.GeneratedSecretName, "tunnelID", tunnel.Status.TunnelID)
 	return r.ensureCredentialsSecret(ctx, tunnel, accountID, "")
+}
+
+// adoptCredentialsSecret takes ownership of an existing Secret without
+// modifying its Data. Sets controller OwnerReference and merges
+// connectorLabels into existing labels. Used for the adoption path of
+// pre-existing unlabeled Secrets (see issue #90).
+func (r *CloudflareTunnelReconciler) adoptCredentialsSecret(ctx context.Context, tunnel *cloudflarev1alpha1.CloudflareTunnel, existing *corev1.Secret) error {
+	if err := controllerutil.SetControllerReference(tunnel, existing, r.Scheme); err != nil {
+		return fmt.Errorf("set controller reference on credentials secret: %w", err)
+	}
+	if existing.Labels == nil {
+		existing.Labels = map[string]string{}
+	}
+	for k, v := range connectorLabels(tunnel) {
+		existing.Labels[k] = v
+	}
+	if err := r.Update(ctx, existing); err != nil {
+		return fmt.Errorf("adopt credentials secret: %w", err)
+	}
+	return nil
+}
+
+// controlledByThisTunnel reports whether s has a controller
+// OwnerReference whose UID matches tun.
+func controlledByThisTunnel(s *corev1.Secret, tun *cloudflarev1alpha1.CloudflareTunnel) bool {
+	for _, ref := range s.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller && ref.UID == tun.UID {
+			return true
+		}
+	}
+	return false
+}
+
+// controlledByOther returns the controller OwnerReference if s has a
+// controller other than tun. Returns nil if s has no controller or the
+// existing controller is tun itself.
+func controlledByOther(s *corev1.Secret, tun *cloudflarev1alpha1.CloudflareTunnel) *metav1.OwnerReference {
+	refs := s.GetOwnerReferences()
+	for i := range refs {
+		ref := &refs[i]
+		if ref.Controller != nil && *ref.Controller && ref.UID != tun.UID {
+			return ref
+		}
+	}
+	return nil
 }
 
 // secretMatchesTunnel reports whether secret's credentials.json is parseable

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -368,16 +368,23 @@ func (r *CloudflareTunnelReconciler) ensureCredentialsSecretExists(ctx context.C
 		)
 	}
 
-	if err := r.adoptCredentialsSecret(ctx, tunnel, &existing); err != nil {
-		return err
+	// Only run adoption when we don't already own the Secret.
+	// Adoption is the SetControllerReference + label-merge work; if we
+	// already own it, that work is a no-op and the redundant Update
+	// would just produce a spurious resource-version conflict on busy
+	// clusters.
+	if !controlledByThisTunnel(&existing, tunnel) {
+		if err := r.adoptCredentialsSecret(ctx, tunnel, &existing); err != nil {
+			return err
+		}
 	}
 
 	if secretMatchesTunnel(&existing, tunnel.Status.TunnelID) {
-		logger.Info("adopted pre-existing credentials Secret; data preserved",
+		logger.Info("credentials Secret matches adopted tunnel; data preserved",
 			"secretName", tunnel.Spec.GeneratedSecretName, "tunnelID", tunnel.Status.TunnelID)
 		return nil
 	}
-	logger.Info("adopted pre-existing credentials Secret but data does not match adopted tunnel; overwriting with empty TunnelSecret, user must refill",
+	logger.Info("credentials Secret does not match adopted tunnel; overwriting with empty TunnelSecret, user must refill",
 		"secretName", tunnel.Spec.GeneratedSecretName, "tunnelID", tunnel.Status.TunnelID)
 	return r.ensureCredentialsSecret(ctx, tunnel, accountID, "")
 }

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -1140,5 +1141,203 @@ func TestEnsureCredentialsSecret_RecoversFromAlreadyExists(t *testing.T) {
 	if !bytes.Equal(got.Data["credentials.json"], wantData) {
 		t.Errorf("credentials.json mismatch:\n got=%s\nwant=%s",
 			string(got.Data["credentials.json"]), string(wantData))
+	}
+}
+
+// TestEnsureCredentialsSecretExists_AdoptsExistingUnlabeledSecret_PreservesData
+// covers the production case from issue #90: a pre-existing unlabeled
+// credentials Secret (created by ExternalSecrets / SOPS / hand-applied)
+// already contains valid credentials.json. The operator must adopt it
+// — add the cloudflare.io/managed=true label and an OwnerRef pointing
+// at the tunnel — without touching the Data field.
+func TestEnsureCredentialsSecretExists_AdoptsExistingUnlabeledSecret_PreservesData(t *testing.T) {
+	s := testScheme(t)
+
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			GeneratedSecretName: "demo-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{TunnelID: "tid-1"},
+	}
+
+	originalData := []byte(`{"AccountTag":"acct-1","TunnelSecret":"user-secret","TunnelID":"tid-1"}`)
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-creds",
+			Namespace: "default",
+			Labels:    map[string]string{"team": "infra"},
+		},
+		Data: map[string][]byte{
+			"credentials.json": originalData,
+		},
+	}
+
+	// Single fake client serves as both Client and APIReader: this case
+	// is "Secret exists, cached client also sees it" — once adopted the
+	// Secret will be cache-visible. The bug fix is correct in either
+	// configuration; this test verifies the adoption logic itself.
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun, preExisting).Build()
+	r := &CloudflareTunnelReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(8),
+	}
+
+	if err := r.ensureCredentialsSecretExists(context.Background(), tun, "acct-1"); err != nil {
+		t.Fatalf("ensureCredentialsSecretExists: %v", err)
+	}
+
+	var got corev1.Secret
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Name: "demo-creds", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get post-adoption: %v", err)
+	}
+
+	// Adoption invariants:
+	if v := got.Labels["cloudflare.io/managed"]; v != "true" {
+		t.Errorf(`expected cloudflare.io/managed=true after adoption, got %q`, v)
+	}
+	if v := got.Labels["team"]; v != "infra" {
+		t.Errorf(`pre-existing label team=infra clobbered, got %q`, v)
+	}
+	var hasOwnerRef bool
+	for _, ref := range got.OwnerReferences {
+		if ref.UID == tun.UID && ref.Controller != nil && *ref.Controller {
+			hasOwnerRef = true
+			break
+		}
+	}
+	if !hasOwnerRef {
+		t.Errorf("expected controller OwnerReference to tunnel UID %q after adoption, got %+v",
+			tun.UID, got.OwnerReferences)
+	}
+	if !bytes.Equal(got.Data["credentials.json"], originalData) {
+		t.Errorf("credentials.json modified during adoption (must be byte-identical):\n got=%s\nwant=%s",
+			string(got.Data["credentials.json"]), string(originalData))
+	}
+}
+
+// TestEnsureCredentialsSecretExists_AdoptsExistingUnlabeledSecret_StaleData_FallsThroughToEmptyOverwrite
+// covers the case where the pre-existing Secret has stale data — the
+// TunnelID inside doesn't match the adopted tunnel's TunnelID. The
+// operator should still take ownership, then fall through to the
+// empty-template overwrite path so the Secret is correctly shaped for
+// the user to manually fill in TunnelSecret.
+func TestEnsureCredentialsSecretExists_AdoptsExistingUnlabeledSecret_StaleData_FallsThroughToEmptyOverwrite(t *testing.T) {
+	s := testScheme(t)
+
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			GeneratedSecretName: "demo-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{TunnelID: "tid-NEW"},
+	}
+
+	// Pre-existing data has a different TunnelID than the adopted one.
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-creds",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"credentials.json": []byte(`{"AccountTag":"acct-old","TunnelSecret":"old-secret","TunnelID":"tid-OLD"}`),
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun, preExisting).Build()
+	r := &CloudflareTunnelReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(8),
+	}
+
+	if err := r.ensureCredentialsSecretExists(context.Background(), tun, "acct-NEW"); err != nil {
+		t.Fatalf("ensureCredentialsSecretExists: %v", err)
+	}
+
+	var got corev1.Secret
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Name: "demo-creds", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get post-adoption: %v", err)
+	}
+
+	// Adoption ownership invariants apply.
+	if v := got.Labels["cloudflare.io/managed"]; v != "true" {
+		t.Errorf(`expected cloudflare.io/managed=true after adoption, got %q`, v)
+	}
+	// Stale data must be replaced by the empty-template payload.
+	wantData := []byte(`{"AccountTag":"acct-NEW","TunnelID":"tid-NEW","TunnelSecret":""}`)
+	if !bytes.Equal(got.Data["credentials.json"], wantData) {
+		t.Errorf("credentials.json should have been overwritten with empty template:\n got=%s\nwant=%s",
+			string(got.Data["credentials.json"]), string(wantData))
+	}
+}
+
+// TestEnsureCredentialsSecretExists_AlreadyOwnedByOtherController_ReturnsActionableError
+// covers the safety case: the pre-existing Secret is already owned by
+// some other CR (e.g. the user accidentally pointed two CloudflareTunnels
+// at the same generatedSecretName). The operator must NOT silently
+// take over; it must return an actionable error.
+func TestEnsureCredentialsSecretExists_AlreadyOwnedByOtherController_ReturnsActionableError(t *testing.T) {
+	s := testScheme(t)
+
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			GeneratedSecretName: "demo-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{TunnelID: "tid-1"},
+	}
+
+	otherCtrl := true
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-creds",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "cloudflare.io/v1alpha1",
+				Kind:       "CloudflareTunnel",
+				Name:       "other-tunnel",
+				UID:        "uid-OTHER",
+				Controller: &otherCtrl,
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun, preExisting).Build()
+	r := &CloudflareTunnelReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(8),
+	}
+
+	err := r.ensureCredentialsSecretExists(context.Background(), tun, "acct-1")
+	if err == nil {
+		t.Fatalf("expected error for Secret owned by other controller, got nil")
+	}
+	var ownedErr *controllerutil.AlreadyOwnedError
+	if !errors.As(err, &ownedErr) {
+		t.Errorf("expected wrapped *controllerutil.AlreadyOwnedError, got %T: %v", err, err)
+	}
+	// Confirm error message is actionable for the user.
+	if !strings.Contains(err.Error(), "demo-creds") || !strings.Contains(err.Error(), "uid-OTHER") {
+		t.Errorf("error message should reference the conflicting Secret and owner, got: %v", err)
 	}
 }

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -1341,3 +1341,74 @@ func TestEnsureCredentialsSecretExists_AlreadyOwnedByOtherController_ReturnsActi
 		t.Errorf("error message should reference the conflicting Secret and owner, got: %v", err)
 	}
 }
+
+// TestEnsureCredentialsSecretExists_AlreadyOwnedStaleData_OverwritesWithoutRedundantAdopt
+// covers the case where an already-operator-owned Secret has stale
+// data — TunnelID inside doesn't match the tunnel's current TunnelID.
+// The fix avoids calling the adoption helper (which would issue a
+// no-op Update against the same controller ref) and goes straight to
+// the empty-template overwrite.
+func TestEnsureCredentialsSecretExists_AlreadyOwnedStaleData_OverwritesWithoutRedundantAdopt(t *testing.T) {
+	s := testScheme(t)
+
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			GeneratedSecretName: "demo-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{TunnelID: "tid-NEW"},
+	}
+
+	// Pre-existing Secret is already controlled by this tunnel but holds stale data.
+	yes := true
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-creds",
+			Namespace: "default",
+			Labels:    map[string]string{"cloudflare.io/managed": "true"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: cloudflarev1alpha1.GroupVersion.String(),
+				Kind:       "CloudflareTunnel",
+				Name:       "demo",
+				UID:        tun.UID,
+				Controller: &yes,
+			}},
+		},
+		Data: map[string][]byte{
+			"credentials.json": []byte(`{"AccountTag":"acct-old","TunnelSecret":"old-secret","TunnelID":"tid-OLD"}`),
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun, preExisting).Build()
+	r := &CloudflareTunnelReconciler{
+		Client:    c,
+		APIReader: c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(8),
+	}
+
+	if err := r.ensureCredentialsSecretExists(context.Background(), tun, "acct-NEW"); err != nil {
+		t.Fatalf("ensureCredentialsSecretExists: %v", err)
+	}
+
+	var got corev1.Secret
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Name: "demo-creds", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get post-overwrite: %v", err)
+	}
+
+	// Stale data must have been replaced by the empty-template payload.
+	wantData := []byte(`{"AccountTag":"acct-NEW","TunnelID":"tid-NEW","TunnelSecret":""}`)
+	if !bytes.Equal(got.Data["credentials.json"], wantData) {
+		t.Errorf("credentials.json should have been overwritten with empty template:\n got=%s\nwant=%s",
+			string(got.Data["credentials.json"]), string(wantData))
+	}
+	// Ownership invariants still hold.
+	if v := got.Labels["cloudflare.io/managed"]; v != "true" {
+		t.Errorf(`expected cloudflare.io/managed=true preserved, got %q`, v)
+	}
+}

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -134,6 +134,7 @@ func buildTunnelReconciler(t *testing.T, mock *mockTunnelClient, objs ...client.
 
 	return &CloudflareTunnelReconciler{
 		Client:        fakeClient,
+		APIReader:     fakeClient,
 		Scheme:        s,
 		Recorder:      record.NewFakeRecorder(10),
 		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
@@ -462,6 +463,7 @@ func buildInterceptedTunnelReconciler(t *testing.T, mock *mockTunnelClient, func
 
 	return &CloudflareTunnelReconciler{
 		Client:         wrapped,
+		APIReader:      wrapped,
 		Scheme:         s,
 		Recorder:       record.NewFakeRecorder(10),
 		ClientFactory:  cfclient.NewClientFactory(wrapped, wrapped),
@@ -671,6 +673,7 @@ func TestCloudflareTunnelReconciler_BadRequest_EmitsInvalidSpecEvent(t *testing.
 	fakeRec := record.NewFakeRecorder(10)
 	r := &CloudflareTunnelReconciler{
 		Client:        fakeClient,
+		APIReader:     fakeClient,
 		Scheme:        s,
 		Recorder:      fakeRec,
 		ClientFactory: cfclient.NewClientFactory(fakeClient, fakeClient),
@@ -718,9 +721,10 @@ func TestEnsureCredentialsSecret_AppliesManagedLabel(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun).Build()
 	r := &CloudflareTunnelReconciler{
-		Client:   c,
-		Scheme:   s,
-		Recorder: record.NewFakeRecorder(8),
+		Client:    c,
+		APIReader: c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(8),
 	}
 
 	if err := r.ensureCredentialsSecret(context.Background(), tun, "acct-1", "tunnel-secret"); err != nil {
@@ -773,9 +777,10 @@ func TestEnsureCredentialsSecret_PreservesExternalLabels(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tun, preExisting).Build()
 	r := &CloudflareTunnelReconciler{
-		Client:   c,
-		Scheme:   s,
-		Recorder: record.NewFakeRecorder(8),
+		Client:    c,
+		APIReader: c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(8),
 	}
 
 	if err := r.ensureCredentialsSecret(context.Background(), tun, "acct-1", "tunnel-secret"); err != nil {

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1037,5 +1038,107 @@ func TestCloudflareTunnelReconcile_DeletionPath_PhasePreserved(t *testing.T) {
 	if fetched.Status.Phase != cloudflarev1alpha1.PhaseDeleting {
 		t.Errorf("expected Phase=%s, got %s — failReconcile inside reconcileDelete is overwriting Phase via derivePhase",
 			cloudflarev1alpha1.PhaseDeleting, fetched.Status.Phase)
+	}
+}
+
+// cacheFilteredClient simulates a label-filtered manager cache: Get on
+// a Secret named "demo-creds" returns NotFound (as if the cache filter
+// excluded it), while Create returns IsAlreadyExists (the API server
+// has it). Update falls through to the inner client (which holds the
+// Secret so writes succeed), modelling the real behaviour where the
+// cached client's Update talks to the same API server as APIReader.
+type cacheFilteredClient struct {
+	client.Client
+	getCount    int
+	createCount int
+}
+
+func (c *cacheFilteredClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*corev1.Secret); ok && key.Name == "demo-creds" && c.getCount == 0 {
+		c.getCount++
+		return apierrors.NewNotFound(corev1.Resource("secrets"), key.Name)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *cacheFilteredClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if sec, ok := obj.(*corev1.Secret); ok && sec.Name == "demo-creds" && c.createCount == 0 {
+		c.createCount++
+		return apierrors.NewAlreadyExists(corev1.Resource("secrets"), sec.Name)
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+// TestEnsureCredentialsSecret_RecoversFromAlreadyExists verifies that
+// when the cached client misses a pre-existing unlabeled Secret (due to
+// the label-filter gate from PR #87) and the API server rejects the
+// Create with IsAlreadyExists, the recovery branch loads the actual
+// state via APIReader and persists the desired mutation via Update.
+func TestEnsureCredentialsSecret_RecoversFromAlreadyExists(t *testing.T) {
+	s := testScheme(t)
+
+	tun := &cloudflarev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: cloudflarev1alpha1.CloudflareTunnelSpec{
+			GeneratedSecretName: "demo-creds",
+		},
+		Status: cloudflarev1alpha1.CloudflareTunnelStatus{TunnelID: "tid-1"},
+	}
+
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-creds",
+			Namespace: "default",
+			Labels:    map[string]string{"team": "infra"},
+		},
+		Data: map[string][]byte{
+			"credentials.json": []byte(`{"AccountTag":"acct-1","TunnelSecret":"user-secret","TunnelID":"tid-1"}`),
+		},
+	}
+
+	// The inner fake has both tun and the pre-existing Secret so that
+	// r.Client.Update (the recovery write) succeeds. The cacheFilteredClient
+	// wrapper intercepts Get to return NotFound on the first call (simulating
+	// the label-filter cache miss) and intercepts Create to return
+	// IsAlreadyExists (simulating the API-server conflict).
+	inner := fake.NewClientBuilder().WithScheme(s).WithObjects(tun, preExisting).Build()
+	cached := &cacheFilteredClient{Client: inner}
+	// APIReader shares the same fake store as the inner client, matching
+	// production where both talk to the same API server.
+	apiReader := inner
+
+	r := &CloudflareTunnelReconciler{
+		Client:    cached,
+		APIReader: apiReader,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(8),
+	}
+
+	if err := r.ensureCredentialsSecret(context.Background(), tun, "acct-1", "user-secret"); err != nil {
+		t.Fatalf("ensureCredentialsSecret: %v", err)
+	}
+
+	// After recovery the operator updated the Secret. Read post-state
+	// from the shared store via APIReader.
+	var got corev1.Secret
+	if err := apiReader.Get(context.Background(),
+		client.ObjectKey{Name: "demo-creds", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get secret post-recovery: %v", err)
+	}
+
+	if v := got.Labels["cloudflare.io/managed"]; v != "true" {
+		t.Errorf(`expected cloudflare.io/managed=true after recovery, got %q`, v)
+	}
+	if v := got.Labels["team"]; v != "infra" {
+		t.Errorf(`pre-existing label team=infra clobbered, got %q`, v)
+	}
+	wantData := []byte(`{"AccountTag":"acct-1","TunnelID":"tid-1","TunnelSecret":"user-secret"}`)
+	if !bytes.Equal(got.Data["credentials.json"], wantData) {
+		t.Errorf("credentials.json mismatch:\n got=%s\nwant=%s",
+			string(got.Data["credentials.json"]), string(wantData))
 	}
 }


### PR DESCRIPTION
## Summary

Fixes two user-reported bugs against v0.14.0. Both are pre-existing (not regressions from the Phase work):

- **#90 (production bug):** `CloudflareTunnel` adoption fails with `secrets "<name>" already exists` when a credentials Secret already exists in the namespace. Latent regression from PR #87's label-gated Secret cache filter — the cache returns NotFound for unlabeled Secrets, so the operator tries to Create, and the API server rejects with AlreadyExists.
- **#91 (UX bug):** chart's `controller.strategy: Recreate` default causes ~10s downtime on Helm upgrades when users opt into HA via `controller.replicas: 2` (PDB doesn't gate Deployment rollouts since they aren't voluntary disruptions).

## How

**Tunnel adoption (`fix/tunnel-adoption-and-chart-rollout` 1–4):**
- Add `APIReader client.Reader` field to `CloudflareTunnelReconciler`, wired from `mgr.GetAPIReader()` — uncached read that bypasses the `cloudflare.io/managed=true` label filter.
- Switch `ensureCredentialsSecretExists` to use `r.APIReader.Get` for the existence check.
- Add `apierrors.IsAlreadyExists` recovery branch in `ensureCredentialsSecret` (re-Get via APIReader, re-apply mutate, Update) as belt-and-suspenders for any other cache/server skew.
- Add adoption decision tree: pre-existing unlabeled Secret with valid `credentials.json` → take ownership (SetControllerReference + label merge) **without modifying `credentials.json`**. Already-owned-stale-data → skip the redundant adoption Update and overwrite directly. Owned by a different controller → wrapped `*controllerutil.AlreadyOwnedError` with actionable message ("rename spec.generatedSecretName or remove the conflicting owner").

**Chart strategy (commit 5):**
- Default `controller.strategy: "RollingUpdate"` (previously `Recreate`).
- New `controller.rollingUpdate.{maxSurge,maxUnavailable}` values block, defaults `1` and `"0"` (`"0"` quoted to survive Go template's falsy-zero handling under the bjw-s common library's `{{- with .unavailable }}` guard; the rendered Deployment has `maxUnavailable: 0` as integer).
- Back-compat: users with `controller.strategy: Recreate` (scalar string) continue to work — the bjw-s common library validates `strategy` as a string, so the dual-form-template approach the original spec proposed couldn't work; the implementation adapted to keep `strategy` scalar and add the rollingUpdate sibling block.

## Notable

- **Adopt-and-preserve invariant:** the adoption path never modifies `existing.Data`. Tests assert `bytes.Equal(post.Data, pre.Data)` byte-for-byte.
- **Decision tree ordering** (in `ensureCredentialsSecretExists`): NotFound → create empty; already-mine + matches → no-op; owned by other controller → actionable error; unowned → adopt; already-mine + stale OR adopted + stale → empty-template overwrite.
- **`AlreadyOwnedError` is `errors.As`-able** through one layer of `fmt.Errorf` wrapping — verified in tests.
- **No CRD changes** — Tunnel-specific Secret-handling fix only.

## Test plan

- [x] `make test` green (controller package 86.1% coverage).
- [x] `go build ./...` clean.
- [x] 5 new tests pass:
  - `TestEnsureCredentialsSecret_RecoversFromAlreadyExists`
  - `TestEnsureCredentialsSecretExists_AdoptsExistingUnlabeledSecret_PreservesData`
  - `TestEnsureCredentialsSecretExists_AdoptsExistingUnlabeledSecret_StaleData_FallsThroughToEmptyOverwrite`
  - `TestEnsureCredentialsSecretExists_AlreadyOwnedByOtherController_ReturnsActionableError`
  - `TestEnsureCredentialsSecretExists_AlreadyOwnedStaleData_OverwritesWithoutRedundantAdopt`
- [x] `helm template chart/ --set controller.replicas=2` renders `strategy.type: RollingUpdate` with `maxSurge:1, maxUnavailable:0`.
- [x] `helm template chart/ --set controller.strategy=Recreate` renders `strategy.type: Recreate` (scalar back-compat).
- [x] `make sync-helm-crds` is a no-op.
- [ ] Manual smoke-test against the reporter's scenario: pre-create a Secret with the target name (no labels, valid credentials.json from manual tunnel setup), create a `CloudflareTunnel` CR pointing at the existing tunnel; observe `Phase=Ready` and the Secret picks up `cloudflare.io/managed=true` + OwnerRef without data change.

## Commits (6)

```
ad6655e refactor(tunnel): skip adopt when Secret is already operator-owned
b0c7211 fix(chart): default to RollingUpdate strategy for zero-downtime HA upgrades
15e8cc8 fix(tunnel): adopt pre-existing credentials Secret without overwriting
dbf8828 refactor(tunnel): wrap mutate error in IsAlreadyExists recovery branch
ec620d1 fix(tunnel): use APIReader for credentials Secret existence check
22b5d12 refactor(tunnel): inject APIReader into CloudflareTunnelReconciler
```

Closes #90
Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)