### PR TITLE
fix: preserve stored remote IDs on transient Cloudflare API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **CloudflareTunnel connector default rename.** The default base name for the operator-managed connector resources is now `cloudflared-<tunnel-name>` (was `<tunnel-name>-connector`). New resource names: Deployment / ServiceAccount `cloudflared-<tun>`, ConfigMap `cloudflared-<tun>-config`, PodDisruptionBudget `cloudflared-<tun>-pdb`. Pods now appear in `kubectl get pods` as `cloudflared-<tun>-...`, matching the Cloudflare upstream Helm chart. The connector reconciler automatically deletes the legacy `<tun>-connector` family of resources owned by your `CloudflareTunnel` on the next reconcile after upgrade, with no traffic gap (the new connector comes up first; both briefly coexist; legacy is then deleted). Users who set `spec.connector.nameOverride` are unaffected and the auto-cleanup is suppressed for them. Update any monitoring/alert filters that match the old pod-name prefix. (#93)
 
+### Fixed
+
+- **Transient errors no longer wipe stored remote IDs.** The DNS and tunnel reconcilers previously cleared `Status.RecordID` / `Status.TunnelID` on any error from the in-flow Get-by-ID call, including transient 5xx responses or network blips. They now gate the ID-clear on `cfclient.IsNotFound(err)` (the same shape the zone reconciler uses); other errors propagate to the existing outer-`Reconcile` classifier, which preserves the stored ID and surfaces a `CloudflareAPIError` (or `PermissionDenied` / `BadRequest` / `PlanTierRequired`) condition `Reason` while the workqueue retries with backoff. Closes #85.
+
 ## [0.14.1](https://github.com/jacaudi/cloudflare-operator/compare/v0.14.0...v0.14.1) (2026-05-06)
 
 ### Bug Fixes

--- a/internal/controller/cloudflarednsrecord_controller.go
+++ b/internal/controller/cloudflarednsrecord_controller.go
@@ -249,7 +249,10 @@ func (r *CloudflareDNSRecordReconciler) reconcileRecord(ctx context.Context, dns
 	if dnsRecord.Status.RecordID != "" {
 		existing, err = dnsClient.GetRecord(ctx, zoneID, dnsRecord.Status.RecordID)
 		if err != nil {
-			logger.Info("could not fetch record by ID, will search by name", "recordID", dnsRecord.Status.RecordID)
+			if !cfclient.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("get record by ID: %w", err)
+			}
+			logger.Info("record not found by ID, will search by name", "recordID", dnsRecord.Status.RecordID)
 			dnsRecord.Status.RecordID = ""
 			existing = nil
 		}

--- a/internal/controller/cloudflarednsrecord_controller_test.go
+++ b/internal/controller/cloudflarednsrecord_controller_test.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -1756,10 +1755,11 @@ func TestDNSReconcile_ZoneRefDeleteZoneNotResolvable(t *testing.T) {
 
 // TestCloudflareDNSRecordReconciler_NotFoundRoutesToRemoteGone verifies that a
 // 404 from the Cloudflare API routes the reconciler to the ReasonRemoteGone
-// condition and an immediate requeue. Note: Status.RecordID is cleared by the
-// in-flow ID-recovery path (lines 240-246 in reconcileRecord) when mock.getErr
-// is set, NOT by the classifier's ResetRemoteID flag. The classifier's reset
-// semantic is unit-tested in error_routing_test.go::TestClassifyCloudflareError.
+// condition and an immediate requeue. The 404 first comes from GetRecord by
+// stale ID — the in-flow recovery path clears Status.RecordID and falls
+// through to ListRecordsByNameAndType, which also returns 404. The list error
+// then propagates to Reconcile's failReconcile site, where the classifier
+// returns ResetRemoteID=true and ReasonRemoteGone.
 func TestCloudflareDNSRecordReconciler_NotFoundRoutesToRemoteGone(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := cloudflarev1alpha1.AddToScheme(scheme); err != nil {
@@ -1793,7 +1793,7 @@ func TestCloudflareDNSRecordReconciler_NotFoundRoutesToRemoteGone(t *testing.T) 
 	}
 
 	mock := newMockDNSClient()
-	mock.getErr = errors.New("transient")
+	mock.getErr = &cfgo.Error{StatusCode: http.StatusNotFound}
 	mock.listErr = &cfgo.Error{StatusCode: http.StatusNotFound}
 
 	r := buildReconciler(scheme, mock, dns, secret)
@@ -2175,5 +2175,134 @@ func TestCloudflareDNSRecord_PhaseReconciling(t *testing.T) {
 	}
 	if fetched.Status.Phase != cloudflarev1alpha1.PhaseReconciling {
 		t.Errorf("Phase = %q, want %q", fetched.Status.Phase, cloudflarev1alpha1.PhaseReconciling)
+	}
+}
+
+// TestReconcileRecord_GetByID_NotFound_FallsThroughToSearch verifies that a
+// 404 from GetRecord clears Status.RecordID and the reconciler proceeds to
+// search by name (here finding the existing record and adopting it).
+func TestReconcileRecord_GetByID_NotFound_FallsThroughToSearch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := cloudflarev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	dns := &cloudflarev1alpha1.CloudflareDNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "rec",
+			Namespace:  "default",
+			Generation: 1,
+			Finalizers: []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
+			ZoneID:    "zone-1",
+			Name:      "x.example.com",
+			Type:      cloudflarev1alpha1.DNSRecordTypeA,
+			Content:   strPtr("1.2.3.4"),
+			SecretRef: cloudflarev1alpha1.SecretReference{Name: "creds"},
+		},
+		Status: cloudflarev1alpha1.CloudflareDNSRecordStatus{
+			RecordID: "rec-stale",
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+		Data:       map[string][]byte{cfclient.SecretKeyAPIToken: []byte("token")},
+	}
+
+	mock := newMockDNSClient()
+	// GetRecord returns 404 (stale ID), but search-by-name finds the record.
+	mock.getErr = &cfgo.Error{StatusCode: http.StatusNotFound}
+	// Seed the existing record so ListRecordsByNameAndType finds it.
+	mock.records["rec-fresh"] = &cfclient.DNSRecord{
+		ID: "rec-fresh", Name: "x.example.com", Type: "A",
+		Content: "1.2.3.4",
+	}
+
+	r := buildReconciler(scheme, mock, dns, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(dns),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &cloudflarev1alpha1.CloudflareDNSRecord{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(dns), updated); err != nil {
+		t.Fatalf("get updated record: %v", err)
+	}
+	// Adopted to the freshly-found record ID.
+	if updated.Status.RecordID != "rec-fresh" {
+		t.Errorf("Status.RecordID = %q, want %q (adopted via search-by-name)", updated.Status.RecordID, "rec-fresh")
+	}
+}
+
+// TestReconcileRecord_GetByID_TransientError_PreservesID verifies that a
+// non-404 error from GetRecord is propagated to the outer wrapper, which
+// classifies it as ReasonCloudflareError and preserves Status.RecordID
+// (the next reconcile retries the same Get).
+func TestReconcileRecord_GetByID_TransientError_PreservesID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := cloudflarev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	dns := &cloudflarev1alpha1.CloudflareDNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "rec",
+			Namespace:  "default",
+			Generation: 1,
+			Finalizers: []string{cloudflarev1alpha1.FinalizerName},
+		},
+		Spec: cloudflarev1alpha1.CloudflareDNSRecordSpec{
+			ZoneID:    "zone-1",
+			Name:      "x.example.com",
+			Type:      cloudflarev1alpha1.DNSRecordTypeA,
+			Content:   strPtr("1.2.3.4"),
+			SecretRef: cloudflarev1alpha1.SecretReference{Name: "creds"},
+		},
+		Status: cloudflarev1alpha1.CloudflareDNSRecordStatus{
+			RecordID: "rec-stable",
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+		Data:       map[string][]byte{cfclient.SecretKeyAPIToken: []byte("token")},
+	}
+
+	mock := newMockDNSClient()
+	// 5xx — transient, ID must NOT be cleared, list path must NOT be reached.
+	mock.getErr = &cfgo.Error{StatusCode: http.StatusInternalServerError}
+
+	r := buildReconciler(scheme, mock, dns, secret)
+
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(dns),
+	}); err != nil {
+		t.Fatalf("unexpected error from Reconcile: %v", err)
+	}
+
+	updated := &cloudflarev1alpha1.CloudflareDNSRecord{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(dns), updated); err != nil {
+		t.Fatalf("get updated record: %v", err)
+	}
+	if updated.Status.RecordID != "rec-stable" {
+		t.Errorf("Status.RecordID = %q, want %q (must NOT be cleared on transient error)", updated.Status.RecordID, "rec-stable")
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("Ready condition missing")
+	}
+	if cond.Reason != cloudflarev1alpha1.ReasonCloudflareError {
+		t.Errorf("Reason = %q, want %q", cond.Reason, cloudflarev1alpha1.ReasonCloudflareError)
+	}
+	if updated.Status.Phase != cloudflarev1alpha1.PhaseError {
+		t.Errorf("Phase = %q, want %q", updated.Status.Phase, cloudflarev1alpha1.PhaseError)
 	}
 }

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -194,7 +194,10 @@ func (r *CloudflareTunnelReconciler) reconcileTunnel(ctx context.Context, tunnel
 	if tunnel.Status.TunnelID != "" {
 		existing, err = tunnelClient.GetTunnel(ctx, accountID, tunnel.Status.TunnelID)
 		if err != nil {
-			logger.Info("could not fetch tunnel by ID, will search by name", "tunnelID", tunnel.Status.TunnelID)
+			if !cfclient.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("get tunnel by ID: %w", err)
+			}
+			logger.Info("tunnel not found by ID, will search by name", "tunnelID", tunnel.Status.TunnelID)
 			tunnel.Status.TunnelID = ""
 			existing = nil
 		}

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -600,9 +600,10 @@ func TestCloudflareTunnelReconciler_TunnelGoneClearsStatus(t *testing.T) {
 	}
 
 	mock := newMockTunnelClient()
-	// getErr triggers the in-flow fallthrough (reconcileTunnel logs + continues).
-	// listErr 404 then propagates to Reconcile's failReconcile site.
-	mock.getErr = errors.New("transient fetch error")
+	// GetTunnel returns 404 (stale ID); search-by-name also returns 404; the
+	// list error propagates to Reconcile's failReconcile site where the
+	// classifier returns ResetRemoteID=true and ReasonRemoteGone.
+	mock.getErr = &cfgo.Error{StatusCode: http.StatusNotFound}
 	mock.listErr = &cfgo.Error{StatusCode: http.StatusNotFound}
 
 	r := buildTunnelReconciler(t, mock, tunnel, secret)
@@ -1410,5 +1411,93 @@ func TestEnsureCredentialsSecretExists_AlreadyOwnedStaleData_OverwritesWithoutRe
 	// Ownership invariants still hold.
 	if v := got.Labels["cloudflare.io/managed"]; v != "true" {
 		t.Errorf(`expected cloudflare.io/managed=true preserved, got %q`, v)
+	}
+}
+
+// TestReconcileTunnel_GetByID_NotFound_FallsThroughToSearch verifies that a
+// 404 from GetTunnel clears Status.TunnelID and the reconciler proceeds to
+// search by name (here finding the existing tunnel and adopting it).
+func TestReconcileTunnel_GetByID_NotFound_FallsThroughToSearch(t *testing.T) {
+	tunnel := newTestTunnel("tun", "default")
+	tunnel.Spec.SecretRef = cloudflarev1alpha1.SecretReference{Name: "creds"}
+	tunnel.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	tunnel.Status.TunnelID = "tun-stale"
+	tunnel.Status.TunnelCNAME = "tun-stale.cfargotunnel.com"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+		Data: map[string][]byte{
+			cfclient.SecretKeyAPIToken:  []byte("token"),
+			cfclient.SecretKeyAccountID: []byte("acct"),
+		},
+	}
+
+	mock := newMockTunnelClient()
+	// GetTunnel returns 404; ListTunnelsByName finds the existing tunnel.
+	mock.getErr = &cfgo.Error{StatusCode: http.StatusNotFound}
+	mock.tunnels["tun-fresh"] = &cfclient.Tunnel{ID: "tun-fresh", Name: "my-tunnel"}
+
+	r := buildTunnelReconciler(t, mock, tunnel, secret)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(tunnel),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &cloudflarev1alpha1.CloudflareTunnel{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(tunnel), updated); err != nil {
+		t.Fatalf("get updated tunnel: %v", err)
+	}
+	if updated.Status.TunnelID != "tun-fresh" {
+		t.Errorf("Status.TunnelID = %q, want %q (adopted via search-by-name)", updated.Status.TunnelID, "tun-fresh")
+	}
+}
+
+// TestReconcileTunnel_GetByID_TransientError_PreservesID verifies that a
+// non-404 error from GetTunnel propagates up. The outer wrapper classifies
+// it as ReasonCloudflareError and preserves Status.TunnelID + TunnelCNAME
+// (the next reconcile retries the same Get).
+func TestReconcileTunnel_GetByID_TransientError_PreservesID(t *testing.T) {
+	tunnel := newTestTunnel("tun", "default")
+	tunnel.Spec.SecretRef = cloudflarev1alpha1.SecretReference{Name: "creds"}
+	tunnel.Finalizers = []string{cloudflarev1alpha1.FinalizerName}
+	tunnel.Status.TunnelID = "tun-stable"
+	tunnel.Status.TunnelCNAME = "tun-stable.cfargotunnel.com"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: "default"},
+		Data: map[string][]byte{
+			cfclient.SecretKeyAPIToken:  []byte("token"),
+			cfclient.SecretKeyAccountID: []byte("acct"),
+		},
+	}
+
+	mock := newMockTunnelClient()
+	mock.getErr = &cfgo.Error{StatusCode: http.StatusInternalServerError}
+
+	r := buildTunnelReconciler(t, mock, tunnel, secret)
+	if _, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKeyFromObject(tunnel),
+	}); err != nil {
+		t.Fatalf("unexpected error from Reconcile: %v", err)
+	}
+
+	updated := &cloudflarev1alpha1.CloudflareTunnel{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(tunnel), updated); err != nil {
+		t.Fatalf("get updated tunnel: %v", err)
+	}
+	if updated.Status.TunnelID != "tun-stable" {
+		t.Errorf("Status.TunnelID = %q, want %q (must NOT be cleared on transient error)", updated.Status.TunnelID, "tun-stable")
+	}
+	if updated.Status.TunnelCNAME != "tun-stable.cfargotunnel.com" {
+		t.Errorf("Status.TunnelCNAME = %q, want %q (must NOT be cleared on transient error)", updated.Status.TunnelCNAME, "tun-stable.cfargotunnel.com")
+	}
+	cond := meta.FindStatusCondition(updated.Status.Conditions, cloudflarev1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("Ready condition missing")
+	}
+	if cond.Reason != cloudflarev1alpha1.ReasonCloudflareError {
+		t.Errorf("Reason = %q, want %q", cond.Reason, cloudflarev1alpha1.ReasonCloudflareError)
+	}
+	if updated.Status.Phase != cloudflarev1alpha1.PhaseError {
+		t.Errorf("Phase = %q, want %q", updated.Status.Phase, cloudflarev1alpha1.PhaseError)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #85. The DNS and tunnel reconcilers' in-flow Get-by-ID error path used to clear `Status.RecordID` / `Status.TunnelID` on **any** error from `GetRecord` / `GetTunnel`, including transient 5xx network blips. A brief Cloudflare API hiccup silently wiped the operator's view of upstream state and forced a re-resolve on the next reconcile.

The fix gates the ID-clear on `cfclient.IsNotFound(err)` — same shape the zone reconciler already uses (`cloudflarezone_controller.go:157`). Non-404 errors propagate up to the existing outer-`Reconcile` classifier, which preserves the stored ID and surfaces a meaningful condition `Reason` while the workqueue retries with backoff.

## How

**DNS (Task 1):**
- `internal/controller/cloudflarednsrecord_controller.go` `reconcileRecord` — when `GetRecord` returns an error, gate the ID-clear on `cfclient.IsNotFound(err)`. Non-404 returns `ctrl.Result{}, fmt.Errorf("get record by ID: %w", err)`.
- The outer `Reconcile` wrapper (lines 191-218) was already calling `ClassifyCloudflareError` + `failReconcile` on any non-nil return; this just stops the inner code from masking the error before the wrapper sees it. `ClassifyCloudflareError` returns `ResetRemoteID: true` only on `IsNotFound`, so the wrapper preserves the ID for non-404 errors automatically.

**Tunnel (Task 2):**
- Same shape in `internal/controller/cloudflaretunnel_controller.go` `reconcileTunnel`. The outer wrapper at lines 132-153 also clears `Status.TunnelCNAME` alongside `TunnelID` only when `routing.ResetRemoteID == true` — so transient errors preserve both fields.

**Tests:**
- Updated existing `TestCloudflareDNSRecordReconciler_NotFoundRoutesToRemoteGone` and the analogous tunnel test (which previously used `mock.getErr = errors.New("transient")` to exercise the indiscriminate clear, and whose godoc literally documented the bug). Both now use a real 404 from `GetRecord` / `GetTunnel`, exercising the same `RemoteGone` path for the right reason.
- Added 4 new tests:
  - `TestReconcileRecord_GetByID_NotFound_FallsThroughToSearch` — 404 clears ID, search-by-name finds and adopts.
  - `TestReconcileRecord_GetByID_TransientError_PreservesID` — 5xx (`http.StatusInternalServerError`) preserves `Status.RecordID`, asserts `Phase == Error` and `Reason == CloudflareAPIError`.
  - `TestReconcileTunnel_GetByID_NotFound_FallsThroughToSearch` — same shape for tunnel.
  - `TestReconcileTunnel_GetByID_TransientError_PreservesID` — additionally asserts `Status.TunnelCNAME` is preserved.

## Behavior matrix

| Error from `Get` | Old | New |
|------------------|-----|-----|
| `IsNotFound` (404) | clear ID, fall through to search-by-name | unchanged |
| `IsBadRequest` / `IsPermissionDenied` / `IsPlanTierRequired` (4xx) | clear ID silently, fall through | propagate via `failReconcile` with the appropriate `Reason` + 1h requeue |
| 5xx / network / timeout / unclassified | clear ID silently, fall through | propagate via `failReconcile` with `ReasonCloudflareError` + workqueue default backoff |
| `nil` | proceed | unchanged |

## Notable

- **Zero new helpers.** The fix uses existing infrastructure — `cfclient.IsNotFound`, `ClassifyCloudflareError`, `failReconcile`. The zone reconciler at `cloudflarezone_controller.go:157` already implements this shape; this PR brings DNS and tunnel into alignment.
- **Sentinel tests catch partial reverts.** The transient-error tests assert three properties jointly (ID preserved, `Phase == Error`, `Reason == CloudflareAPIError`), so a future regression that, say, removes the gate but keeps the return — or removes the return but keeps the gate — would be caught.
- **No CRD changes, no API surface changes.** Pure internal reliability fix.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./... -count=1` green across all packages.
- [x] `go vet ./...` clean.
- [x] 4 new tests + 2 existing-test updates pass.
- [ ] Manual smoke test: temporarily simulate a Cloudflare API 502 (e.g. via a network mock or by killing local DNS during a reconcile) on a tunnel/record with a known-good `Status.TunnelID` / `Status.RecordID`. Confirm the ID stays set, `Phase` becomes `Error` with `Reason: CloudflareAPIError`, and the next reconcile after recovery resumes normally without re-resolving.

## Commits (3)

```
f0f1cfd docs: changelog entry for transient-error ID preservation (#85)
ab02730 fix(tunnel): preserve Status.TunnelID on transient GetTunnel errors (#85)
9a65ad5 fix(dns): preserve Status.RecordID on transient GetRecord errors (#85)
```

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)