### PR TITLE
P2: tunnel hardening — SSA emit pivot + event dedupe

### DIFF
--- a/internal/bootstrap/controller_test.go
+++ b/internal/bootstrap/controller_test.go
@@ -18,7 +18,6 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -30,43 +29,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 )
-
-// ssaTranslatingClient wraps a fake client to translate SSA patches into
-// create-or-update calls. The fake client doesn't natively support SSA, so
-// this helper lets bootstrap tests exercise the reconciler's Apply path
-// without envtest. Real SSA behavior is verified in T18 envtest.
-func ssaTranslatingClient(t *testing.T, base client.WithWatch) client.WithWatch {
-	t.Helper()
-	return interceptor.NewClient(base, interceptor.Funcs{
-		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			if patch.Type() != types.ApplyPatchType {
-				return c.Patch(ctx, obj, patch, opts...)
-			}
-			key := client.ObjectKeyFromObject(obj)
-			existing, ok := obj.DeepCopyObject().(client.Object)
-			if !ok {
-				return fmt.Errorf("DeepCopyObject did not produce client.Object")
-			}
-			err := c.Get(ctx, key, existing)
-			if apierrors.IsNotFound(err) {
-				return c.Create(ctx, obj)
-			}
-			if err != nil {
-				return err
-			}
-			obj.SetResourceVersion(existing.GetResourceVersion())
-			return c.Update(ctx, obj)
-		},
-	})
-}
 
 func newBootstrapScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -85,7 +54,7 @@ func TestReconcile_RejectsNonClusterName(t *testing.T) {
 		WithObjects(op).
 		WithStatusSubresource(&v1alpha1.CloudflareOperator{}).
 		Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := &Reconciler{Client: c, Scheme: s, OperatorNamespace: "cf", OperatorImage: "img:1"}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "other"}})
 	require.NoError(t, err)
@@ -116,7 +85,7 @@ func TestReconcile_BothBundlesEnabled_CreatesAll(t *testing.T) {
 		WithObjects(op).
 		WithStatusSubresource(&v1alpha1.CloudflareOperator{}).
 		Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := &Reconciler{Client: c, Scheme: s, OperatorNamespace: "cf", OperatorImage: "img:1"}
 	res, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: v1alpha1.CloudflareOperatorSingletonName}})
 	require.NoError(t, err)
@@ -155,7 +124,7 @@ func TestReconcile_TunnelDisabled_DeletesTunnelDeployment(t *testing.T) {
 		WithObjects(op, existing).
 		WithStatusSubresource(&v1alpha1.CloudflareOperator{}).
 		Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := &Reconciler{Client: c, Scheme: s, OperatorNamespace: "cf", OperatorImage: "img:1"}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: v1alpha1.CloudflareOperatorSingletonName}})
 	require.NoError(t, err)
@@ -207,7 +176,7 @@ func TestReconcile_StaleCRSweep_OnDisable(t *testing.T) {
 			&v1alpha1.CloudflareZone{},
 		).
 		Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := &Reconciler{Client: c, Scheme: s, OperatorNamespace: "cf", OperatorImage: "img:1"}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: v1alpha1.CloudflareOperatorSingletonName}})
 	require.NoError(t, err)

--- a/internal/controller/tunnel/emit.go
+++ b/internal/controller/tunnel/emit.go
@@ -63,7 +63,10 @@ type EmitOpts struct {
 // Field ownership: this helper operates as the "cloudflare-operator" field
 // manager (per reconcile.Apply). Operator-edits-win is intentional — matches
 // Foundation's SSA convention for owned children. A user `kubectl edit` of
-// an emitted CR will be reverted on the next reconcile.
+// an emitted CR will be reverted on the next reconcile — including Spec.Adopt and
+// Spec.ZoneRef, which are re-asserted from the SOURCE object's annotations
+// (cloudflare.io/adopt, cloudflare.io/zone-ref). Toggle these on the
+// source, not on the emitted CR.
 func EmitDNSRecord(ctx context.Context, c client.Client, scheme *runtime.Scheme, opts EmitOpts) error {
 	content := opts.Content // local copy so we can take its address; Spec.Content is *string
 	dr := &v1alpha1.CloudflareDNSRecord{

--- a/internal/controller/tunnel/emit.go
+++ b/internal/controller/tunnel/emit.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
+)
+
+// EmitOpts is the parameter bag for EmitDNSRecord. Owner+OwnerKind are split
+// because the controller-runtime typed cache erases TypeMeta on Get; the kind
+// cannot be read back from the object, so the caller passes it literally.
+type EmitOpts struct {
+	// Owner is the source object (Service / Gateway / HTTPRoute / TLSRoute) to
+	// which the emitted CR is owner-reffed. Must already exist (have a UID).
+	Owner client.Object
+	// OwnerKind is the literal Kind name. Used for the source-kind label and
+	// the owner-ref kind.
+	OwnerKind string
+	// Hostname is the public FQDN this record routes for (becomes Spec.Name).
+	Hostname string
+	// Content is the CNAME target. For Service callers, this is the tunnel
+	// CNAME (Status.TunnelCNAME). For Route callers, this is the Gateway apex
+	// hostname (the intermediate stabilizer in the per-design §4.2 CNAME chain).
+	Content string
+	// Annotations carries optional source-object annotations that thread into
+	// the emitted CR. Recognized keys: AnnotationZoneRef, AnnotationAdopt.
+	// Unrecognized keys are ignored.
+	Annotations map[string]string
+}
+
+// EmitDNSRecord upserts a CloudflareDNSRecord CR for opts.Hostname, owner-
+// reffed to opts.Owner and labeled with the source-kind. Routes through
+// reconcile.Apply (server-side apply) so per-reconcile annotation drift on
+// the source (e.g. cloudflare.io/adopt flipping false → true) propagates
+// into the emitted CR's Spec. The legacy Create+IsAlreadyExists path that
+// this replaces silently dropped such drift — see design Item D1 /
+// docs/follow/tunnel-deferred.md Follow-up B.
+//
+// TypeMeta is set unconditionally; SSA hard-rejects objects without it.
+//
+// Field ownership: this helper operates as the "cloudflare-operator" field
+// manager (per reconcile.Apply). Operator-edits-win is intentional — matches
+// Foundation's SSA convention for owned children. A user `kubectl edit` of
+// an emitted CR will be reverted on the next reconcile.
+func EmitDNSRecord(ctx context.Context, c client.Client, scheme *runtime.Scheme, opts EmitOpts) error {
+	content := opts.Content // local copy so we can take its address; Spec.Content is *string
+	dr := &v1alpha1.CloudflareDNSRecord{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "CloudflareDNSRecord",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      emittedDNSRecordName(opts.Owner.GetName(), opts.Hostname),
+			Namespace: opts.Owner.GetNamespace(),
+		},
+		Spec: v1alpha1.CloudflareDNSRecordSpec{
+			Type:    "CNAME",
+			Name:    opts.Hostname,
+			Content: &content,
+		},
+	}
+	reconcilelib.StampSourceLabels(dr, opts.OwnerKind, opts.Owner.GetName(), opts.Owner.GetNamespace())
+	if err := reconcilelib.SetControllerOwner(opts.Owner, dr, scheme); err != nil {
+		return err
+	}
+	if zr := opts.Annotations[conventions.AnnotationZoneRef]; zr != "" {
+		dr.Spec.ZoneRef = &v1alpha1.ZoneReference{Name: zr, Namespace: opts.Owner.GetNamespace()}
+	}
+	if adopt, _ := conventions.ParseTruthy(opts.Annotations[conventions.AnnotationAdopt]); adopt {
+		dr.Spec.Adopt = true
+	}
+	return reconcilelib.Apply(ctx, c, dr)
+}

--- a/internal/controller/tunnel/emit_test.go
+++ b/internal/controller/tunnel/emit_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
+)
+
+func emitTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestEmitDNSRecord_CreatesNew(t *testing.T) {
+	s := emitTestScheme(t)
+	svc := &corev1.Service{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns", UID: "uid-svc"},
+	}
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	err := EmitDNSRecord(context.Background(), c, s, EmitOpts{
+		Owner:       svc,
+		OwnerKind:   "Service",
+		Hostname:    "foo.example.com",
+		Content:     "tunnel.cfargotunnel.com",
+		Annotations: map[string]string{conventions.AnnotationZoneRef: "example-com", conventions.AnnotationAdopt: "true"},
+	})
+	require.NoError(t, err)
+
+	var got v1alpha1.CloudflareDNSRecord
+	name := emittedDNSRecordName("svc", "foo.example.com")
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "ns"}, &got))
+	require.Equal(t, "CNAME", got.Spec.Type)
+	require.Equal(t, "foo.example.com", got.Spec.Name)
+	require.NotNil(t, got.Spec.Content)
+	require.Equal(t, "tunnel.cfargotunnel.com", *got.Spec.Content)
+	require.NotNil(t, got.Spec.ZoneRef)
+	require.Equal(t, "example-com", got.Spec.ZoneRef.Name)
+	require.True(t, got.Spec.Adopt)
+	require.Equal(t, "Service", got.Labels[conventions.LabelSourceKind])
+}
+
+func TestEmitDNSRecord_UpdatesSpecOnAnnotationChange(t *testing.T) {
+	// This is the silent-bug regression check. Emit with adopt=false, then
+	// emit again with adopt=true: the second emit must update the CR (SSA
+	// path) rather than swallow it (Create+IsAlreadyExists path).
+	s := emitTestScheme(t)
+	svc := &corev1.Service{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns", UID: "uid-svc"},
+	}
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	require.NoError(t, EmitDNSRecord(context.Background(), c, s, EmitOpts{
+		Owner: svc, OwnerKind: "Service",
+		Hostname: "foo.example.com", Content: "tunnel.cfargotunnel.com",
+		Annotations: map[string]string{conventions.AnnotationAdopt: "false"},
+	}))
+	require.NoError(t, EmitDNSRecord(context.Background(), c, s, EmitOpts{
+		Owner: svc, OwnerKind: "Service",
+		Hostname: "foo.example.com", Content: "tunnel.cfargotunnel.com",
+		Annotations: map[string]string{conventions.AnnotationAdopt: "true"},
+	}))
+
+	var got v1alpha1.CloudflareDNSRecord
+	name := emittedDNSRecordName("svc", "foo.example.com")
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "ns"}, &got))
+	require.True(t, got.Spec.Adopt,
+		"adopt annotation flip must propagate through SSA; got Spec.Adopt=false (silent-bug regression)")
+}
+
+func TestEmitDNSRecord_NoAnnotationsAreNoOpFields(t *testing.T) {
+	s := emitTestScheme(t)
+	svc := &corev1.Service{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "ns", UID: "uid-svc"},
+	}
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	require.NoError(t, EmitDNSRecord(context.Background(), c, s, EmitOpts{
+		Owner: svc, OwnerKind: "Service",
+		Hostname: "foo.example.com", Content: "tunnel.cfargotunnel.com",
+	}))
+
+	var got v1alpha1.CloudflareDNSRecord
+	name := emittedDNSRecordName("svc", "foo.example.com")
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "ns"}, &got))
+	require.Nil(t, got.Spec.ZoneRef, "no zoneRef annotation → no ZoneRef")
+	require.False(t, got.Spec.Adopt, "no adopt annotation → Adopt=false")
+}

