### PR TITLE
feat(connector): default base name to cloudflared-<tunnel> with auto-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **CloudflareTunnel connector default rename.** The default base name for the operator-managed connector resources is now `cloudflared-<tunnel-name>` (was `<tunnel-name>-connector`). New resource names: Deployment / ServiceAccount `cloudflared-<tun>`, ConfigMap `cloudflared-<tun>-config`, PodDisruptionBudget `cloudflared-<tun>-pdb`. Pods now appear in `kubectl get pods` as `cloudflared-<tun>-...`, matching the Cloudflare upstream Helm chart. The connector reconciler automatically deletes the legacy `<tun>-connector` family of resources owned by your `CloudflareTunnel` on the next reconcile after upgrade, with no traffic gap (the new connector comes up first; both briefly coexist; legacy is then deleted). Users who set `spec.connector.nameOverride` are unaffected and the auto-cleanup is suppressed for them. Update any monitoring/alert filters that match the old pod-name prefix. (#93)
+
 ## [0.14.1](https://github.com/jacaudi/cloudflare-operator/compare/v0.14.0...v0.14.1) (2026-05-06)
 
 ### Bug Fixes

--- a/api/v1alpha1/cloudflaretunnel_types.go
+++ b/api/v1alpha1/cloudflaretunnel_types.go
@@ -96,9 +96,15 @@ type ConnectorSpec struct {
 	// NameOverride sets the base name for the operator-managed connector
 	// resources. When set, the Deployment and ServiceAccount are named
 	// exactly NameOverride and the ConfigMap is named "<NameOverride>-config".
-	// When unset, the operator falls back to "<tunnel.metadata.name>-connector"
-	// for the Deployment + ServiceAccount and "<tunnel.metadata.name>-connector-config"
-	// for the ConfigMap.
+	// When unset, names default to the "cloudflared-<tunnel.metadata.name>"
+	// family (Deployment and ServiceAccount) and
+	// "cloudflared-<tunnel.metadata.name>-config" (ConfigMap).
+	//
+	// On upgrade from operator versions that defaulted the base to
+	// "<tunnel.metadata.name>-connector", the connector reconciler
+	// automatically deletes the legacy-named resources owned by this
+	// CloudflareTunnel after the new-named resources are running. Setting
+	// NameOverride suppresses this auto-cleanup; the user is in charge.
 	//
 	// Changing NameOverride on a live tunnel reconciles new resources at the
 	// new name; the old resources are not cleaned up automatically (see #52).

--- a/chart/crds/cloudflare.io_cloudflaretunnels.yaml
+++ b/chart/crds/cloudflare.io_cloudflaretunnels.yaml
@@ -1010,9 +1010,15 @@ spec:
                       NameOverride sets the base name for the operator-managed connector
                       resources. When set, the Deployment and ServiceAccount are named
                       exactly NameOverride and the ConfigMap is named "<NameOverride>-config".
-                      When unset, the operator falls back to "<tunnel.metadata.name>-connector"
-                      for the Deployment + ServiceAccount and "<tunnel.metadata.name>-connector-config"
-                      for the ConfigMap.
+                      When unset, names default to the "cloudflared-<tunnel.metadata.name>"
+                      family (Deployment and ServiceAccount) and
+                      "cloudflared-<tunnel.metadata.name>-config" (ConfigMap).
+
+                      On upgrade from operator versions that defaulted the base to
+                      "<tunnel.metadata.name>-connector", the connector reconciler
+                      automatically deletes the legacy-named resources owned by this
+                      CloudflareTunnel after the new-named resources are running. Setting
+                      NameOverride suppresses this auto-cleanup; the user is in charge.
 
                       Changing NameOverride on a live tunnel reconciles new resources at the
                       new name; the old resources are not cleaned up automatically (see #52).

--- a/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
+++ b/config/crd/bases/cloudflare.io_cloudflaretunnels.yaml
@@ -1010,9 +1010,15 @@ spec:
                       NameOverride sets the base name for the operator-managed connector
                       resources. When set, the Deployment and ServiceAccount are named
                       exactly NameOverride and the ConfigMap is named "<NameOverride>-config".
-                      When unset, the operator falls back to "<tunnel.metadata.name>-connector"
-                      for the Deployment + ServiceAccount and "<tunnel.metadata.name>-connector-config"
-                      for the ConfigMap.
+                      When unset, names default to the "cloudflared-<tunnel.metadata.name>"
+                      family (Deployment and ServiceAccount) and
+                      "cloudflared-<tunnel.metadata.name>-config" (ConfigMap).
+
+                      On upgrade from operator versions that defaulted the base to
+                      "<tunnel.metadata.name>-connector", the connector reconciler
+                      automatically deletes the legacy-named resources owned by this
+                      CloudflareTunnel after the new-named resources are running. Setting
+                      NameOverride suppresses this auto-cleanup; the user is in charge.
 
                       Changing NameOverride on a live tunnel reconciles new resources at the
                       new name; the old resources are not cleaned up automatically (see #52).

--- a/docs/crd-reference.md
+++ b/docs/crd-reference.md
@@ -240,7 +240,7 @@ For the full operator-managed connector story — connector spec fields in depth
 |-------|------|---------|-------------|
 | `enabled` | bool | `false` | When `true`, the operator reconciles a Deployment, ConfigMap, and ServiceAccount running cloudflared. |
 | `replicas` | int | `2` | Number of cloudflared replicas. Minimum `1`. |
-| `nameOverride` | string | `""` | Optional base name for the connector resources. When set, the Deployment and ServiceAccount are named exactly `<nameOverride>` and the ConfigMap is named `<nameOverride>-config`. When unset, the operator falls back to `<tunnel.metadata.name>-connector` (and `…-config` for the ConfigMap). DNS-1123 subdomain validation. See [`tunnels.md`](tunnels.md) for caveats around live renames. |
+| `nameOverride` | string | `""` | Optional base name for the connector resources. When set, the Deployment and ServiceAccount are named exactly `<nameOverride>` and the ConfigMap is named `<nameOverride>-config`. When unset, the operator defaults to `cloudflared-<tunnel.metadata.name>` (and `…-config` for the ConfigMap). DNS-1123 subdomain validation. See [`tunnels.md`](tunnels.md) for caveats around live renames and the auto-cleanup of legacy `<tunnel-name>-connector` resources on upgrade. |
 | `image.repository` | string | `docker.io/cloudflare/cloudflared` | Container image repository. |
 | `image.tag` | string | compile-time default | Container image tag. |
 | `resources` | object | sane defaults | Container `resources` (requests + limits). |
@@ -278,7 +278,7 @@ Conditions: `Ready`, `IngressConfigured`, and (when connector is enabled) `Conne
 
 When `spec.connector.replicas` is `>= 2`, the operator automatically creates two safe-by-default Kubernetes objects to keep the connector available during voluntary disruption:
 
-- A **`PodDisruptionBudget`** named `<connector-base>-pdb` (where `<connector-base>` follows the same naming as the Deployment, including any `spec.connector.nameOverride`) with `minAvailable: 1`. This protects the connector from node drains, autoscaler scale-downs, and manual evictions.
+- A **`PodDisruptionBudget`** named `<connector-base>-pdb` (where `<connector-base>` is `cloudflared-<tunnel-name>` by default, or `<spec.connector.nameOverride>` when set) with `minAvailable: 1`. This protects the connector from node drains, autoscaler scale-downs, and manual evictions.
 - A **`topologySpreadConstraint`** on the connector pod template with `maxSkew: 1`, `topologyKey: kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`. Connector replicas land on different nodes by default. Soft semantics preserve scheduling on small clusters where `replicas > nodes`.
 
 Both defaults are skipped at `replicas: 1`. A `minAvailable: 1` PDB on a single-replica deployment blocks all voluntary disruptions (strictly worse than no PDB), and a `topologySpreadConstraint` across one pod is meaningless.
@@ -311,7 +311,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: <tunnel-name>-connector-pdb
+  name: cloudflared-<tunnel-name>-pdb
 spec:
   minAvailable: 1
   selector:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -176,7 +176,7 @@ If two rules claim the same hostname, one wins and the other gets `TunnelAccepte
 kubectl get deploy -n <namespace> -l cloudflare.io/tunnel=<name>
 
 # Describe it for events
-kubectl describe deploy <tunnel-name>-connector -n <namespace>
+kubectl describe deploy cloudflared-<tunnel-name> -n <namespace>
 ```
 
 Common causes:
@@ -192,7 +192,7 @@ Common causes:
 - **Unowned Deployment** — a Deployment with the expected name exists but was not created by the operator (no ownerRef to the `CloudflareTunnel`). The operator logs `AggregationFailed` and requeues without modifying the Deployment. Check:
 
   ```bash
-  kubectl get deploy <tunnel-name>-connector -n <namespace> \
+  kubectl get deploy cloudflared-<tunnel-name> -n <namespace> \
     -o jsonpath='{.metadata.ownerReferences}'
   ```
 

--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -101,7 +101,7 @@ Operator versions before this change defaulted the base name to
 `<tunnel.metadata.name>-connector`. On upgrade, the connector reconciler
 automatically deletes the legacy-named resources (Deployment,
 ServiceAccount, ConfigMap, PDB) owned by your `CloudflareTunnel` after
-applying the new `cloudflared-<tunnel>` family. The two connectors briefly
+applying the new `cloudflared-<tunnel.metadata.name>` family. The two connectors briefly
 coexist while the new pods come up, so there is no traffic gap. No manual
 action is required for users who did not set `nameOverride`.
 

--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -44,7 +44,7 @@ spec:
     replicas: 2             # default: 2. Minimum: 1.
     nameOverride: ""        # default: "". When set, names the Deployment + SA exactly
                             # this value and the ConfigMap "<nameOverride>-config".
-                            # When unset, names use "<tunnel.metadata.name>-connector".
+                            # When unset, names use "cloudflared-<tunnel.metadata.name>".
     image:
       repository: docker.io/cloudflare/cloudflared
       tag: "2026.3.0"       # omit to use the operator's compile-time default
@@ -66,7 +66,16 @@ At `replicas: 2` or higher the operator additionally creates a `PodDisruptionBud
 
 ### Naming the connector resources
 
-By default the operator names the Deployment, ServiceAccount, and ConfigMap as `<tunnel.metadata.name>-connector`, `<tunnel.metadata.name>-connector`, and `<tunnel.metadata.name>-connector-config`. To use a different name family — for example, to fit existing monitoring labels or GitOps drift expectations — set `spec.connector.nameOverride`:
+By default the operator names the Deployment and ServiceAccount as
+`cloudflared-<tunnel.metadata.name>`, the ConfigMap as
+`cloudflared-<tunnel.metadata.name>-config`, and the PodDisruptionBudget
+(when configured) as `cloudflared-<tunnel.metadata.name>-pdb`. The
+`cloudflared-` prefix matches Cloudflare's official Helm chart and makes
+`kubectl get pods | grep cloudflared` find every operator-managed connector
+cluster-wide.
+
+To use a different name family — for example, to fit existing monitoring
+labels or GitOps drift expectations — set `spec.connector.nameOverride`:
 
 ```yaml
 spec:
@@ -75,15 +84,30 @@ spec:
     nameOverride: cloudflared-prod
 ```
 
-This produces:
+With `nameOverride: cloudflared-prod`, the Deployment and ServiceAccount are
+named `cloudflared-prod` and the ConfigMap is named `cloudflared-prod-config`.
 
-- Deployment: `cloudflared-prod`
-- ServiceAccount: `cloudflared-prod`
-- ConfigMap: `cloudflared-prod-config`
+Changing `nameOverride` on a live tunnel reconciles new resources at the new
+name; the old resources are NOT cleaned up automatically (tracked alongside
+[#52](https://github.com/jacaudi/cloudflare-operator/issues/52)). Delete the
+orphaned Deployment/SA/ConfigMap/PDB manually after a rename.
 
-Changing `nameOverride` on a live tunnel reconciles new resources at the new name; the old resources are NOT cleaned up automatically (tracked alongside [#52](https://github.com/jacaudi/cloudflare-operator/issues/52)). Delete the orphaned Deployment/SA/ConfigMap manually after a rename.
+`nameOverride` must be a valid DNS-1123 subdomain (lowercase alphanumerics
+and `-`, length ≤ 253).
 
-`nameOverride` must be a valid DNS-1123 subdomain (lowercase alphanumerics and `-`, length ≤ 253).
+#### Upgrading from earlier versions
+
+Operator versions before this change defaulted the base name to
+`<tunnel.metadata.name>-connector`. On upgrade, the connector reconciler
+automatically deletes the legacy-named resources (Deployment,
+ServiceAccount, ConfigMap, PDB) owned by your `CloudflareTunnel` after
+applying the new `cloudflared-<tunnel>` family. The two connectors briefly
+coexist while the new pods come up, so there is no traffic gap. No manual
+action is required for users who did not set `nameOverride`.
+
+If you have monitoring queries, alert routes, or external automation that
+filter by the old pod-name prefix (for example, `pod=~"<tunnel>-connector-.*"`),
+update them to match `cloudflared-<tunnel>-.*` after the upgrade.
 
 ### Upgrading the cloudflared image
 
@@ -280,7 +304,7 @@ If you currently run your own cloudflared Deployment:
 4. Set `connector.enabled: true`. The operator creates the managed `ServiceAccount`, `ConfigMap`, and `Deployment`, then compare the rendered ConfigMap against your hand-rolled config:
 
    ```bash
-   kubectl get configmap prod-connector-config -n network -o yaml
+   kubectl get configmap cloudflared-prod-config -n network -o yaml
    ```
 
 5. Once satisfied, delete your hand-rolled Deployment. Brief overlap is safe — cloudflared supports multiple connectors per tunnel.

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -155,7 +155,10 @@ func reconcileConnectorResources(ctx context.Context, c client.Client, tun *clou
 		return err
 	}
 
-	return applyOwnedPDB(ctx, c, tun)
+	if err := applyOwnedPDB(ctx, c, tun); err != nil {
+		return err
+	}
+	return cleanupLegacyConnectorResources(ctx, c, tun)
 }
 
 // applyOwnedPDB ensures the connector PDB matches what

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -108,9 +108,12 @@ func filterRulesForTunnel(all []cloudflarev1alpha1.CloudflareTunnelRule, tunnelN
 
 // reconcileConnectorResources reconciles the ServiceAccount, ConfigMap,
 // Deployment, and PodDisruptionBudget for the operator-managed cloudflared
-// workload. After every apply succeeds, prunes any legacy-named resources
-// owned by tun (see cleanupLegacyConnectorResources) so a successful return
-// implies the rename has converged.
+// workload. After every apply succeeds AND the new connector has at least
+// one Ready replica, prunes any legacy-named resources owned by tun (see
+// cleanupLegacyConnectorResources). A successful return with the new
+// Deployment not yet Ready leaves legacy resources in place; the controller
+// watches owned Deployments and will re-reconcile when ReadyReplicas
+// advances.
 //
 // All apply paths absorb transient optimistic-concurrency conflicts
 // in-process via retry.RetryOnConflict (see applyOwned for the SA + ConfigMap
@@ -161,7 +164,31 @@ func reconcileConnectorResources(ctx context.Context, c client.Client, tun *clou
 	if err := applyOwnedPDB(ctx, c, tun); err != nil {
 		return err
 	}
+	ready, err := connectorDeploymentReady(ctx, c, tun)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		return nil
+	}
 	return cleanupLegacyConnectorResources(ctx, c, tun)
+}
+
+// connectorDeploymentReady reports whether the new-named connector
+// Deployment for tun has at least one Ready replica. Returns false
+// (without error) if the Deployment doesn't yet exist — apply paths
+// create it idempotently and the next reconcile will see it.
+func connectorDeploymentReady(ctx context.Context, c client.Client, tun *cloudflarev1alpha1.CloudflareTunnel) (bool, error) {
+	current := ConnectorNames(tun)
+	var dep appsv1.Deployment
+	err := c.Get(ctx, types.NamespacedName{Name: current.Deployment, Namespace: tun.Namespace}, &dep)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get new Deployment for cleanup gate: %w", err)
+	}
+	return dep.Status.ReadyReplicas >= 1, nil
 }
 
 // applyOwnedPDB ensures the connector PDB matches what
@@ -214,8 +241,8 @@ func applyOwnedPDB(ctx context.Context, c client.Client, tun *cloudflarev1alpha1
 }
 
 // cleanupLegacyConnectorResources removes the legacy "<tunnel>-connector"
-// family of resources owned by tun. It is intended to run AFTER the
-// new-named resources have been applied, so that the rename appears as a
+// family of resources owned by tun. It is intended to run AFTER at least
+// one new-named connector pod is Ready, so that the rename appears as a
 // single transition: both connectors briefly coexist (Cloudflare permits
 // multiple connectors per tunnel — same mechanism as replicas > 1), then
 // the legacy ones are deleted.

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -106,12 +106,15 @@ func filterRulesForTunnel(all []cloudflarev1alpha1.CloudflareTunnelRule, tunnelN
 	return out
 }
 
-// reconcileConnectorResources reconciles the ServiceAccount, ConfigMap, and
-// Deployment for the operator-managed cloudflared workload.
+// reconcileConnectorResources reconciles the ServiceAccount, ConfigMap,
+// Deployment, and PodDisruptionBudget for the operator-managed cloudflared
+// workload. After every apply succeeds, prunes any legacy-named resources
+// owned by tun (see cleanupLegacyConnectorResources) so a successful return
+// implies the rename has converged.
 //
-// All three apply paths absorb transient optimistic-concurrency conflicts
+// All apply paths absorb transient optimistic-concurrency conflicts
 // in-process via retry.RetryOnConflict (see applyOwned for the SA + ConfigMap
-// path; the Deployment path retries inline below). Without this, sustained
+// path; the Deployment and PDB paths retry inline). Without this, sustained
 // conflicts propagate as reconcile errors, the controller workqueue
 // rate-limiter applies exponential backoff up to ~16 minutes, and downstream
 // events (e.g. CR deletion) sit behind that backoff until the operator pod

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -207,6 +207,80 @@ func applyOwnedPDB(ctx context.Context, c client.Client, tun *cloudflarev1alpha1
 	})
 }
 
+// cleanupLegacyConnectorResources removes the legacy "<tunnel>-connector"
+// family of resources owned by tun. It runs at the end of
+// reconcileConnectorResources, after the new-named resources have been
+// applied, so that the rename appears as a single transition: both
+// connectors briefly coexist (Cloudflare permits multiple connectors per
+// tunnel — same mechanism as replicas > 1), then the legacy ones are
+// deleted.
+//
+// Gated on:
+//   - tun.Spec.Connector != nil && tun.Spec.Connector.Enabled (otherwise the
+//     operator is not managing this connector at all).
+//   - tun.Spec.Connector.NameOverride == "" (when the user has set an
+//     override, they own the naming and we must not delete anything that
+//     happens to match the legacy pattern).
+//   - legacy and current base names differ (a defensive guard; today the
+//     two formulas can't collide for any valid tunnel name, but the check
+//     keeps the function correct if either formula changes).
+//
+// For each of the four legacy resource kinds, the function does a Get,
+// skips on IsNotFound, refuses to delete a resource not owned by tun, and
+// otherwise deletes. IsNotFound on Delete is treated as success (race
+// tolerance).
+func cleanupLegacyConnectorResources(ctx context.Context, c client.Client, tun *cloudflarev1alpha1.CloudflareTunnel) error {
+	if tun.Spec.Connector == nil || !tun.Spec.Connector.Enabled {
+		return nil
+	}
+	if tun.Spec.Connector.NameOverride != "" {
+		return nil
+	}
+
+	current := ConnectorNames(tun)
+	legacy := legacyConnectorNames(tun)
+	if legacy.Deployment == current.Deployment {
+		return nil
+	}
+
+	// Order: Deployment first (highest blast radius if left running), then
+	// PDB (which references the deployment via selector labels), then SA
+	// and ConfigMap (small + leaf objects).
+	if err := deleteOwnedByName(ctx, c, &appsv1.Deployment{}, types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, tun.UID); err != nil {
+		return fmt.Errorf("cleanup legacy Deployment: %w", err)
+	}
+	if err := deleteOwnedByName(ctx, c, &policyv1.PodDisruptionBudget{}, types.NamespacedName{Name: legacy.PodDisruptionBudget, Namespace: tun.Namespace}, tun.UID); err != nil {
+		return fmt.Errorf("cleanup legacy PDB: %w", err)
+	}
+	if err := deleteOwnedByName(ctx, c, &corev1.ServiceAccount{}, types.NamespacedName{Name: legacy.ServiceAccount, Namespace: tun.Namespace}, tun.UID); err != nil {
+		return fmt.Errorf("cleanup legacy ServiceAccount: %w", err)
+	}
+	if err := deleteOwnedByName(ctx, c, &corev1.ConfigMap{}, types.NamespacedName{Name: legacy.ConfigMap, Namespace: tun.Namespace}, tun.UID); err != nil {
+		return fmt.Errorf("cleanup legacy ConfigMap: %w", err)
+	}
+	return nil
+}
+
+// deleteOwnedByName Get/Delete-pairs a single named resource. It skips
+// IsNotFound on Get (nothing to do), refuses to delete when the resource
+// is not owner-ref-controlled by ownerUID, and treats IsNotFound on Delete
+// as success.
+func deleteOwnedByName(ctx context.Context, c client.Client, obj client.Object, key types.NamespacedName, ownerUID types.UID) error {
+	if err := c.Get(ctx, key, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get %s: %w", key, err)
+	}
+	if !isOwnedBy(obj.GetOwnerReferences(), ownerUID) {
+		return nil
+	}
+	if err := c.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("delete %s: %w", key, err)
+	}
+	return nil
+}
+
 // applyOwned creates or updates a fully operator-owned resource (SA or
 // ConfigMap). On create: submit as-is. On update: wholesale-overwrite
 // labels, annotations, ownerRefs, and the data fields that Build*

--- a/internal/controller/cloudflaretunnel_aggregation.go
+++ b/internal/controller/cloudflaretunnel_aggregation.go
@@ -208,12 +208,11 @@ func applyOwnedPDB(ctx context.Context, c client.Client, tun *cloudflarev1alpha1
 }
 
 // cleanupLegacyConnectorResources removes the legacy "<tunnel>-connector"
-// family of resources owned by tun. It runs at the end of
-// reconcileConnectorResources, after the new-named resources have been
-// applied, so that the rename appears as a single transition: both
-// connectors briefly coexist (Cloudflare permits multiple connectors per
-// tunnel — same mechanism as replicas > 1), then the legacy ones are
-// deleted.
+// family of resources owned by tun. It is intended to run AFTER the
+// new-named resources have been applied, so that the rename appears as a
+// single transition: both connectors briefly coexist (Cloudflare permits
+// multiple connectors per tunnel — same mechanism as replicas > 1), then
+// the legacy ones are deleted.
 //
 // Gated on:
 //   - tun.Spec.Connector != nil && tun.Spec.Connector.Enabled (otherwise the

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -1554,3 +1554,48 @@ func TestCleanupLegacyConnectorResources_NoOpWhenConnectorDisabled(t *testing.T)
 		t.Errorf("PodDisruptionBudget unexpectedly deleted: %v", err)
 	}
 }
+
+// TestReconcileConnectorResources_CleansUpLegacyOnRename verifies the end-to-end
+// rename: with a legacy-named Deployment, SA, ConfigMap, and PDB already in
+// place (owned by the tunnel), reconcileConnectorResources applies the new
+// "cloudflared-<tun>" family AND deletes the legacy "<tun>-connector" family.
+func TestReconcileConnectorResources_CleansUpLegacyOnRename(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true)
+	dep, sa, cm, pdb := legacyOwnedFixture(tun)
+	c := buildAggFakeClient(tun, dep, sa, cm, pdb)
+
+	agg := Aggregate(tun.Status.TunnelID, nil, nil)
+	if err := reconcileConnectorResources(context.Background(), c, tun, agg); err != nil {
+		t.Fatalf("reconcileConnectorResources: %v", err)
+	}
+
+	// New-named resources exist.
+	current := ConnectorNames(tun)
+	if err := c.Get(context.Background(), types.NamespacedName{Name: current.Deployment, Namespace: tun.Namespace}, &appsv1.Deployment{}); err != nil {
+		t.Errorf("new Deployment %q missing: %v", current.Deployment, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: current.ServiceAccount, Namespace: tun.Namespace}, &corev1.ServiceAccount{}); err != nil {
+		t.Errorf("new ServiceAccount %q missing: %v", current.ServiceAccount, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: current.ConfigMap, Namespace: tun.Namespace}, &corev1.ConfigMap{}); err != nil {
+		t.Errorf("new ConfigMap %q missing: %v", current.ConfigMap, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: current.PodDisruptionBudget, Namespace: tun.Namespace}, &policyv1.PodDisruptionBudget{}); err != nil {
+		t.Errorf("new PDB %q missing: %v", current.PodDisruptionBudget, err)
+	}
+
+	// Legacy-named resources are gone.
+	legacy := legacyConnectorNames(tun)
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, &appsv1.Deployment{}); !apierrors.IsNotFound(err) {
+		t.Errorf("legacy Deployment %q not deleted: err=%v", legacy.Deployment, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ServiceAccount, Namespace: tun.Namespace}, &corev1.ServiceAccount{}); !apierrors.IsNotFound(err) {
+		t.Errorf("legacy ServiceAccount %q not deleted: err=%v", legacy.ServiceAccount, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ConfigMap, Namespace: tun.Namespace}, &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
+		t.Errorf("legacy ConfigMap %q not deleted: err=%v", legacy.ConfigMap, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.PodDisruptionBudget, Namespace: tun.Namespace}, &policyv1.PodDisruptionBudget{}); !apierrors.IsNotFound(err) {
+		t.Errorf("legacy PDB %q not deleted: err=%v", legacy.PodDisruptionBudget, err)
+	}
+}

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -1462,15 +1462,20 @@ func TestCleanupLegacyConnectorResources_DeletesOwned(t *testing.T) {
 }
 
 // TestCleanupLegacyConnectorResources_LeavesUnowned verifies that the cleanup