--- a/internal/controller/tunnel/eventdedupe.go
+++ b/internal/controller/tunnel/eventdedupe.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Default TTL for the dedupe cache. 1h matches the Kubernetes default Event
+// TTL; on suppression-window expiry, the same warning may emit again and the
+// apiserver garbage-collects the prior copy on its own schedule.
+const defaultEventDedupeTTL = 1 * time.Hour
+
+// Default cap on cache entries per reconciler. 1024 keys × ~120 bytes ≈
+// 125 KB worst case. Far below the controller's memory budget; the cap
+// exists to prevent unbounded growth on pathological inputs (e.g. messages
+// that embed a counter or timestamp).
+const defaultEventDedupeMaxSize = 1024
+
+// eventDedupe is a per-reconciler suppression cache for repeated Events.
+// Source-reconcilers stamp the same TranslateWarning Event every reconcile
+// pass (every 30m), producing 48 identical Events per route per day. This
+// type collapses them to one emit per (UID, reason, message) per TTL.
+//
+// Lifecycle: live on the reconciler struct as a pointer; lazy-init via
+// sync.Once in the reconciler's setup path (mirror cacheTracker). On
+// process restart the cache empties; the K8s Event TTL handles cleanup of
+// the now-stale duplicates already in etcd.
+type eventDedupe struct {
+	mu      sync.Mutex
+	recent  map[string]time.Time
+	ttl     time.Duration
+	maxSize int
+}
+
+func newEventDedupe(ttl time.Duration, maxSize int) *eventDedupe {
+	if ttl <= 0 {
+		ttl = defaultEventDedupeTTL
+	}
+	if maxSize <= 0 {
+		maxSize = defaultEventDedupeMaxSize
+	}
+	return &eventDedupe{
+		recent:  make(map[string]time.Time),
+		ttl:     ttl,
+		maxSize: maxSize,
+	}
+}
+
+// eventDedupeKey returns the dedupe key for an emit. Hashing isn't necessary
+// at this volume — string concatenation costs less than a map lookup of a
+// long string in any realistic load.
+func eventDedupeKey(uid types.UID, reason, message string) string {
+	return string(uid) + "|" + reason + "|" + message
+}
+
+// emit records the (target, reason, message) tuple via the supplied
+// Recorder, suppressing identical emits within the dedupe window. Safe to
+// call with a nil Recorder (no-op, no cache state change either). Safe to
+// call concurrently.
+func (d *eventDedupe) emit(recorder record.EventRecorder, target client.Object, eventType, reason, message string) {
+	if recorder == nil {
+		return
+	}
+	k := eventDedupeKey(target.GetUID(), reason, message)
+
+	d.mu.Lock()
+	now := time.Now()
+	if t, ok := d.recent[k]; ok && now.Sub(t) < d.ttl {
+		d.mu.Unlock()
+		return
+	}
+	if len(d.recent) >= d.maxSize {
+		// Evict the oldest entry. O(n) on cap; cap is small (1024) so this
+		// is comfortably under a microsecond even on the slowest CI runners.
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+		for ek, et := range d.recent {
+			if first || et.Before(oldestTime) {
+				oldestKey, oldestTime, first = ek, et, false
+			}
+		}
+		delete(d.recent, oldestKey)
+	}
+	d.recent[k] = now
+	d.mu.Unlock()
+
+	recorder.Event(target, eventType, reason, message)
+}

--- a/internal/controller/tunnel/eventdedupe_test.go
+++ b/internal/controller/tunnel/eventdedupe_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+)
+
+func makeDedupeObj(uid string) *corev1.Service {
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "obj-" + uid, Namespace: "ns", UID: types.UID(uid)}}
+}
+
+func TestEventDedupe_SuppressesIdenticalWithinTTL(t *testing.T) {
+	d := newEventDedupe(1*time.Hour, 1024)
+	rec := record.NewFakeRecorder(10)
+	obj := makeDedupeObj("u1")
+
+	d.emit(rec, obj, corev1.EventTypeWarning, "R", "msg")
+	d.emit(rec, obj, corev1.EventTypeWarning, "R", "msg")
+	d.emit(rec, obj, corev1.EventTypeWarning, "R", "msg")
+
+	require.Len(t, rec.Events, 1, "two duplicates within TTL must be suppressed")
+}
+
+func TestEventDedupe_AllowsDifferentReason(t *testing.T) {
+	d := newEventDedupe(1*time.Hour, 1024)
+	rec := record.NewFakeRecorder(10)
+	obj := makeDedupeObj("u1")
+
+	d.emit(rec, obj, corev1.EventTypeWarning, "R1", "msg")
+	d.emit(rec, obj, corev1.EventTypeWarning, "R2", "msg")
+
+	require.Len(t, rec.Events, 2)
+}
+
+func TestEventDedupe_AllowsDifferentMessage(t *testing.T) {
+	d := newEventDedupe(1*time.Hour, 1024)
+	rec := record.NewFakeRecorder(10)
+	obj := makeDedupeObj("u1")
+
+	d.emit(rec, obj, corev1.EventTypeWarning, "R", "msg-a")
+	d.emit(rec, obj, corev1.EventTypeWarning, "R", "msg-b")
+
+	require.Len(t, rec.Events, 2)
+}
+
+func TestEventDedupe_AllowsAfterTTLExpiry(t *testing.T) {
+	d := newEventDedupe(50*time.Millisecond, 1024)
+	rec := record.NewFakeRecorder(10)
+	obj := makeDedupeObj("u1")
+
+	d.emit(rec, obj, corev1.EventTypeWarning, "R", "msg")
+	time.Sleep(80 * time.Millisecond)
+	d.emit(rec, obj, corev1.EventTypeWarning, "R", "msg")
+
+	require.Len(t, rec.Events, 2)
+}
+
+func TestEventDedupe_PerTarget(t *testing.T) {
+	d := newEventDedupe(1*time.Hour, 1024)
+	rec := record.NewFakeRecorder(10)
+
+	d.emit(rec, makeDedupeObj("u1"), corev1.EventTypeWarning, "R", "msg")
+	d.emit(rec, makeDedupeObj("u2"), corev1.EventTypeWarning, "R", "msg")
+
+	require.Len(t, rec.Events, 2, "different target UIDs must produce separate emits")
+}
+
+func TestEventDedupe_NilRecorderIsNoOp(t *testing.T) {
+	d := newEventDedupe(1*time.Hour, 1024)
+	obj := makeDedupeObj("u1")
+	// Should not panic.
+	d.emit(nil, obj, corev1.EventTypeWarning, "R", "msg")
+}
+
+func TestEventDedupe_MaxSizeEvictsOldest(t *testing.T) {
+	d := newEventDedupe(1*time.Hour, 2) // tiny cap
+	rec := record.NewFakeRecorder(10)
+
+	d.emit(rec, makeDedupeObj("u1"), corev1.EventTypeWarning, "R", "msg")
+	// Tiny sleep so u1's time stamp is strictly older than u2/u3 — the
+	// oldest-eviction uses time.Now() granularity, which on some CI systems
+	// has sub-microsecond resolution but identical adjacent calls.
+	time.Sleep(1 * time.Millisecond)
+	d.emit(rec, makeDedupeObj("u2"), corev1.EventTypeWarning, "R", "msg")
+	time.Sleep(1 * time.Millisecond)
+	d.emit(rec, makeDedupeObj("u3"), corev1.EventTypeWarning, "R", "msg") // forces u1 eviction
+	d.emit(rec, makeDedupeObj("u1"), corev1.EventTypeWarning, "R", "msg") // would have been deduped if u1 still cached
+
+	require.Len(t, rec.Events, 4, "cap-2 cache must evict u1, allowing the re-emit")
+}