-// refuses to touch a legacy-named resource that this tunnel does NOT own.
+// refuses to touch a legacy-named resource owned by a DIFFERENT CloudflareTunnel
+// (same name, different UID) — the realistic collision scenario.
 func TestCleanupLegacyConnectorResources_LeavesUnowned(t *testing.T) {
 	tun := newTunnelForAgg("home", "network", true)
 	legacy := legacyConnectorNames(tun)
-	// Same name, but no owner reference at all.
+	// Owner ref points at a DIFFERENT tunnel UID — the legacy Deployment
+	// belongs to someone else, even though the name collides.
+	otherTun := newTunnelForAgg("home", "network", true)
+	otherTun.UID = "some-other-tunnel-uid"
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      legacy.Deployment,
-			Namespace: tun.Namespace,
+			Name:            legacy.Deployment,
+			Namespace:       tun.Namespace,
+			OwnerReferences: connectorOwnerRef(otherTun),
 		},
 	}
 	c := buildAggFakeClient(tun, dep)
@@ -1481,7 +1486,7 @@ func TestCleanupLegacyConnectorResources_LeavesUnowned(t *testing.T) {
 
 	got := &appsv1.Deployment{}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, got); err != nil {
-		t.Fatalf("unowned Deployment was deleted (or get failed): %v", err)
+		t.Fatalf("Deployment owned by another tunnel was deleted (or get failed): %v", err)
 	}
 }
 

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -1555,47 +1555,98 @@ func TestCleanupLegacyConnectorResources_NoOpWhenConnectorDisabled(t *testing.T)
 	}
 }
 