--- a/internal/controller/tunnel/gateway_source_controller.go
+++ b/internal/controller/tunnel/gateway_source_controller.go
@@ -24,7 +24,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +33,6 @@ import (
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
-	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 	"github.com/jacaudi/cloudflare-operator/internal/tunnelsynth"
 )
 
@@ -269,46 +267,21 @@ func listenerHostnames(gw *gwv1.Gateway) []string {
 	return out
 }
 
-// emitDNSRecord creates (idempotently) a CloudflareDNSRecord CR for one
-// Gateway listener hostname, owner-reffed to the Gateway and stamped with
-// source labels. The CR name uses the same hash-suffixed scheme as the
-// Service source reconciler (emittedDNSRecordName helper) so we never collide
-// across alias hostnames or get truncated into a clash.
+// emitDNSRecord upserts the CloudflareDNSRecord CR for this Gateway +
+// hostname pair via the shared SSA-based helper. Annotation drift
+// (cloudflare.io/adopt, cloudflare.io/zone-ref) propagates to the emitted
+// CR because EmitDNSRecord uses SSA.
 //
-// Per spec 2 contract:
-//   - spec.zoneRef.name (resolved by the zone reconciler) when
-//     cloudflare.io/zone-ref is set on the Gateway — never spec.zoneID
-//   - spec.type = CNAME
-//   - spec.name = hostname
-//   - spec.content = tunnel CNAME (caller guards non-empty)
-//   - spec.adopt threaded from cloudflare.io/adopt
+// Operator-edits-win: a user `kubectl edit` on the emitted CR will be
+// reverted on the next reconcile.
 func (r *GatewaySourceReconciler) emitDNSRecord(ctx context.Context, gw *gwv1.Gateway, hostname string, tn *v1alpha1.CloudflareTunnel) error {
-	content := tn.Status.TunnelCNAME // copy so we can take its address
-	dr := &v1alpha1.CloudflareDNSRecord{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      emittedDNSRecordName(gw.Name, hostname),
-			Namespace: gw.Namespace,
-		},
-		Spec: v1alpha1.CloudflareDNSRecordSpec{
-			Type:    "CNAME",
-			Name:    hostname,
-			Content: &content,
-		},
-	}
-	reconcilelib.StampSourceLabels(dr, "Gateway", gw.Name, gw.Namespace)
-	if err := reconcilelib.SetControllerOwner(gw, dr, r.Scheme); err != nil {
-		return err
-	}
-	if zr := gw.Annotations[conventions.AnnotationZoneRef]; zr != "" {
-		dr.Spec.ZoneRef = &v1alpha1.ZoneReference{Name: zr, Namespace: gw.Namespace}
-	}
-	if adopt, _ := conventions.ParseTruthy(gw.Annotations[conventions.AnnotationAdopt]); adopt {
-		dr.Spec.Adopt = true
-	}
-	if err := r.Create(ctx, dr); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	return nil
+	return EmitDNSRecord(ctx, r.Client, r.Scheme, EmitOpts{
+		Owner:       gw,
+		OwnerKind:   "Gateway",
+		Hostname:    hostname,
+		Content:     tn.Status.TunnelCNAME,
+		Annotations: gw.GetAnnotations(),
+	})
 }
 
 var _ reconcile.Reconciler = (*GatewaySourceReconciler)(nil)

--- a/internal/controller/tunnel/gateway_source_controller.go
+++ b/internal/controller/tunnel/gateway_source_controller.go
@@ -85,7 +85,9 @@ func (r *GatewaySourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
-		r.dedupe = newEventDedupe(0, 0)
+		if r.dedupe == nil {
+			r.dedupe = newEventDedupe(0, 0)
+		}
 	})
 }
 

--- a/internal/controller/tunnel/gateway_source_controller.go
+++ b/internal/controller/tunnel/gateway_source_controller.go
@@ -74,6 +74,7 @@ type GatewaySourceReconciler struct {
 
 	tracker     *cacheTracker
 	trackerOnce sync.Once
+	dedupe      *eventDedupe // D2 event dedupe; lazy-inited inside trackerOnce.
 }
 
 // ensureTracker initializes r.tracker exactly once. Safe against concurrent
@@ -84,6 +85,7 @@ func (r *GatewaySourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
+		r.dedupe = newEventDedupe(0, 0)
 	})
 }
 
@@ -135,7 +137,7 @@ func (r *GatewaySourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 	hostnames := listenerHostnames(&gw)
 	if len(hostnames) == 0 {
 		if r.Recorder != nil {
-			r.Recorder.Eventf(&gw, corev1.EventTypeWarning, conventions.ReasonNoListenerHostname,
+			r.dedupe.emit(r.Recorder, &gw, corev1.EventTypeWarning, conventions.ReasonNoListenerHostname,
 				"Gateway has no listener with a hostname; tunnel-apex synthesis requires at least one")
 		}
 		if prev, ok := r.tracker.sweep(srcKey); ok {
@@ -154,7 +156,7 @@ func (r *GatewaySourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 			reason = conventions.ReasonNameTooLong
 		}
 		if r.Recorder != nil {
-			r.Recorder.Eventf(&gw, corev1.EventTypeWarning, reason, "%v", err)
+			r.dedupe.emit(r.Recorder, &gw, corev1.EventTypeWarning, reason, err.Error())
 		}
 		if prev, ok := r.tracker.sweep(srcKey); ok {
 			r.Cache.Clear(prev, srcKey)
@@ -174,7 +176,7 @@ func (r *GatewaySourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 			reason = conventions.ReasonGatewayServiceUnresolved
 		}
 		if r.Recorder != nil {
-			r.Recorder.Eventf(&gw, corev1.EventTypeWarning, reason, "%v", err)
+			r.dedupe.emit(r.Recorder, &gw, corev1.EventTypeWarning, reason, err.Error())
 		}
 		if prev, ok := r.tracker.sweep(srcKey); ok {
 			r.Cache.Clear(prev, srcKey)
@@ -211,8 +213,8 @@ func (r *GatewaySourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 			// separate contribution under the same tunnel-key without clash.
 		default:
 			if r.Recorder != nil {
-				r.Recorder.Eventf(&gw, corev1.EventTypeWarning, conventions.ReasonUnsupportedProtocol,
-					"listener %q protocol %s not supported on tunnel-apex Gateway", l.Name, l.Protocol)
+				r.dedupe.emit(r.Recorder, &gw, corev1.EventTypeWarning, conventions.ReasonUnsupportedProtocol,
+					fmt.Sprintf("listener %q protocol %s not supported on tunnel-apex Gateway", l.Name, l.Protocol))
 			}
 		}
 	}

--- a/internal/controller/tunnel/gateway_source_controller_test.go
+++ b/internal/controller/tunnel/gateway_source_controller_test.go
@@ -33,6 +33,7 @@ import (
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 	"github.com/jacaudi/cloudflare-operator/internal/tunnelsynth"
 )
 
@@ -104,8 +105,9 @@ func TestGatewaySource_HappyPath(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-gw-ns-edge", "gw-ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareDNSRecord{}, &v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
@@ -151,8 +153,9 @@ func TestGatewaySource_AutoCreateStampsSourceLabels(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "envoy-gw", Namespace: "gw-ns"},
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: tunnelsynth.NewCache(),
@@ -177,7 +180,8 @@ func TestGatewaySource_OptOut_ClearsCache(t *testing.T) {
 		},
 		Spec: gwv1.GatewaySpec{},
 	}
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).Build()
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	// Pre-populate a stale entry for this source.
 	cache.Set(tunnelsynth.TunnelKey{Namespace: "ns", Name: "cf-ns"},
@@ -204,8 +208,9 @@ func TestGatewaySource_NoGatewayServiceAnnotation_RejectsWithEvent(t *testing.T)
 		},
 		Spec: gwv1.GatewaySpec{Listeners: []gwv1.Listener{gwListener("h", "h.example.com", 80, gwv1.HTTPProtocolType)}},
 	}
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	rec := record.NewFakeRecorder(8)
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: tunnelsynth.NewCache(), Recorder: rec,
@@ -239,7 +244,8 @@ func TestGatewaySource_NoListenerHostname_RejectsWithEvent(t *testing.T) {
 		},
 		Spec: gwv1.GatewaySpec{Listeners: []gwv1.Listener{{Name: "n", Port: 80, Protocol: gwv1.HTTPProtocolType}}},
 	}
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).Build()
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	rec := record.NewFakeRecorder(8)
 	r := &GatewaySourceReconciler{Client: c, Scheme: gwScheme(t), Cache: tunnelsynth.NewCache(), Recorder: rec}
 
@@ -261,8 +267,9 @@ func TestGatewaySource_MultipleListenerHostnames(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -295,8 +302,9 @@ func TestGatewaySource_TunnelCNAMEEmpty_DefersEmission(t *testing.T) {
 		},
 		// No Status.TunnelCNAME.
 	}
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, tn).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -321,8 +329,9 @@ func TestGatewaySource_AnnotationPortOverride(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -344,8 +353,9 @@ func TestGatewaySource_FallsBackToServiceFirstPort(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 8080}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -387,8 +397,9 @@ func TestGatewaySource_AllTLSListeners_RegistersEmptyContribs(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -429,8 +440,9 @@ func TestGatewaySource_UnsupportedProtocol_EmitsEvent(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	rec := record.NewFakeRecorder(16)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
@@ -481,8 +493,9 @@ func TestGatewaySource_HTTPSScheme(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 443}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -506,8 +519,9 @@ func TestGatewaySource_AnnotationChangeSweepsPriorKey(t *testing.T) {
 	}
 	tnA := gwPreCreatedTunnel("cf-ns-edge", "ns")
 	tnB := gwPreCreatedTunnel("cf-ns-billing", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, tnA, tnB).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, tnA, tnB).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -538,8 +552,9 @@ func TestGatewaySource_GatewayDeletedSweepsCache(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: cache,
@@ -566,8 +581,9 @@ func TestGatewaySource_ZoneRefAndAdoptThreaded(t *testing.T) {
 		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := gwPreCreatedTunnel("cf-ns-edge", "ns")
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw, svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := &GatewaySourceReconciler{
 		Client: c, Scheme: gwScheme(t), Cache: tunnelsynth.NewCache(),
 		DefaultConnector: v1alpha1.ConnectorSpec{Replicas: 2, Protocol: "auto", LogLevel: "info", GracePeriodSeconds: 30},
@@ -587,7 +603,8 @@ func TestGatewaySource_ZoneRefAndAdoptThreaded(t *testing.T) {
 func TestGatewaySource_InvalidName_StatusEventOnly(t *testing.T) {
 	gw := mkGw("gw", "ns", "ns/gw-svc", []string{"a.example.com"})
 	gw.Annotations[conventions.AnnotationTunnelName] = "Invalid_Name" // uppercase + underscore
-	c := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).Build()
+	base := fake.NewClientBuilder().WithScheme(gwScheme(t)).WithObjects(gw).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	rec := record.NewFakeRecorder(8)
 	r := &GatewaySourceReconciler{Client: c, Scheme: gwScheme(t), Cache: tunnelsynth.NewCache(), Recorder: rec}
 

--- a/internal/controller/tunnel/httproute_source_controller.go
+++ b/internal/controller/tunnel/httproute_source_controller.go
@@ -280,49 +280,22 @@ func firstListenerHostname(gw *gwv1.Gateway) string {
 	return hosts[0]
 }
 
-// emitChainDNSRecord creates (idempotently) a CloudflareDNSRecord CR for one
-// Route hostname pointing at the Gateway apex (the CNAME chain's middle hop).
+// emitChainDNSRecord upserts the chain CloudflareDNSRecord CR (route
+// hostname → Gateway apex) for this HTTPRoute + hostname pair via the
+// shared SSA-based helper. Annotation drift (cloudflare.io/adopt,
+// cloudflare.io/zone-ref) propagates to the emitted CR because
+// EmitDNSRecord uses SSA.
 //
-// Per design §4.2: <route-hostname> → <gateway-apex-hostname> → <tunnel-CNAME>.
-// The intermediate stabilizes per-Route DNS even if the tunnel CR is
-// recreated.
-//
-// Per spec 2 contract:
-//   - spec.zoneRef.name (resolved by the zone reconciler) when
-//     cloudflare.io/zone-ref is set on the Route — never spec.zoneID
-//   - spec.type = CNAME
-//   - spec.name = hostname
-//   - spec.content = gateway apex (caller guards non-empty)
-//   - spec.adopt threaded from cloudflare.io/adopt
-//
-// Uses emittedDNSRecordName (attach.go) for collision-safe CR naming.
+// Operator-edits-win: a user `kubectl edit` on the emitted CR will be
+// reverted on the next reconcile.
 func (r *HTTPRouteSourceReconciler) emitChainDNSRecord(ctx context.Context, rt *gwv1.HTTPRoute, hostname, gwApex string) error {
-	content := gwApex // copy so we can take its address (Spec.Content is *string)
-	dr := &v1alpha1.CloudflareDNSRecord{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      emittedDNSRecordName(rt.Name, hostname),
-			Namespace: rt.Namespace,
-		},
-		Spec: v1alpha1.CloudflareDNSRecordSpec{
-			Type:    "CNAME",
-			Name:    hostname,
-			Content: &content,
-		},
-	}
-	reconcilelib.StampSourceLabels(dr, "HTTPRoute", rt.Name, rt.Namespace)
-	if err := reconcilelib.SetControllerOwner(rt, dr, r.Scheme); err != nil {
-		return err
-	}
-	if zr := rt.Annotations[conventions.AnnotationZoneRef]; zr != "" {
-		dr.Spec.ZoneRef = &v1alpha1.ZoneReference{Name: zr, Namespace: rt.Namespace}
-	}
-	if adopt, _ := conventions.ParseTruthy(rt.Annotations[conventions.AnnotationAdopt]); adopt {
-		dr.Spec.Adopt = true
-	}
-	if err := r.Create(ctx, dr); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	return nil
+	return EmitDNSRecord(ctx, r.Client, r.Scheme, EmitOpts{
+		Owner:       rt,
+		OwnerKind:   "HTTPRoute",
+		Hostname:    hostname,
+		Content:     gwApex,
+		Annotations: rt.GetAnnotations(),
+	})
 }
 
 // writeParentStatus is the parent-only status write. Touches ONLY the

--- a/internal/controller/tunnel/httproute_source_controller.go
+++ b/internal/controller/tunnel/httproute_source_controller.go
@@ -91,7 +91,9 @@ func (r *HTTPRouteSourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
-		r.dedupe = newEventDedupe(0, 0)
+		if r.dedupe == nil {
+			r.dedupe = newEventDedupe(0, 0)
+		}
 	})
 }
 

--- a/internal/controller/tunnel/httproute_source_controller.go
+++ b/internal/controller/tunnel/httproute_source_controller.go
@@ -80,6 +80,7 @@ type HTTPRouteSourceReconciler struct {
 
 	tracker     *cacheTracker
 	trackerOnce sync.Once
+	dedupe      *eventDedupe // D2 event dedupe; lazy-inited inside trackerOnce.
 }
 
 // ensureTracker initializes r.tracker exactly once. Safe against concurrent
@@ -90,6 +91,7 @@ func (r *HTTPRouteSourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
+		r.dedupe = newEventDedupe(0, 0)
 	})
 }
 
@@ -166,7 +168,7 @@ func (r *HTTPRouteSourceReconciler) Reconcile(ctx context.Context, req reconcile
 	// Surface translator warnings as Events for operator visibility.
 	if r.Recorder != nil {
 		for _, w := range warns {
-			r.Recorder.Eventf(&rt, corev1.EventTypeWarning, w.Reason, "%s", w.Message)
+			r.dedupe.emit(r.Recorder, &rt, corev1.EventTypeWarning, w.Reason, w.Message)
 		}
 	}
 

--- a/internal/controller/tunnel/httproute_source_controller_test.go
+++ b/internal/controller/tunnel/httproute_source_controller_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 	"github.com/jacaudi/cloudflare-operator/internal/tunnelsynth"
 )
 
@@ -94,8 +95,9 @@ func TestHTTPRouteSource_HappyPath(t *testing.T) {
 			Rules: []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareTunnel{}).Build()
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
@@ -148,8 +150,9 @@ func TestHTTPRouteSource_FilterRejected_PartiallyInvalid(t *testing.T) {
 			Rules:           []gwv1.HTTPRouteRule{{Filters: []gwv1.HTTPRouteFilter{{Type: gwv1.HTTPRouteFilterRequestRedirect}}}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: tunnelsynth.NewCache()}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
@@ -189,8 +192,9 @@ func TestHTTPRouteSource_MultiParent_OnlyTunnelTargetedTouched(t *testing.T) {
 			Rules: []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: tunnelsynth.NewCache()}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
 	require.NoError(t, err)
@@ -242,8 +246,9 @@ func TestHTTPRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 			},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: tunnelsynth.NewCache()}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
@@ -290,8 +295,9 @@ func TestHTTPRouteSource_DeferredOnEmptyTunnelCNAME(t *testing.T) {
 			Rules:           []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
 		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
@@ -325,8 +331,9 @@ func TestHTTPRouteSource_NoTunnelTargetedParent(t *testing.T) {
 			Rules:           []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(otherGw, rt).
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(otherGw, rt).
 		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
@@ -359,8 +366,9 @@ func TestHTTPRouteSource_DeleteSweepsCache(t *testing.T) {
 			Rules:           []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
 
@@ -408,8 +416,9 @@ func TestHTTPRouteSource_MultipleHostnames_EmitsPerHostname(t *testing.T) {
 			Rules: []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
@@ -487,8 +496,9 @@ func TestHTTPRouteSource_TwoTunnelTargetedParents_FirstWins(t *testing.T) {
 			Rules: []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw1, gw2, tn1, tn2, gwSvc, rt).
-		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw1, gw2, tn1, tn2, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
 
@@ -523,8 +533,9 @@ func TestHTTPRouteSource_ParentGatewayNotFound_Skips(t *testing.T) {
 			Rules: []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(rt).
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(rt).
 		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
 
@@ -577,8 +588,9 @@ func TestHTTPRouteSource_GatewayServiceUnresolved_Skips(t *testing.T) {
 			Rules: []gwv1.HTTPRouteRule{{}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, rt).
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, rt).
 		WithStatusSubresource(&gwv1.HTTPRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: cache}
 

--- a/internal/controller/tunnel/service_source_controller.go
+++ b/internal/controller/tunnel/service_source_controller.go
@@ -27,7 +27,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +35,6 @@ import (
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
-	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 	"github.com/jacaudi/cloudflare-operator/internal/tunnelsynth"
 )
 
@@ -201,42 +199,21 @@ func (r *ServiceSourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 	return reconcile.Result{}, nil
 }
 
-// emitDNSRecord creates (idempotently) a CloudflareDNSRecord CR for the given
-// hostname, owner-reffed to the Service and stamped with source labels.
+// emitDNSRecord upserts the CloudflareDNSRecord CR for this Service +
+// hostname pair via the shared SSA-based helper. Annotation drift
+// (cloudflare.io/adopt, cloudflare.io/zone-ref) propagates to the emitted
+// CR because EmitDNSRecord uses SSA.
 //
-// Per spec 2 contract:
-//   - spec.zoneRef.name (resolved by the zone reconciler from
-//     cloudflare.io/zone-ref OR longest-suffix match) — never spec.zoneID
-//   - spec.type = CNAME
-//   - spec.name = hostname
-//   - spec.content = tunnel CNAME (populated; guarded by caller)
+// Operator-edits-win: a user `kubectl edit` on the emitted CR will be
+// reverted on the next reconcile.
 func (r *ServiceSourceReconciler) emitDNSRecord(ctx context.Context, svc *corev1.Service, hostname string, tn *v1alpha1.CloudflareTunnel) error {
-	content := tn.Status.TunnelCNAME // copy to take address; caller guards non-empty
-	dr := &v1alpha1.CloudflareDNSRecord{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      emittedDNSRecordName(svc.Name, hostname),
-			Namespace: svc.Namespace,
-		},
-		Spec: v1alpha1.CloudflareDNSRecordSpec{
-			Type:    "CNAME",
-			Name:    hostname,
-			Content: &content,
-		},
-	}
-	reconcilelib.StampSourceLabels(dr, "Service", svc.Name, svc.Namespace)
-	if err := reconcilelib.SetControllerOwner(svc, dr, r.Scheme); err != nil {
-		return err
-	}
-	if zr := svc.Annotations[conventions.AnnotationZoneRef]; zr != "" {
-		dr.Spec.ZoneRef = &v1alpha1.ZoneReference{Name: zr, Namespace: svc.Namespace}
-	}
-	if adopt, _ := conventions.ParseTruthy(svc.Annotations[conventions.AnnotationAdopt]); adopt {
-		dr.Spec.Adopt = true
-	}
-	if err := r.Create(ctx, dr); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	return nil
+	return EmitDNSRecord(ctx, r.Client, r.Scheme, EmitOpts{
+		Owner:       svc,
+		OwnerKind:   "Service",
+		Hostname:    hostname,
+		Content:     tn.Status.TunnelCNAME,
+		Annotations: svc.GetAnnotations(),
+	})
 }
 
 // emittedDNSRecordName produces a stable, DNS-1123-compliant CR name combining

--- a/internal/controller/tunnel/service_source_controller.go
+++ b/internal/controller/tunnel/service_source_controller.go
@@ -83,7 +83,9 @@ func (r *ServiceSourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
-		r.dedupe = newEventDedupe(0, 0)
+		if r.dedupe == nil {
+			r.dedupe = newEventDedupe(0, 0)
+		}
 	})
 }
 

--- a/internal/controller/tunnel/service_source_controller.go
+++ b/internal/controller/tunnel/service_source_controller.go
@@ -72,6 +72,7 @@ type ServiceSourceReconciler struct {
 
 	tracker     *cacheTracker
 	trackerOnce sync.Once
+	dedupe      *eventDedupe // D2 event dedupe; lazy-inited inside trackerOnce.
 }
 
 // ensureTracker initializes r.tracker exactly once. Safe against concurrent
@@ -82,6 +83,7 @@ func (r *ServiceSourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
+		r.dedupe = newEventDedupe(0, 0)
 	})
 }
 