-// TestReconcileConnectorResources_CleansUpLegacyOnRename verifies the end-to-end
-// rename: with a legacy-named Deployment, SA, ConfigMap, and PDB already in
-// place (owned by the tunnel), reconcileConnectorResources applies the new
-// "cloudflared-<tun>" family AND deletes the legacy "<tun>-connector" family.
+// TestReconcileConnectorResources_CleansUpLegacyOnRename verifies the
+// two-phase rename behavior: on the first reconcile (when the new-named
+// connector Deployment has no Ready replicas yet) the new-named resources
+// are applied AND the legacy-named family is left in place, so traffic
+// continues to flow through the legacy pods. After the new Deployment
+// reports at least one Ready replica, a second reconcile prunes the
+// legacy family.
 func TestReconcileConnectorResources_CleansUpLegacyOnRename(t *testing.T) {
 	tun := newTunnelForAgg("home", "network", true)
 	dep, sa, cm, pdb := legacyOwnedFixture(tun)
-	c := buildAggFakeClient(tun, dep, sa, cm, pdb)
+
+	// Build a local fake client that registers Deployment as a status
+	// subresource so we can flip Status.ReadyReplicas via c.Status().Update.
+	// The shared buildAggFakeClient helper only registers status subresource
+	// for v1alpha1 CRDs, which is sufficient for every other test in this
+	// file but not here.
+	s := aggTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(tun, dep, sa, cm, pdb).
+		WithStatusSubresource(tun, &appsv1.Deployment{}).
+		Build()
 
 	agg := Aggregate(tun.Status.TunnelID, nil, nil)
+
+	// --- First reconcile: apply new-named resources, but cleanup is gated
+	// on Deployment readiness so the legacy family must remain.
 	if err := reconcileConnectorResources(context.Background(), c, tun, agg); err != nil {
-		t.Fatalf("reconcileConnectorResources: %v", err)
+		t.Fatalf("reconcileConnectorResources (first): %v", err)
 	}
 
-	// New-named resources exist.
 	current := ConnectorNames(tun)
 	if err := c.Get(context.Background(), types.NamespacedName{Name: current.Deployment, Namespace: tun.Namespace}, &appsv1.Deployment{}); err != nil {
-		t.Errorf("new Deployment %q missing: %v", current.Deployment, err)
+		t.Errorf("new Deployment %q missing after first reconcile: %v", current.Deployment, err)
 	}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: current.ServiceAccount, Namespace: tun.Namespace}, &corev1.ServiceAccount{}); err != nil {
-		t.Errorf("new ServiceAccount %q missing: %v", current.ServiceAccount, err)
+		t.Errorf("new ServiceAccount %q missing after first reconcile: %v", current.ServiceAccount, err)
 	}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: current.ConfigMap, Namespace: tun.Namespace}, &corev1.ConfigMap{}); err != nil {
-		t.Errorf("new ConfigMap %q missing: %v", current.ConfigMap, err)
+		t.Errorf("new ConfigMap %q missing after first reconcile: %v", current.ConfigMap, err)
 	}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: current.PodDisruptionBudget, Namespace: tun.Namespace}, &policyv1.PodDisruptionBudget{}); err != nil {
-		t.Errorf("new PDB %q missing: %v", current.PodDisruptionBudget, err)
+		t.Errorf("new PDB %q missing after first reconcile: %v", current.PodDisruptionBudget, err)
 	}
 