@@ -137,7 +139,7 @@ func (r *ServiceSourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 			reason = conventions.ReasonNameTooLong
 		}
 		if r.Recorder != nil {
-			r.Recorder.Eventf(&svc, corev1.EventTypeWarning, reason, "%v", err)
+			r.dedupe.emit(r.Recorder, &svc, corev1.EventTypeWarning, reason, err.Error())
 		}
 		// Sweep any stale prior key — the source is now in a broken state and
 		// must not contribute to any tunnel.
@@ -156,7 +158,7 @@ func (r *ServiceSourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 	contribs, warns := tunnelsynth.TranslateService(&svc, tunnelsynth.Defaults{})
 	for _, w := range warns {
 		if r.Recorder != nil {
-			r.Recorder.Eventf(&svc, corev1.EventTypeWarning, w.Reason, "%s", w.Message)
+			r.dedupe.emit(r.Recorder, &svc, corev1.EventTypeWarning, w.Reason, w.Message)
 		}
 	}
 

--- a/internal/controller/tunnel/service_source_controller_test.go
+++ b/internal/controller/tunnel/service_source_controller_test.go
@@ -589,8 +589,8 @@ func TestEmittedDNSRecordNameDNS1123Compliant(t *testing.T) {
 // TestEmittedDNSRecordName_NoCollisionOnSanitizedAlias verifies that two
 // hostnames which sanitize to the same prefix (because the only difference
 // is non-alphanumeric punctuation) still produce distinct CR names. Without
-// the hash suffix, the second hostname's DNSRecord would be silently dropped
-// because emitDNSRecord swallows IsAlreadyExists.
+// the hash suffix, the second hostname's DNSRecord would be
+// silently overwritten by the second SSA Apply on the same CR name.
 func TestEmittedDNSRecordName_NoCollisionOnSanitizedAlias(t *testing.T) {
 	a := emittedDNSRecordName("svc", "foo.example.com")
 	b := emittedDNSRecordName("svc", "foo-example-com")

--- a/internal/controller/tunnel/service_source_controller_test.go
+++ b/internal/controller/tunnel/service_source_controller_test.go
@@ -33,6 +33,7 @@ import (
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 	"github.com/jacaudi/cloudflare-operator/internal/tunnelsynth"
 )
 
@@ -78,8 +79,9 @@ func TestServiceSource_OptInCreatesTunnelAndDNSRecord(t *testing.T) {
 	// Pre-create the tunnel with TunnelCNAME populated so the source
 	// reconciler proceeds to emit the DNSRecord on first reconcile.
 	tn := preCreatedTunnel("cf-app-foo-payments", "app-foo")
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
 		WithStatusSubresource(&v1alpha1.CloudflareDNSRecord{}, &v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &ServiceSourceReconciler{
@@ -137,8 +139,9 @@ func TestServiceSource_AutoCreateStampsSourceLabels(t *testing.T) {
 	}
 	// NO pre-created tunnel — exercise the auto-create path through
 	// EnsureTunnelCR so the source-labels stamp is observable.
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: tunnelsynth.NewCache(),
@@ -166,8 +169,9 @@ func TestServiceSource_NoTunnelNameAttachesToNamespacePool(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &ServiceSourceReconciler{Client: c, Scheme: srcScheme(t), Cache: tunnelsynth.NewCache()}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app-foo", Name: "svc"}})
@@ -185,7 +189,8 @@ func TestServiceSource_OptOut_ClearsCache(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	cache.Set(tunnelsynth.TunnelKey{Namespace: "ns", Name: "cf-ns"},
@@ -216,7 +221,8 @@ func TestServiceSource_OptOutSweepsBothPoolAndNamed(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	cache.Set(tunnelsynth.TunnelKey{Namespace: "ns", Name: "cf-ns-billing"},
 		tunnelsynth.SourceKey{Kind: "Service", Namespace: "ns", Name: "svc"},
@@ -247,8 +253,9 @@ func TestServiceSource_AnnotationChangeSweepsPriorKey(t *testing.T) {
 	}
 	tnA := preCreatedTunnel("cf-ns-payments", "ns")
 	tnB := preCreatedTunnel("cf-ns-billing", "ns")
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svcA, tnA, tnB).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svcA, tnA, tnB).
 		WithStatusSubresource(&v1alpha1.CloudflareDNSRecord{}, &v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &ServiceSourceReconciler{
@@ -291,7 +298,8 @@ func TestServiceSource_NameTooLong_StatusEventOnly(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	rec := record.NewFakeRecorder(8)
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: tunnelsynth.NewCache(), Recorder: rec,
@@ -325,8 +333,9 @@ func TestServiceSource_MultipleHostnames_EmitsOneRecordEach(t *testing.T) {
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	tn := preCreatedTunnel("cf-app-foo-payments", "app-foo")
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
 		WithStatusSubresource(&v1alpha1.CloudflareDNSRecord{}, &v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: tunnelsynth.NewCache(),
@@ -373,8 +382,9 @@ func TestServiceSource_TunnelCNAMEEmpty_DefersEmission(t *testing.T) {
 			},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
 		WithStatusSubresource(&v1alpha1.CloudflareDNSRecord{}, &v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: cache,
@@ -407,8 +417,9 @@ func TestServiceSource_ZoneRefAnnotation_ThreadedToDNSRecord(t *testing.T) {
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	tn := preCreatedTunnel("cf-app-foo-payments", "app-foo")
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, tn).
 		WithStatusSubresource(&v1alpha1.CloudflareDNSRecord{}, &v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: tunnelsynth.NewCache(),
@@ -441,8 +452,9 @@ func TestServiceSource_ServiceDeletedSweepsCache(t *testing.T) {
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := preCreatedTunnel("cf-ns-payments", "ns")
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareDNSRecord{}, &v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: cache,
@@ -480,7 +492,8 @@ func TestServiceSource_InvalidName_StatusEventOnly(t *testing.T) {
 		},
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	rec := record.NewFakeRecorder(10)
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: tunnelsynth.NewCache(), Recorder: rec,
@@ -519,8 +532,9 @@ func TestServiceSource_TranslatorWarningsEmitEvents(t *testing.T) {
 		Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 80}}},
 	}
 	preTun := preCreatedTunnel("cf-ns-payments", "ns")
-	c := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, preTun).
+	base := fake.NewClientBuilder().WithScheme(srcScheme(t)).WithObjects(svc, preTun).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	rec := record.NewFakeRecorder(10)
 	r := &ServiceSourceReconciler{
 		Client: c, Scheme: srcScheme(t), Cache: tunnelsynth.NewCache(), Recorder: rec,

--- a/internal/controller/tunnel/tlsroute_source_controller.go
+++ b/internal/controller/tunnel/tlsroute_source_controller.go
@@ -267,42 +267,22 @@ func (r *TLSRouteSourceReconciler) findTunnelTargetedParent(
 // Route hostname pointing at the Gateway apex (the CNAME chain's middle hop).
 //
 // Per design §4.2 / §4.3: <route-hostname> → <gateway-apex> → <tunnel-CNAME>.
-// Per spec 2 contract:
-//   - spec.zoneRef.name (resolved by the zone reconciler) when
-//     cloudflare.io/zone-ref is set on the Route — never spec.zoneID;
-//   - spec.type = CNAME;
-//   - spec.name = hostname;
-//   - spec.content = gateway apex (caller guards non-empty);
-//   - spec.adopt threaded from cloudflare.io/adopt.
+// emitChainDNSRecord upserts the chain CloudflareDNSRecord CR (route
+// hostname → Gateway apex) for this TLSRoute + hostname pair via the
+// shared SSA-based helper. Annotation drift (cloudflare.io/adopt,
+// cloudflare.io/zone-ref) propagates to the emitted CR because
+// EmitDNSRecord uses SSA.
 //
-// Uses emittedDNSRecordName (attach.go) for collision-safe CR naming.
+// Operator-edits-win: a user `kubectl edit` on the emitted CR will be
+// reverted on the next reconcile.
 func (r *TLSRouteSourceReconciler) emitChainDNSRecord(ctx context.Context, rt *gwv1a2.TLSRoute, hostname, gwApex string) error {
-	content := gwApex // copy so we can take its address (Spec.Content is *string)
-	dr := &v1alpha1.CloudflareDNSRecord{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      emittedDNSRecordName(rt.Name, hostname),
-			Namespace: rt.Namespace,
-		},
-		Spec: v1alpha1.CloudflareDNSRecordSpec{
-			Type:    "CNAME",
-			Name:    hostname,
-			Content: &content,
-		},
-	}
-	reconcilelib.StampSourceLabels(dr, "TLSRoute", rt.Name, rt.Namespace)
-	if err := reconcilelib.SetControllerOwner(rt, dr, r.Scheme); err != nil {
-		return err
-	}
-	if zr := rt.Annotations[conventions.AnnotationZoneRef]; zr != "" {
-		dr.Spec.ZoneRef = &v1alpha1.ZoneReference{Name: zr, Namespace: rt.Namespace}
-	}
-	if adopt, _ := conventions.ParseTruthy(rt.Annotations[conventions.AnnotationAdopt]); adopt {
-		dr.Spec.Adopt = true
-	}
-	if err := r.Create(ctx, dr); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	return nil
+	return EmitDNSRecord(ctx, r.Client, r.Scheme, EmitOpts{
+		Owner:       rt,
+		OwnerKind:   "TLSRoute",
+		Hostname:    hostname,
+		Content:     gwApex,
+		Annotations: rt.GetAnnotations(),
+	})
 }
 
 // writeParentStatus is the parent-only status write. Touches ONLY the

--- a/internal/controller/tunnel/tlsroute_source_controller.go
+++ b/internal/controller/tunnel/tlsroute_source_controller.go
@@ -81,6 +81,7 @@ type TLSRouteSourceReconciler struct {
 
 	tracker     *cacheTracker
 	trackerOnce sync.Once
+	dedupe      *eventDedupe // D2 event dedupe; lazy-inited inside trackerOnce.
 }
 
 // ensureTracker initializes r.tracker exactly once. Safe against concurrent
@@ -91,6 +92,7 @@ func (r *TLSRouteSourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
+		r.dedupe = newEventDedupe(0, 0)
 	})
 }
 
@@ -178,7 +180,7 @@ func (r *TLSRouteSourceReconciler) Reconcile(ctx context.Context, req reconcile.
 	// Surface translator warnings as Events for operator visibility.
 	if r.Recorder != nil {
 		for _, w := range warns {
-			r.Recorder.Eventf(&rt, corev1.EventTypeWarning, w.Reason, "%s", w.Message)
+			r.dedupe.emit(r.Recorder, &rt, corev1.EventTypeWarning, w.Reason, w.Message)
 		}
 	}
 

--- a/internal/controller/tunnel/tlsroute_source_controller.go
+++ b/internal/controller/tunnel/tlsroute_source_controller.go
@@ -92,7 +92,9 @@ func (r *TLSRouteSourceReconciler) ensureTracker() {
 		if r.tracker == nil {
 			r.tracker = newCacheTracker()
 		}
-		r.dedupe = newEventDedupe(0, 0)
+		if r.dedupe == nil {
+			r.dedupe = newEventDedupe(0, 0)
+		}
 	})
 }
 

--- a/internal/controller/tunnel/tlsroute_source_controller_test.go
+++ b/internal/controller/tunnel/tlsroute_source_controller_test.go
@@ -33,6 +33,7 @@ import (
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 	"github.com/jacaudi/cloudflare-operator/internal/tunnelsynth"
 )
 
@@ -104,8 +105,9 @@ func TestTLSRouteSource_HappyPath_StampsClientSideClientRequired(t *testing.T) {
 			},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareTunnel{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
@@ -162,8 +164,9 @@ func TestTLSRouteSource_TCPProtocolURL(t *testing.T) {
 			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
@@ -191,8 +194,9 @@ func TestTLSRouteSource_NoTunnelTargetedParent(t *testing.T) {
 			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "other-gw", Namespace: ptrNs("gw-ns")}}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(otherGw, rt).
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(otherGw, rt).
 		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
@@ -230,8 +234,9 @@ func TestTLSRouteSource_MultiParent_OnlyTunnelTargetedTouched(t *testing.T) {
 			}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: tunnelsynth.NewCache()}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
 	require.NoError(t, err)
@@ -280,8 +285,9 @@ func TestTLSRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 			},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: tunnelsynth.NewCache()}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
@@ -325,8 +331,9 @@ func TestTLSRouteSource_DeleteSweepsCache(t *testing.T) {
 			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 
@@ -358,8 +365,9 @@ func TestTLSRouteSource_MultipleHostnames_EmitsPerHostname(t *testing.T) {
 			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 
@@ -395,8 +403,9 @@ func TestTLSRouteSource_DeferredOnEmptyTunnelCNAME(t *testing.T) {
 			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
 		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
@@ -456,8 +465,9 @@ func TestTLSRouteSource_TwoTunnelTargetedParents_FirstWins(t *testing.T) {
 			}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw1, gw2, tn1, tn2, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw1, gw2, tn1, tn2, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 
@@ -492,8 +502,9 @@ func TestTLSRouteSource_ParentGatewayNotFound_Skips(t *testing.T) {
 			}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(rt).
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(rt).
 		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 
@@ -549,8 +560,9 @@ func TestTLSRouteSource_GatewayServiceUnresolved_Skips(t *testing.T) {
 			}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, rt).
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, rt).
 		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 
@@ -618,8 +630,9 @@ func TestTLSRouteSource_NoListenerHostname_ZeroContribs_AcceptedFalse(t *testing
 			}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
 		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 
@@ -692,8 +705,9 @@ func TestTLSRouteSource_InheritsListenerHostname_WhenSpecEmpty(t *testing.T) {
 			}},
 		},
 	}
-	c := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
-		WithStatusSubresource(&gwv1a2.TLSRoute{}).Build()
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
 	cache := tunnelsynth.NewCache()
 	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: cache}
 

--- a/internal/controller/tunnel/tunnel_controller_test.go
+++ b/internal/controller/tunnel/tunnel_controller_test.go
@@ -19,7 +19,6 @@ package tunnel
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,44 +32,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	cloudflare "github.com/jacaudi/cloudflare-operator/internal/cloudflare"
 	mockcf "github.com/jacaudi/cloudflare-operator/internal/cloudflare/mock"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
 	"github.com/jacaudi/cloudflare-operator/internal/tunnelsynth"
 )
-
-// ssaTranslatingClient mirrors the bootstrap test helper: the fake client
-// doesn't natively support server-side apply, so this interceptor rewrites
-// SSA patches into Create-or-Update so the reconciler's Apply path is
-// exercised without envtest. Real SSA behaviour is covered by the envtest
-// suite under test/envtest/.
-func ssaTranslatingClient(t *testing.T, base client.WithWatch) client.WithWatch {
-	t.Helper()
-	return interceptor.NewClient(base, interceptor.Funcs{
-		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			if patch.Type() != types.ApplyPatchType {
-				return c.Patch(ctx, obj, patch, opts...)
-			}
-			key := client.ObjectKeyFromObject(obj)
-			existing, ok := obj.DeepCopyObject().(client.Object)
-			if !ok {
-				return fmt.Errorf("DeepCopyObject did not produce client.Object")
-			}
-			err := c.Get(ctx, key, existing)
-			if apierrors.IsNotFound(err) {
-				return c.Create(ctx, obj)
-			}
-			if err != nil {
-				return err
-			}
-			obj.SetResourceVersion(existing.GetResourceVersion())
-			return c.Update(ctx, obj)
-		},
-	})
-}
 
 func tunnelScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -117,7 +86,7 @@ func TestTunnelReconciler_CreatesTunnelAndDataplane(t *testing.T) {
 		WithObjects(tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).
 		Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	m := mockcf.New()
 	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
 
@@ -181,7 +150,7 @@ func TestTunnelReconciler_DriftSkipsPutWhenObservedMatches(t *testing.T) {
 	base := fake.NewClientBuilder().
 		WithScheme(s).WithObjects(tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
 
 	_, err = r.Reconcile(context.Background(), ctrl.Request{
@@ -219,7 +188,7 @@ func TestTunnelReconciler_FinalizerDrainSequence(t *testing.T) {
 	base := fake.NewClientBuilder().
 		WithScheme(s).WithObjects(tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
 
 	// Drain: with no Deployment present, the reconciler should proceed to
@@ -266,7 +235,7 @@ func TestTunnelReconciler_FinalizerDrain_TolerantOf404(t *testing.T) {
 	base := fake.NewClientBuilder().
 		WithScheme(s).WithObjects(tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
@@ -294,7 +263,7 @@ func TestTunnelReconciler_StatusConditionsWrittenByOuterFunction(t *testing.T) {
 	}
 	base := fake.NewClientBuilder().WithScheme(s).WithObjects(tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	m := mockcf.New()
 	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
 
@@ -347,7 +316,7 @@ func TestTunnelReconciler_NotReadyWhenDeploymentNotAvailable(t *testing.T) {
 	}
 	base := fake.NewClientBuilder().WithScheme(s).WithObjects(tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	m := mockcf.New()
 	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
 
@@ -426,7 +395,7 @@ func TestTunnelReconciler_CredentialsHaltUpdatesStatus(t *testing.T) {
 	}
 	base := fake.NewClientBuilder().WithScheme(s).WithObjects(tn).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 	m := mockcf.New()
 	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
 
@@ -469,7 +438,7 @@ func TestTunnelReconciler_DuplicateHostname_EmitsEventOnLoser(t *testing.T) {
 	base := fake.NewClientBuilder().
 		WithScheme(s).WithObjects(tn, winnerSvc, loserSvc).
 		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
-	c := ssaTranslatingClient(t, base)
+	c := reconcilelib.SSATranslatingClient(t, base)
 
 	cache := tunnelsynth.NewCache()
 	tk := tunnelsynth.TunnelKey{Namespace: "ns", Name: "tnl"}

--- a/internal/reconcile/ssatesthelper.go
+++ b/internal/reconcile/ssatesthelper.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// SSATranslatingClient wraps a controller-runtime fake client so that
+// server-side-apply Patch calls are translated into Create-or-Update. The
+// fake client does not natively support SSA; without this wrapper, unit
+// tests that exercise reconcilers using Apply() would fail with a
+// "patch type ApplyPatchType not supported" error.
+//
+// Real SSA semantics (e.g. field-manager ownership conflicts) are NOT
+// emulated — those are covered by the envtest suite under test/envtest/.
+// This helper exists solely to make reconciler unit tests exercise the same
+// Apply call path without spinning up a real apiserver.
+//
+// Usage:
+//
+//	base := fake.NewClientBuilder().WithScheme(s).Build()
+//	c    := reconcile.SSATranslatingClient(t, base)
+//	// pass c to the reconciler under test.
+//
+// The test parameter is used for t.Helper() so failures point at the caller.
+func SSATranslatingClient(t *testing.T, base client.WithWatch) client.WithWatch {
+	t.Helper()
+	return interceptor.NewClient(base, interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if patch.Type() != types.ApplyPatchType {
+				return c.Patch(ctx, obj, patch, opts...)
+			}
+			key := client.ObjectKeyFromObject(obj)
+			existing, ok := obj.DeepCopyObject().(client.Object)
+			if !ok {
+				return fmt.Errorf("SSATranslatingClient: DeepCopyObject did not produce client.Object")
+			}
+			err := c.Get(ctx, key, existing)
+			if apierrors.IsNotFound(err) {
+				return c.Create(ctx, obj)
+			}
+			if err != nil {
+				return err
+			}
+			obj.SetResourceVersion(existing.GetResourceVersion())
+			return c.Update(ctx, obj)
+		},
+	})
+}

--- a/internal/reconcile/ssatesthelper_test.go
+++ b/internal/reconcile/ssatesthelper_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconcile_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	reconcilelib "github.com/jacaudi/cloudflare-operator/internal/reconcile"
+)
+
+func TestSSATranslatingClient_CreatesWhenMissing(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	base := fake.NewClientBuilder().WithScheme(s).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+		Data:       map[string]string{"k": "v"},
+	}
+	require.NoError(t, reconcilelib.Apply(context.Background(), c, cm))
+
+	var got corev1.ConfigMap
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "cm", Namespace: "ns"}, &got))
+	require.Equal(t, "v", got.Data["k"])
+}
+
+func TestSSATranslatingClient_UpdatesWhenExists(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	existing := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+		Data:       map[string]string{"k": "old"},
+	}
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(existing).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"},
+		Data:       map[string]string{"k": "new"},
+	}
+	require.NoError(t, reconcilelib.Apply(context.Background(), c, cm))
+
+	var got corev1.ConfigMap
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "cm", Namespace: "ns"}, &got))
+	require.Equal(t, "new", got.Data["k"])
+}

--- a/test/envtest/tunnel_annotation_drift_test.go
+++ b/test/envtest/tunnel_annotation_drift_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+)
+
+// TestServiceSourceEnvtest_AnnotationChangePropagatesToDNSRecord pins the
+// SSA-pivot regression check against a real apiserver. The pre-pivot
+// Create+IsAlreadyExists path failed this silently: flipping
+// cloudflare.io/adopt on the source Service did not propagate to the
+// emitted CloudflareDNSRecord because Create returned IsAlreadyExists and
+// no Update path existed.
+//
+// After the SSA pivot (P2 T2-T6), the change must propagate.
+// See design D1 / docs/follow/tunnel-deferred.md Follow-up B for the
+// reproducer narrative.
+func TestServiceSourceEnvtest_AnnotationChangePropagatesToDNSRecord(t *testing.T) {
+	if sharedConfig == nil {
+		t.Skip("envtest not initialized (KUBEBUILDER_ASSETS unset)")
+	}
+	f := setupServiceEnv(t, "")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Zone CR for example.com — the emitted DNSRecord references this via
+	// spec.zoneRef per the same convention used in the sibling envtests.
+	zone := &v1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: f.ns},
+		Spec: v1alpha1.CloudflareZoneSpec{
+			Name:           "example.com",
+			Type:           "full",
+			DeletionPolicy: "Retain",
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, zone))
+
+	// Annotated Service with adopt=false initially.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc", Namespace: f.ns,
+			Annotations: map[string]string{
+				conventions.AnnotationTunnel:     "true",
+				conventions.AnnotationTunnelName: "payments",
+				conventions.AnnotationHostnames:  "foo.example.com",
+				conventions.AnnotationZoneRef:    "example-com",
+				conventions.AnnotationAdopt:      "false",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, svc))
+
+	// Wait for the tunnel CR + Status.TunnelCNAME (same as the sibling
+	// envtest's deferred-emission flow).
+	expectedTunnel := "cf-" + f.ns + "-payments"
+	require.Eventually(t, func() bool {
+		var tn v1alpha1.CloudflareTunnel
+		if err := f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: expectedTunnel}, &tn); err != nil {
+			return false
+		}
+		return tn.Status.TunnelCNAME != ""
+	}, 30*time.Second, 250*time.Millisecond, "tunnel Status.TunnelCNAME populated")
+
+	// Wait for the emitted DNSRecord with Spec.Adopt=false.
+	// List by namespace and filter — the namespace is unique to this test.
+	var initialDR *v1alpha1.CloudflareDNSRecord
+	require.Eventually(t, func() bool {
+		var list v1alpha1.CloudflareDNSRecordList
+		if err := f.c.List(ctx, &list, client.InNamespace(f.ns)); err != nil {
+			return false
+		}
+		for i := range list.Items {
+			dr := &list.Items[i]
+			if dr.Spec.Name == "foo.example.com" && !dr.Spec.Adopt {
+				initialDR = dr
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 250*time.Millisecond, "DNSRecord with Spec.Adopt=false should be emitted")
+	require.NotNil(t, initialDR)
+	drName := initialDR.Name
+
+	// Flip the annotation: adopt=false → adopt=true.
+	require.NoError(t, f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: "svc"}, svc))
+	svc.Annotations[conventions.AnnotationAdopt] = "true"
+	require.NoError(t, f.c.Update(ctx, svc))
+
+	// The next source-reconciler pass must propagate the annotation change
+	// to Spec.Adopt on the existing emitted CR. The silent-bug regression
+	// would leave Spec.Adopt=false here.
+	require.Eventually(t, func() bool {
+		var got v1alpha1.CloudflareDNSRecord
+		if err := f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: drName}, &got); err != nil {
+			return false
+		}
+		return got.Spec.Adopt
+	}, 30*time.Second, 250*time.Millisecond,
+		"after annotation flip, Spec.Adopt must become true (silent-bug regression catch)")
+}

--- a/test/envtest/tunnel_annotation_drift_test.go
+++ b/test/envtest/tunnel_annotation_drift_test.go
@@ -127,4 +127,12 @@ func TestServiceSourceEnvtest_AnnotationChangePropagatesToDNSRecord(t *testing.T
 		return got.Spec.Adopt
 	}, 30*time.Second, 250*time.Millisecond,
 		"after annotation flip, Spec.Adopt must become true (silent-bug regression catch)")
+
+	// The DNSRecord must be updated in place, not recreated. A future
+	// regression that accidentally introduced delete+recreate would pass
+	// the Spec.Adopt poll but break this UID assertion.
+	var finalDR v1alpha1.CloudflareDNSRecord
+	require.NoError(t, f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: drName}, &finalDR))
+	require.Equal(t, initialDR.UID, finalDR.UID,
+		"DNSRecord must be updated in place (UID preserved), not recreated")
 }


### PR DESCRIPTION
## Summary

Phase 2 of the post-refactor follow-up suite — tunnel-bundle hardening on top of `refactor/total`. Two design items from Section D: D1 (SSA pivot for the four source-reconciler emit helpers) and D2 (per-reconciler Event dedupe). 10 commits, +943/-306 LOC across 17 files. No CRD schema changes.

### What landed