-	// Legacy-named resources are gone.
 	legacy := legacyConnectorNames(tun)
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, &appsv1.Deployment{}); err != nil {
+		t.Errorf("legacy Deployment %q must remain until new connector is Ready, got err=%v", legacy.Deployment, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ServiceAccount, Namespace: tun.Namespace}, &corev1.ServiceAccount{}); err != nil {
+		t.Errorf("legacy ServiceAccount %q must remain until new connector is Ready, got err=%v", legacy.ServiceAccount, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ConfigMap, Namespace: tun.Namespace}, &corev1.ConfigMap{}); err != nil {
+		t.Errorf("legacy ConfigMap %q must remain until new connector is Ready, got err=%v", legacy.ConfigMap, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.PodDisruptionBudget, Namespace: tun.Namespace}, &policyv1.PodDisruptionBudget{}); err != nil {
+		t.Errorf("legacy PDB %q must remain until new connector is Ready, got err=%v", legacy.PodDisruptionBudget, err)
+	}
+
+	// --- Simulate readiness: bump the new Deployment's Status.ReadyReplicas
+	// to 1 via the status subresource, then verify it stuck.
+	var newDep appsv1.Deployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: current.Deployment, Namespace: tun.Namespace}, &newDep); err != nil {
+		t.Fatalf("get new Deployment to flip readiness: %v", err)
+	}
+	newDep.Status.ReadyReplicas = 1
+	if err := c.Status().Update(context.Background(), &newDep); err != nil {
+		t.Fatalf("status update on new Deployment: %v", err)
+	}
+	var verify appsv1.Deployment
+	if err := c.Get(context.Background(), types.NamespacedName{Name: current.Deployment, Namespace: tun.Namespace}, &verify); err != nil {
+		t.Fatalf("re-get new Deployment after status update: %v", err)
+	}
+	if verify.Status.ReadyReplicas != 1 {
+		t.Fatalf("expected ReadyReplicas=1 after Status().Update, got %d", verify.Status.ReadyReplicas)
+	}
+
+	// --- Second reconcile: cleanup gate now opens; legacy family is pruned.
+	if err := reconcileConnectorResources(context.Background(), c, tun, agg); err != nil {
+		t.Fatalf("reconcileConnectorResources (second): %v", err)
+	}
+
 	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, &appsv1.Deployment{}); !apierrors.IsNotFound(err) {
-		t.Errorf("legacy Deployment %q not deleted: err=%v", legacy.Deployment, err)
+		t.Errorf("legacy Deployment %q not deleted after readiness: err=%v", legacy.Deployment, err)
 	}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ServiceAccount, Namespace: tun.Namespace}, &corev1.ServiceAccount{}); !apierrors.IsNotFound(err) {
-		t.Errorf("legacy ServiceAccount %q not deleted: err=%v", legacy.ServiceAccount, err)
+		t.Errorf("legacy ServiceAccount %q not deleted after readiness: err=%v", legacy.ServiceAccount, err)
 	}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ConfigMap, Namespace: tun.Namespace}, &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