**D1 — SSA pivot + emit consolidation**
- Lifted the duplicated `ssaTranslatingClient` test helper to `internal/reconcile/SSATranslatingClient` so all four source-reconciler test suites reuse the same SSA-translating fake-client wrapper.
- New `internal/controller/tunnel/EmitDNSRecord` helper routes every emitted `CloudflareDNSRecord` through `reconcile.Apply` (server-side apply) with `TypeMeta` set unconditionally and an `EmitOpts` parameter bag.
- Migrated the four source reconcilers (`Service`/`Gateway`/`HTTPRoute`/`TLSRoute`) to call the shared helper — the old 25-line `Create+IsAlreadyExists` bodies become 8-line shims.
- Fixes the silent annotation-drift bug: flipping `cloudflare.io/adopt` (or `cloudflare.io/zone-ref`) on a source object now propagates into the emitted CR's spec on the next reconcile, because SSA Patch updates in place where the prior Create+IsAlreadyExists path silently dropped the change.
- New envtest `TestServiceSourceEnvtest_AnnotationChangePropagatesToDNSRecord` pins the contract against a real apiserver, including a UID-identity assertion (update-in-place, not delete-and-recreate).

**D2 — Event dedupe**
- New `internal/controller/tunnel/eventDedupe` type — per-reconciler `(UID, reason, message)`-keyed suppression cache with 1h TTL and 1024-entry cap. Mutex-protected; safe to call concurrently and with a nil recorder.
- Wired into all eight `Recorder.Eventf` callsites in the four source reconcilers via lazy-init inside the existing `trackerOnce`.
- TLSRoute's always-emitted `ClientSideClientRequired` warning drops from 48/route/day to 1/route/hour in steady state.

### Operator-edits-win semantics (new)

`EmitDNSRecord`'s godoc now spells out that `Spec.Adopt` and `Spec.ZoneRef` are re-asserted from the source object's annotations every reconcile. Users must toggle these on the SOURCE (`cloudflare.io/adopt`, `cloudflare.io/zone-ref`), not on the emitted CR — a `kubectl edit` of the emitted CR will be reverted on the next reconcile.

### Review

Independent comprehensive review (full diff, no shared context) found 0 critical, 3 important, 5 minor. All 3 important + 2 actionable minor items folded into the final cleanup commit `c7f7172`. Remaining minors were non-issues per the reviewer's own assessment. Two observations deferred: `docs/follow/tunnel-deferred.md` update (local-only doc) and tunnel-reconciler Eventf dedupe (out of P2 scope; only source reconcilers were wired).

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -count=1 ./...` — 12 packages PASS
- [x] `go test ./test/envtest/...` with `KUBEBUILDER_ASSETS` set — PASS in 21.3s, including new annotation-drift regression case
- [ ] Smoke-deploy: exercise a Service annotation flip (`cloudflare.io/adopt: false` → `true`) and confirm the emitted DNSRecord's `Spec.Adopt` flips within one reconcile cycle
- [ ] Smoke-deploy: confirm TLSRoute `ClientSideClientRequired` warning emits only once per hour per route in steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)