-		t.Errorf("legacy ConfigMap %q not deleted: err=%v", legacy.ConfigMap, err)
+		t.Errorf("legacy ConfigMap %q not deleted after readiness: err=%v", legacy.ConfigMap, err)
 	}
 	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.PodDisruptionBudget, Namespace: tun.Namespace}, &policyv1.PodDisruptionBudget{}); !apierrors.IsNotFound(err) {
-		t.Errorf("legacy PDB %q not deleted: err=%v", legacy.PodDisruptionBudget, err)
+		t.Errorf("legacy PDB %q not deleted after readiness: err=%v", legacy.PodDisruptionBudget, err)
 	}
 }

--- a/internal/controller/cloudflaretunnel_aggregation_test.go
+++ b/internal/controller/cloudflaretunnel_aggregation_test.go
@@ -1382,3 +1382,170 @@ func TestApplyOwned_RetriesOnServiceAccountConflict(t *testing.T) {
 		t.Errorf("expected >=3 update attempts, got %d", calls)
 	}
 }
+
+// ---- cleanupLegacyConnectorResources tests ---------------------------------
+
+// legacyOwnedFixture returns the four legacy-named resources for tun, all
+// stamped with a controller owner-ref pointing at tun.UID. Used by the
+// happy-path cleanup test.
+func legacyOwnedFixture(tun *cloudflarev1alpha1.CloudflareTunnel) (*appsv1.Deployment, *corev1.ServiceAccount, *corev1.ConfigMap, *policyv1.PodDisruptionBudget) {
+	legacy := legacyConnectorNames(tun)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            legacy.Deployment,
+			Namespace:       tun.Namespace,
+			OwnerReferences: connectorOwnerRef(tun),
+		},
+	}
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            legacy.ServiceAccount,
+			Namespace:       tun.Namespace,
+			OwnerReferences: connectorOwnerRef(tun),
+		},
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            legacy.ConfigMap,
+			Namespace:       tun.Namespace,
+			OwnerReferences: connectorOwnerRef(tun),
+		},
+	}
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            legacy.PodDisruptionBudget,
+			Namespace:       tun.Namespace,
+			OwnerReferences: connectorOwnerRef(tun),
+		},
+	}
+	return dep, sa, cm, pdb
+}
+
+// TestCleanupLegacyConnectorResources_DeletesOwned verifies the happy path:
+// when all four legacy-named resources exist and are owned by this tunnel,
+// they are all deleted.
+func TestCleanupLegacyConnectorResources_DeletesOwned(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true)
+	dep, sa, cm, pdb := legacyOwnedFixture(tun)
+	c := buildAggFakeClient(tun, dep, sa, cm, pdb)
+
+	if err := cleanupLegacyConnectorResources(context.Background(), c, tun); err != nil {
+		t.Fatalf("cleanup returned error: %v", err)
+	}
+
+	legacy := legacyConnectorNames(tun)
+	for _, tc := range []struct {
+		name string
+		obj  client.Object
+	}{
+		{"Deployment", &appsv1.Deployment{}},
+		{"ServiceAccount", &corev1.ServiceAccount{}},
+		{"ConfigMap", &corev1.ConfigMap{}},
+		{"PodDisruptionBudget", &policyv1.PodDisruptionBudget{}},
+	} {
+		var name string
+		switch tc.name {
+		case "Deployment":
+			name = legacy.Deployment
+		case "ServiceAccount":
+			name = legacy.ServiceAccount
+		case "ConfigMap":
+			name = legacy.ConfigMap
+		case "PodDisruptionBudget":
+			name = legacy.PodDisruptionBudget
+		}
+		err := c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: tun.Namespace}, tc.obj)
+		if !apierrors.IsNotFound(err) {
+			t.Errorf("expected %s %q to be deleted, got err=%v", tc.name, name, err)
+		}
+	}
+}
+
+// TestCleanupLegacyConnectorResources_LeavesUnowned verifies that the cleanup
+// refuses to touch a legacy-named resource that this tunnel does NOT own.
+func TestCleanupLegacyConnectorResources_LeavesUnowned(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true)
+	legacy := legacyConnectorNames(tun)
+	// Same name, but no owner reference at all.
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      legacy.Deployment,
+			Namespace: tun.Namespace,
+		},
+	}
+	c := buildAggFakeClient(tun, dep)
+
+	if err := cleanupLegacyConnectorResources(context.Background(), c, tun); err != nil {
+		t.Fatalf("cleanup returned error: %v", err)
+	}
+
+	got := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, got); err != nil {
+		t.Fatalf("unowned Deployment was deleted (or get failed): %v", err)
+	}
+}
+
+// TestCleanupLegacyConnectorResources_NoOpWithNameOverride verifies that the
+// cleanup is a no-op when the user has set spec.connector.nameOverride. A
+// resource that happens to match the legacy pattern must not be deleted.
+func TestCleanupLegacyConnectorResources_NoOpWithNameOverride(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true)
+	tun.Spec.Connector.NameOverride = "cloudflared-prod"
+	legacy := legacyConnectorNames(tun)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            legacy.Deployment, // "home-connector"
+			Namespace:       tun.Namespace,
+			OwnerReferences: connectorOwnerRef(tun),
+		},
+	}
+	c := buildAggFakeClient(tun, dep)
+
+	if err := cleanupLegacyConnectorResources(context.Background(), c, tun); err != nil {
+		t.Fatalf("cleanup returned error: %v", err)
+	}
+
+	got := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, got); err != nil {
+		t.Fatalf("Deployment deleted despite nameOverride being set: %v", err)
+	}
+}
+
+// TestCleanupLegacyConnectorResources_NoOpWhenAbsent verifies that the cleanup
+// is a no-op (no error) when there are no legacy-named resources to clean up.
+func TestCleanupLegacyConnectorResources_NoOpWhenAbsent(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", true)
+	c := buildAggFakeClient(tun)
+
+	if err := cleanupLegacyConnectorResources(context.Background(), c, tun); err != nil {
+		t.Fatalf("cleanup returned error on empty cluster: %v", err)
+	}
+}
+
+// TestCleanupLegacyConnectorResources_NoOpWhenConnectorDisabled verifies that
+// the cleanup is a no-op when spec.connector is nil or disabled — the operator
+// is not managing this connector at all.
+func TestCleanupLegacyConnectorResources_NoOpWhenConnectorDisabled(t *testing.T) {
+	tun := newTunnelForAgg("home", "network", false) // Connector == nil
+	dep, sa, cm, pdb := legacyOwnedFixture(tun)
+	c := buildAggFakeClient(tun, dep, sa, cm, pdb)
+
+	if err := cleanupLegacyConnectorResources(context.Background(), c, tun); err != nil {
+		t.Fatalf("cleanup returned error: %v", err)
+	}
+
+	// All four legacy-named resources must still exist.
+	legacy := legacyConnectorNames(tun)
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.Deployment, Namespace: tun.Namespace}, &appsv1.Deployment{}); err != nil {
+		t.Errorf("Deployment unexpectedly deleted: %v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ServiceAccount, Namespace: tun.Namespace}, &corev1.ServiceAccount{}); err != nil {
+		t.Errorf("ServiceAccount unexpectedly deleted: %v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.ConfigMap, Namespace: tun.Namespace}, &corev1.ConfigMap{}); err != nil {
+		t.Errorf("ConfigMap unexpectedly deleted: %v", err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Name: legacy.PodDisruptionBudget, Namespace: tun.Namespace}, &policyv1.PodDisruptionBudget{}); err != nil {
+		t.Errorf("PodDisruptionBudget unexpectedly deleted: %v", err)
+	}
+}

--- a/internal/controller/connector.go
+++ b/internal/controller/connector.go
@@ -59,12 +59,31 @@ type ConnectorResourceNames struct {
 // When tun.Spec.Connector.NameOverride is set, the Deployment and
 // ServiceAccount are named exactly NameOverride and the ConfigMap is named
 // "<NameOverride>-config". When unset, names fall back to the
-// "<tunnel.metadata.name>-connector" family.
+// "cloudflared-<tunnel.metadata.name>" family so the workload type is
+// visible in `kubectl get pods` output cluster-wide.
 func ConnectorNames(tun *cloudflarev1alpha1.CloudflareTunnel) ConnectorResourceNames {
-	base := tun.Name + "-connector"
+	base := "cloudflared-" + tun.Name
 	if tun.Spec.Connector != nil && tun.Spec.Connector.NameOverride != "" {
 		base = tun.Spec.Connector.NameOverride
 	}
+	return ConnectorResourceNames{
+		Deployment:          base,
+		ConfigMap:           base + "-config",
+		ServiceAccount:      base,
+		PodDisruptionBudget: base + "-pdb",
+	}
+}
+
+// legacyConnectorNames returns the pre-rename "<tunnel-name>-connector"
+// family of resource names for tun. It exists so the connector reconciler
+// can find and delete legacy-named resources after a successful rename to
+// the new default.
+//
+// Callers MUST gate use on tun.Spec.Connector.NameOverride == "": when an
+// override is set, the override name is the source of truth and there is
+// no legacy family to clean up.
+func legacyConnectorNames(tun *cloudflarev1alpha1.CloudflareTunnel) ConnectorResourceNames {
+	base := tun.Name + "-connector"
 	return ConnectorResourceNames{
 		Deployment:          base,
 		ConfigMap:           base + "-config",

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -61,7 +61,7 @@ func TestConnectorNames(t *testing.T) {
 }
 
 // TestConnectorNames_NameOverride verifies that spec.connector.nameOverride
-// replaces the default "<tunnel-name>-connector" base across the Deployment,
+// replaces the default "cloudflared-<tunnel-name>" base across the Deployment,
 // ServiceAccount, and ConfigMap. ConfigMap retains its "-config" suffix to
 // disambiguate it from the Deployment/SA, which share the override name (#68).
 func TestConnectorNames_NameOverride(t *testing.T) {

--- a/internal/controller/connector_test.go
+++ b/internal/controller/connector_test.go
@@ -46,17 +46,17 @@ func tunnelFixture(enabled bool) *cloudflarev1alpha1.CloudflareTunnel {
 func TestConnectorNames(t *testing.T) {
 	tun := tunnelFixture(true)
 	n := ConnectorNames(tun)
-	if n.Deployment != "home-connector" {
+	if n.Deployment != "cloudflared-home" {
 		t.Errorf("Deployment name = %q", n.Deployment)
 	}
-	if n.ConfigMap != "home-connector-config" {
+	if n.ConfigMap != "cloudflared-home-config" {
 		t.Errorf("ConfigMap name = %q", n.ConfigMap)
 	}
-	if n.ServiceAccount != "home-connector" {
+	if n.ServiceAccount != "cloudflared-home" {
 		t.Errorf("ServiceAccount name = %q", n.ServiceAccount)
 	}
-	if n.PodDisruptionBudget != "home-connector-pdb" {
-		t.Errorf("PodDisruptionBudget name = %q, want %q", n.PodDisruptionBudget, "home-connector-pdb")
+	if n.PodDisruptionBudget != "cloudflared-home-pdb" {
+		t.Errorf("PodDisruptionBudget name = %q, want %q", n.PodDisruptionBudget, "cloudflared-home-pdb")
 	}
 }
 
@@ -81,20 +81,20 @@ func TestConnectorNames_NameOverride(t *testing.T) {
 }
 
 // TestConnectorNames_NameOverrideEmpty verifies that an empty NameOverride
-// (the zero value) falls back to the default "<tunnel-name>-connector" family.
+// (the zero value) falls back to the default "cloudflared-<tunnel-name>" family.
 func TestConnectorNames_NameOverrideEmpty(t *testing.T) {
 	tun := tunnelFixture(true)
 	tun.Spec.Connector.NameOverride = ""
 
 	n := ConnectorNames(tun)
-	if n.Deployment != "home-connector" {
-		t.Errorf("Deployment name = %q, want default %q", n.Deployment, "home-connector")
+	if n.Deployment != "cloudflared-home" {
+		t.Errorf("Deployment name = %q, want default %q", n.Deployment, "cloudflared-home")
 	}
-	if n.ConfigMap != "home-connector-config" {
-		t.Errorf("ConfigMap name = %q, want default %q", n.ConfigMap, "home-connector-config")
+	if n.ConfigMap != "cloudflared-home-config" {
+		t.Errorf("ConfigMap name = %q, want default %q", n.ConfigMap, "cloudflared-home-config")
 	}
-	if n.ServiceAccount != "home-connector" {
-		t.Errorf("ServiceAccount name = %q, want default %q", n.ServiceAccount, "home-connector")
+	if n.ServiceAccount != "cloudflared-home" {
+		t.Errorf("ServiceAccount name = %q, want default %q", n.ServiceAccount, "cloudflared-home")
 	}
 }
 
@@ -105,8 +105,27 @@ func TestConnectorNames_NameOverrideNilConnector(t *testing.T) {
 	tun.Spec.Connector = nil
 
 	n := ConnectorNames(tun)
+	if n.Deployment != "cloudflared-home" {
+		t.Errorf("Deployment name = %q, want default %q", n.Deployment, "cloudflared-home")
+	}
+}
+
+// TestLegacyConnectorNames verifies that legacyConnectorNames returns the
+// pre-rename "<tunnel-name>-connector" family used by the cleanup path.
+func TestLegacyConnectorNames(t *testing.T) {
+	tun := tunnelFixture(true)
+	n := legacyConnectorNames(tun)
 	if n.Deployment != "home-connector" {
-		t.Errorf("Deployment name = %q, want default %q", n.Deployment, "home-connector")
+		t.Errorf("Deployment name = %q, want %q", n.Deployment, "home-connector")
+	}
+	if n.ConfigMap != "home-connector-config" {
+		t.Errorf("ConfigMap name = %q, want %q", n.ConfigMap, "home-connector-config")
+	}
+	if n.ServiceAccount != "home-connector" {
+		t.Errorf("ServiceAccount name = %q, want %q", n.ServiceAccount, "home-connector")
+	}
+	if n.PodDisruptionBudget != "home-connector-pdb" {
+		t.Errorf("PodDisruptionBudget name = %q, want %q", n.PodDisruptionBudget, "home-connector-pdb")
 	}
 }
 
@@ -523,8 +542,8 @@ func TestBuildConnectorPodDisruptionBudget_AtReplicasTwo(t *testing.T) {
 	if pdb == nil {
 		t.Fatal("expected non-nil PDB at replicas==2")
 	}
-	if pdb.Name != "home-connector-pdb" {
-		t.Errorf("Name = %q, want %q", pdb.Name, "home-connector-pdb")
+	if pdb.Name != "cloudflared-home-pdb" {
+		t.Errorf("Name = %q, want %q", pdb.Name, "cloudflared-home-pdb")
 	}
 	if pdb.Namespace != tun.Namespace {
 		t.Errorf("Namespace = %q, want %q", pdb.Namespace, tun.Namespace)


### PR DESCRIPTION
## Summary

Closes #93. Renames the default base name for the operator-managed connector resources from `<tunnel.metadata.name>-connector` to `cloudflared-<tunnel.metadata.name>`. Pods now show up as `cloudflared-<tun>-...` in `kubectl get pods` so the workload type is visible at a glance and a single cluster-wide query (`kubectl get pods | grep cloudflared`) finds every operator-managed connector. Matches the upstream Cloudflare Helm chart's pod-name prefix.

`spec.connector.nameOverride` semantics are unchanged — when set, it still wins. No new CRD field.

## How

**Naming (Task 1):**
- `ConnectorNames()` default base flips to `"cloudflared-" + tun.Name`. Resource families:
  - Deployment / ServiceAccount: `cloudflared-<tun>`
  - ConfigMap: `cloudflared-<tun>-config`
  - PodDisruptionBudget: `cloudflared-<tun>-pdb`
- Sibling helper `legacyConnectorNames()` returns the pre-rename `<tun>-connector` family for the cleanup path. Doc-comment requires callers to gate on `NameOverride == ""`.

**Migration (Tasks 2–3, plus follow-up):**
- New `cleanupLegacyConnectorResources` helper deletes the four legacy-named resources owned by this `CloudflareTunnel` (UID-controller-ref check via existing `isOwnedBy`). Gated on `Connector.Enabled`, `NameOverride == ""`, and a defensive "names actually differ" guard.
- Wired into `reconcileConnectorResources` at the **end**, after SA/ConfigMap/Deployment/PDB apply paths succeed.
- **Readiness gate** (`connectorDeploymentReady`): cleanup only fires after the new connector Deployment reports `ReadyReplicas >= 1`. The controller already `.Owns(&appsv1.Deployment{})`, so the Ready transition triggers a re-reconcile that runs cleanup. Result: legacy connector keeps serving traffic until the new one is up — actual no-traffic-gap migration, not best-effort.
- `IsNotFound` on Delete is treated as success; ownership refusal is silent (skipped, not error). Apply-failure short-circuits before cleanup so partial-apply states never leave the user without a working connector.

**API doc + CRDs (Task 4):**
- `NameOverride` godoc rewritten to describe the new default and the auto-cleanup contract (including the "setting `NameOverride` suppresses auto-cleanup" caveat).
- `make manifests` + `make sync-helm-crds` regenerated `config/crd/bases/` and `chart/crds/` (byte-for-byte identical).

**User docs (Task 5):**
- `docs/tunnels.md`: rewrote "Naming the connector resources" section, added "Upgrading from earlier versions" subsection that calls out the no-traffic-gap rollover and the monitoring-filter migration (`pod=~"<tunnel>-connector-.*"` → `cloudflared-<tunnel>-.*`).
- `docs/crd-reference.md`: `nameOverride` row description, PDB resource bullet, example PDB name.
- `docs/troubleshooting.md`: example `kubectl describe deploy` / `get deploy` commands.
- `CHANGELOG.md`: new `## [Unreleased]` / `### Changed` entry.

## Notable

- **Edge cases walked through.** Pathological tunnel names (`cloudflared`, `<X>-connector`, etc.) cannot make legacy and new families collide for the same tunnel. Cross-tunnel name collisions are blocked by the UID-based ownership check.
- **Ownership refusal exercises the UID comparison**, not just owner-ref presence. The unowned test fixture stamps the legacy Deployment with a different tunnel's UID — the realistic collision scenario.
- **Two-phase integration test** (`TestReconcileConnectorResources_CleansUpLegacyOnRename`) explicitly models the readiness gate: phase 1 applies new resources but leaves legacy in place; status-flip on the new Deployment; phase 2 cleans up legacy.
- **No CRD schema change** — `nameOverride` field, validation, and JSON tag are untouched.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./... -count=1` green across all packages.
- [x] `go vet ./...` clean.
- [x] `make manifests` + `make sync-helm-crds` are no-ops on rerun (committed artifacts in sync).
- [x] 6 new tests pass: `TestLegacyConnectorNames`, five `TestCleanupLegacyConnectorResources_*` (DeletesOwned, LeavesUnowned with different-UID fixture, NoOpWithNameOverride, NoOpWhenAbsent, NoOpWhenConnectorDisabled), and the two-phase `TestReconcileConnectorResources_CleansUpLegacyOnRename`.
- [x] All four pre-existing `TestConnectorNames*` tests + the `TestBuildConnectorPodDisruptionBudget_AtReplicasTwo` PDB-name assertion updated for the new default and pass.
- [ ] Manual smoke-test on a homelab tunnel: deploy operator with this branch onto an existing install that has `<tun>-connector` resources running. Observe new `cloudflared-<tun>` Deployment come up alongside the legacy one, then legacy disappears once the new pod is Ready. Tunnel stays connected throughout.

## Commits (10)

```
80a70e0 fix(connector): defer legacy cleanup until new connector is Ready (#93)
90b51cb docs(tunnels): normalize tunnel placeholder in upgrade section
1d2eb69 docs: document cloudflared-<tunnel> connector default and upgrade behavior (#93)
e1933d7 docs(api): update NameOverride doc comment for cloudflared-<tun> default (#93)
2879d3f docs(connector): refresh reconcileConnectorResources godoc
c6b132c feat(connector): run legacy-name cleanup after successful apply (#93)
1ea38d0 fix(connector): tighten cleanup unowned-test + soften godoc (#93)
422b79b feat(connector): add legacy-name cleanup helper for default rename (#93)
2e18e13 docs(connector): fix stale doc comment on TestConnectorNames_NameOverride
0633fac feat(connector): default base name to cloudflared-<tunnel> (#93)
```

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)