### PR TITLE
P3: tunnel minor wiring (annotation inheritance, drift detect, orphan prune)

### DIFF
--- a/internal/controller/tunnel/annotation_inherit.go
+++ b/internal/controller/tunnel/annotation_inherit.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+)
+
+// inheritAnnotation returns the route's own value for `key` if set, falling
+// back to the parent Gateway's value. Per tunnel-controller design §5:
+// HTTPRoute and TLSRoute annotation values flow from the route, with
+// fallback to the Gateway the route attaches to.
+//
+// A nil Gateway is tolerated (returns the route's value or empty).
+func inheritAnnotation(routeAnnotations map[string]string, gw *gwv1.Gateway, key string) string {
+	if v, ok := routeAnnotations[key]; ok && v != "" {
+		return v
+	}
+	if gw == nil {
+		return ""
+	}
+	return gw.Annotations[key]
+}
+
+// inheritedAnnotations returns a merged annotation map where route values
+// take precedence over Gateway values, scoped to the cloudflare.io/* family
+// the source-emit path cares about. Threaded into EmitOpts.Annotations so
+// each emitted DNSRecord reflects the effective per-Gateway defaults +
+// per-route overrides.
+//
+// Returned map is always non-nil (callers index into it without guarding).
+func inheritedAnnotations(routeAnnotations map[string]string, gw *gwv1.Gateway) map[string]string {
+	keys := []string{
+		conventions.AnnotationZoneRef,
+		conventions.AnnotationAdopt,
+		conventions.AnnotationProxied,
+		conventions.AnnotationTTL,
+		conventions.AnnotationNoTLSVerify,
+		conventions.AnnotationOriginServerName,
+	}
+	out := make(map[string]string, len(keys))
+	for _, k := range keys {
+		if v := inheritAnnotation(routeAnnotations, gw, k); v != "" {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/internal/controller/tunnel/annotation_inherit_test.go
+++ b/internal/controller/tunnel/annotation_inherit_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestInheritAnnotation_RouteWins(t *testing.T) {
+	route := map[string]string{"cloudflare.io/adopt": "true"}
+	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"cloudflare.io/adopt": "false"}}}
+	require.Equal(t, "true", inheritAnnotation(route, gw, "cloudflare.io/adopt"))
+}
+
+func TestInheritAnnotation_FallsThroughToGateway(t *testing.T) {
+	route := map[string]string{}
+	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"cloudflare.io/adopt": "true"}}}
+	require.Equal(t, "true", inheritAnnotation(route, gw, "cloudflare.io/adopt"))
+}
+
+func TestInheritAnnotation_EmptyOnBothIsEmpty(t *testing.T) {
+	require.Equal(t, "", inheritAnnotation(map[string]string{}, &gwv1.Gateway{}, "cloudflare.io/adopt"))
+}
+
+func TestInheritAnnotation_NilGatewayTolerated(t *testing.T) {
+	route := map[string]string{"cloudflare.io/adopt": "true"}
+	require.Equal(t, "true", inheritAnnotation(route, nil, "cloudflare.io/adopt"))
+}
+
+func TestInheritedAnnotations_MergesFamily(t *testing.T) {
+	route := map[string]string{"cloudflare.io/adopt": "true"}
+	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+		"cloudflare.io/adopt":    "false", // route wins
+		"cloudflare.io/zone-ref": "shared-zone",
+	}}}
+	got := inheritedAnnotations(route, gw)
+	require.Equal(t, "true", got["cloudflare.io/adopt"], "route override wins")
+	require.Equal(t, "shared-zone", got["cloudflare.io/zone-ref"], "gateway value inherited when route unset")
+}

--- a/internal/controller/tunnel/annotation_inherit_test.go
+++ b/internal/controller/tunnel/annotation_inherit_test.go
@@ -22,36 +22,46 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
 )
 
 func TestInheritAnnotation_RouteWins(t *testing.T) {
-	route := map[string]string{"cloudflare.io/adopt": "true"}
-	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"cloudflare.io/adopt": "false"}}}
-	require.Equal(t, "true", inheritAnnotation(route, gw, "cloudflare.io/adopt"))
+	route := map[string]string{conventions.AnnotationAdopt: "true"}
+	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{conventions.AnnotationAdopt: "false"}}}
+	require.Equal(t, "true", inheritAnnotation(route, gw, conventions.AnnotationAdopt))
 }
 
 func TestInheritAnnotation_FallsThroughToGateway(t *testing.T) {
 	route := map[string]string{}
-	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"cloudflare.io/adopt": "true"}}}
-	require.Equal(t, "true", inheritAnnotation(route, gw, "cloudflare.io/adopt"))
+	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{conventions.AnnotationAdopt: "true"}}}
+	require.Equal(t, "true", inheritAnnotation(route, gw, conventions.AnnotationAdopt))
+}
+
+func TestInheritAnnotation_EmptyRouteValueFallsThroughToGateway(t *testing.T) {
+	// Route key present but explicitly empty must fall through to the
+	// Gateway value (the "set AND non-empty" half of the precedence rule).
+	route := map[string]string{conventions.AnnotationAdopt: ""}
+	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{conventions.AnnotationAdopt: "true"}}}
+	require.Equal(t, "true", inheritAnnotation(route, gw, conventions.AnnotationAdopt))
 }
 
 func TestInheritAnnotation_EmptyOnBothIsEmpty(t *testing.T) {
-	require.Equal(t, "", inheritAnnotation(map[string]string{}, &gwv1.Gateway{}, "cloudflare.io/adopt"))
+	require.Equal(t, "", inheritAnnotation(map[string]string{}, &gwv1.Gateway{}, conventions.AnnotationAdopt))
 }
 
 func TestInheritAnnotation_NilGatewayTolerated(t *testing.T) {
-	route := map[string]string{"cloudflare.io/adopt": "true"}
-	require.Equal(t, "true", inheritAnnotation(route, nil, "cloudflare.io/adopt"))
+	route := map[string]string{conventions.AnnotationAdopt: "true"}
+	require.Equal(t, "true", inheritAnnotation(route, nil, conventions.AnnotationAdopt))
 }
 
 func TestInheritedAnnotations_MergesFamily(t *testing.T) {
-	route := map[string]string{"cloudflare.io/adopt": "true"}
+	route := map[string]string{conventions.AnnotationAdopt: "true"}
 	gw := &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-		"cloudflare.io/adopt":    "false", // route wins
-		"cloudflare.io/zone-ref": "shared-zone",
+		conventions.AnnotationAdopt:   "false", // route wins
+		conventions.AnnotationZoneRef: "shared-zone",
 	}}}
 	got := inheritedAnnotations(route, gw)
-	require.Equal(t, "true", got["cloudflare.io/adopt"], "route override wins")
-	require.Equal(t, "shared-zone", got["cloudflare.io/zone-ref"], "gateway value inherited when route unset")
+	require.Equal(t, "true", got[conventions.AnnotationAdopt], "route override wins")
+	require.Equal(t, "shared-zone", got[conventions.AnnotationZoneRef], "gateway value inherited when route unset")
 }

--- a/internal/controller/tunnel/gateway_source_controller.go
+++ b/internal/controller/tunnel/gateway_source_controller.go
@@ -243,10 +243,26 @@ func (r *GatewaySourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 	}
 
 	// Emit one CloudflareDNSRecord (CNAME → tunnel CNAME) per listener hostname.
+	desired := make(map[string]struct{}, len(hostnames))
 	for _, h := range hostnames {
+		desired[h] = struct{}{}
 		if err := r.emitDNSRecord(ctx, &gw, h, tn); err != nil {
 			return reconcile.Result{}, fmt.Errorf("emit dns record for %q: %w", h, err)
 		}
+	}
+
+	// Prune previously-emitted DNSRecord CRs whose hostname is no longer in
+	// the desired set. Best-effort: a prune error logs and continues — the
+	// desired records are already emitted, and any surviving orphan is retried
+	// on the next reconcile. Placed strictly AFTER the emit loop on the
+	// post-emit path; never reached on the deferred-emission early-return
+	// above (where desired would be empty and would wrongly delete live CRs).
+	pruned, perr := pruneOrphanedDNSRecords(ctx, r.Client, "Gateway", gw.Name, gw.Namespace, desired)
+	if perr != nil {
+		logger.Error(perr, "orphan-prune failed (continuing)")
+	} else if len(pruned) > 0 {
+		r.dedupe.emit(r.Recorder, &gw, corev1.EventTypeNormal, conventions.ReasonOrphanedDNSRecordPruned,
+			fmt.Sprintf("deleted %d orphaned DNSRecord CR(s) for hostnames no longer in spec", len(pruned)))
 	}
 
 	// No cross-controller Status write: the tunnel reconciler reads

--- a/internal/controller/tunnel/httproute_source_controller.go
+++ b/internal/controller/tunnel/httproute_source_controller.go
@@ -190,10 +190,26 @@ func (r *HTTPRouteSourceReconciler) Reconcile(ctx context.Context, req reconcile
 	}
 
 	// Emit per-Route DNSRecord CRs: CNAME <hostname> → <gateway-apex>.
+	desired := make(map[string]struct{}, len(rt.Spec.Hostnames))
 	for _, h := range rt.Spec.Hostnames {
+		desired[string(h)] = struct{}{}
 		if err := r.emitChainDNSRecord(ctx, &rt, string(h), gwApex, gw); err != nil {
 			return reconcile.Result{}, fmt.Errorf("emit dns record for %q: %w", h, err)
 		}
+	}
+
+	// Prune previously-emitted DNSRecord CRs whose hostname is no longer in
+	// the desired set. Best-effort: a prune error logs and continues — the
+	// desired records are already emitted, and any surviving orphan is retried
+	// on the next reconcile. Placed strictly AFTER the emit loop on the
+	// post-emit path; never reached on the deferred-emission early-return
+	// above (where desired would be empty and would wrongly delete live CRs).
+	pruned, perr := pruneOrphanedDNSRecords(ctx, r.Client, "HTTPRoute", rt.Name, rt.Namespace, desired)
+	if perr != nil {
+		logger.Error(perr, "orphan-prune failed (continuing)")
+	} else if len(pruned) > 0 {
+		r.dedupe.emit(r.Recorder, &rt, corev1.EventTypeNormal, conventions.ReasonOrphanedDNSRecordPruned,
+			fmt.Sprintf("deleted %d orphaned DNSRecord CR(s) for hostnames no longer in spec", len(pruned)))
 	}
 
 	if err := r.writeParentStatus(ctx, &rt, *parent, warns, len(contribs) > 0); err != nil {

--- a/internal/controller/tunnel/httproute_source_controller.go
+++ b/internal/controller/tunnel/httproute_source_controller.go
@@ -191,7 +191,7 @@ func (r *HTTPRouteSourceReconciler) Reconcile(ctx context.Context, req reconcile
 
 	// Emit per-Route DNSRecord CRs: CNAME <hostname> → <gateway-apex>.
 	for _, h := range rt.Spec.Hostnames {
-		if err := r.emitChainDNSRecord(ctx, &rt, string(h), gwApex); err != nil {
+		if err := r.emitChainDNSRecord(ctx, &rt, string(h), gwApex, gw); err != nil {
 			return reconcile.Result{}, fmt.Errorf("emit dns record for %q: %w", h, err)
 		}
 	}
@@ -287,18 +287,23 @@ func firstListenerHostname(gw *gwv1.Gateway) string {
 // emitChainDNSRecord upserts the chain CloudflareDNSRecord CR (route
 // hostname → Gateway apex) for this HTTPRoute + hostname pair via the
 // shared SSA-based helper. Annotation drift (cloudflare.io/adopt,
-// cloudflare.io/zone-ref) propagates to the emitted CR because
+// cloudflare.io/zone-ref, etc.) propagates to the emitted CR because
 // EmitDNSRecord uses SSA.
+//
+// cloudflare.io/* annotations are merged via inheritedAnnotations: the
+// route's own value wins when set; missing values fall through to the
+// parent Gateway. This implements the per-route override / per-gateway
+// default pattern from design §5.
 //
 // Operator-edits-win: a user `kubectl edit` on the emitted CR will be
 // reverted on the next reconcile.
-func (r *HTTPRouteSourceReconciler) emitChainDNSRecord(ctx context.Context, rt *gwv1.HTTPRoute, hostname, gwApex string) error {
+func (r *HTTPRouteSourceReconciler) emitChainDNSRecord(ctx context.Context, rt *gwv1.HTTPRoute, hostname, gwApex string, gw *gwv1.Gateway) error {
 	return EmitDNSRecord(ctx, r.Client, r.Scheme, EmitOpts{
 		Owner:       rt,
 		OwnerKind:   "HTTPRoute",
 		Hostname:    hostname,
 		Content:     gwApex,
-		Annotations: rt.GetAnnotations(),
+		Annotations: inheritedAnnotations(rt.GetAnnotations(), gw),
 	})
 }
 

--- a/internal/controller/tunnel/httproute_source_controller_test.go
+++ b/internal/controller/tunnel/httproute_source_controller_test.go
@@ -612,6 +612,89 @@ func TestHTTPRouteSource_GatewayServiceUnresolved_Skips(t *testing.T) {
 	require.Empty(t, got.Status.Parents)
 }
 
+// TestHTTPRouteSource_InheritsAdoptFromGateway verifies Design E1 §5: when the
+// HTTPRoute omits cloudflare.io/adopt, the value falls through from the parent
+// Gateway's annotation. The emitted CloudflareDNSRecord must carry Spec.Adopt
+// reflecting the Gateway's setting.
+func TestHTTPRouteSource_InheritsAdoptFromGateway(t *testing.T) {
+	// Gateway carries adopt=true; HTTPRoute has no adopt annotation.
+	gw := mkParentGw("gw", "gw-ns")
+	gw.Annotations[conventions.AnnotationAdopt] = "true"
+
+	tn := &v1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "cf-gw-ns-edge", Namespace: "gw-ns"},
+		Status:     v1alpha1.CloudflareTunnelStatus{TunnelID: "tnl-1", TunnelCNAME: "tnl-1.cfargotunnel.com"},
+	}
+	gwSvc := mkGwSvc("gw-svc", "gw-ns")
+	rt := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "r",
+			Namespace: "app",
+			// No adopt annotation — must inherit from Gateway.
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			Hostnames:       []gwv1.Hostname{"notes.example.com"},
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
+			Rules:           []gwv1.HTTPRouteRule{{}},
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: tunnelsynth.NewCache()}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
+	require.NoError(t, err)
+
+	// Re-Get the emitted DNSRecord and assert Spec.Adopt reflects the Gateway's annotation.
+	drName := emittedDNSRecordName("r", "notes.example.com")
+	var got v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "app", Name: drName}, &got))
+	require.True(t, got.Spec.Adopt, "Spec.Adopt must be true (inherited from parent Gateway)")
+}
+
+// TestHTTPRouteSource_RouteOverridesGatewayAdopt verifies Design E1 §5: when
+// the HTTPRoute explicitly sets cloudflare.io/adopt, its value wins over the
+// parent Gateway's value. Route-side annotations have priority.
+func TestHTTPRouteSource_RouteOverridesGatewayAdopt(t *testing.T) {
+	// Gateway carries adopt=true; HTTPRoute overrides to adopt=false.
+	gw := mkParentGw("gw", "gw-ns")
+	gw.Annotations[conventions.AnnotationAdopt] = "true"
+
+	tn := &v1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "cf-gw-ns-edge", Namespace: "gw-ns"},
+		Status:     v1alpha1.CloudflareTunnelStatus{TunnelID: "tnl-1", TunnelCNAME: "tnl-1.cfargotunnel.com"},
+	}
+	gwSvc := mkGwSvc("gw-svc", "gw-ns")
+	rt := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "r",
+			Namespace: "app",
+			Annotations: map[string]string{
+				conventions.AnnotationAdopt: "false",
+			},
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			Hostnames:       []gwv1.Hostname{"notes.example.com"},
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
+			Rules:           []gwv1.HTTPRouteRule{{}},
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1.HTTPRoute{}, &v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	r := &HTTPRouteSourceReconciler{Client: c, Scheme: rtScheme(t), Cache: tunnelsynth.NewCache()}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
+	require.NoError(t, err)
+
+	// Re-Get the emitted DNSRecord and assert the route's own annotation wins.
+	drName := emittedDNSRecordName("r", "notes.example.com")
+	var got v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "app", Name: drName}, &got))
+	require.False(t, got.Spec.Adopt, "Spec.Adopt must be false (HTTPRoute annotation overrides Gateway)")
+}
+
 func TestFirstListenerHostname_IsLexicographicallyStable(t *testing.T) {
 	h := func(s string) *gwv1.Hostname {
 		v := gwv1.Hostname(s)

--- a/internal/controller/tunnel/orphan_prune.go
+++ b/internal/controller/tunnel/orphan_prune.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+)
+
+// pruneOrphanedDNSRecords deletes operator-emitted CloudflareDNSRecord CRs that
+// a source previously emitted but no longer wants. It lists all CRs in
+// sourceNamespace that carry the three source-identity labels
+// (conventions.LabelSourceKind, conventions.LabelSourceName,
+// conventions.LabelSourceNamespace) matching the provided values, then deletes
+// any whose Spec.Name is not a key in desired.
+//
+// Label scope: the three-key selector means a CR owned by a different source
+// kind, name, or namespace is invisible to this helper and will never be
+// touched. Likewise, a user-authored CR missing these labels is invisible.
+//
+// Racing deletions: Delete is wrapped in client.IgnoreNotFound, so a CR that
+// another actor already removed between List and Delete is treated as already
+// gone — not as an error.
+//
+// On error, the pruned slice accumulated so far is returned alongside the
+// error so the caller has partial progress information.
+func pruneOrphanedDNSRecords(
+	ctx context.Context,
+	c client.Client,
+	sourceKind, sourceName, sourceNamespace string,
+	desired map[string]struct{},
+) ([]string, error) {
+	var existing v1alpha1.CloudflareDNSRecordList
+	if err := c.List(ctx, &existing,
+		client.InNamespace(sourceNamespace),
+		client.MatchingLabels{
+			conventions.LabelSourceKind:      sourceKind,
+			conventions.LabelSourceName:      sourceName,
+			conventions.LabelSourceNamespace: sourceNamespace,
+		},
+	); err != nil {
+		return nil, fmt.Errorf("list emitted DNSRecord CRs for prune: %w", err)
+	}
+
+	var pruned []string
+	for i := range existing.Items {
+		cr := &existing.Items[i]
+		if _, ok := desired[cr.Spec.Name]; ok {
+			continue
+		}
+		if err := client.IgnoreNotFound(c.Delete(ctx, cr)); err != nil {
+			return pruned, fmt.Errorf("delete orphaned DNSRecord %s: %w", cr.Name, err)
+		}
+		pruned = append(pruned, cr.Spec.Name)
+	}
+	return pruned, nil
+}

--- a/internal/controller/tunnel/orphan_prune_test.go
+++ b/internal/controller/tunnel/orphan_prune_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func pruneScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(s))
+	return s
+}
+
+func makeEmittedRecord(svcName, hostname string) *v1alpha1.CloudflareDNSRecord {
+	return &v1alpha1.CloudflareDNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      emittedDNSRecordName(svcName, hostname),
+			Namespace: "ns",
+			Labels: map[string]string{
+				conventions.LabelSourceKind:      "Service",
+				conventions.LabelSourceName:      svcName,
+				conventions.LabelSourceNamespace: "ns",
+			},
+		},
+		Spec: v1alpha1.CloudflareDNSRecordSpec{
+			Type: "CNAME",
+			Name: hostname,
+		},
+	}
+}
+
+func TestPruneOrphanedDNSRecords_DeletesNonDesired(t *testing.T) {
+	s := pruneScheme(t)
+	keep := makeEmittedRecord("svc", "keep.example.com")
+	drop := makeEmittedRecord("svc", "drop.example.com")
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(keep, drop).Build()
+
+	desired := map[string]struct{}{"keep.example.com": {}}
+	deleted, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"drop.example.com"}, deleted)
+
+	// keep.example.com CR must still exist.
+	var got v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(keep), &got))
+
+	// drop.example.com CR must be gone.
+	var gone v1alpha1.CloudflareDNSRecord
+	err = c.Get(context.Background(), client.ObjectKeyFromObject(drop), &gone)
+	require.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
+}
+
+func TestPruneOrphanedDNSRecords_RespectsLabelScope(t *testing.T) {
+	s := pruneScheme(t)
+	mine := makeEmittedRecord("svc", "mine.example.com")
+	// Record owned by a different source (LabelSourceName=other).
+	theirs := makeEmittedRecord("other", "theirs.example.com")
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(mine, theirs).Build()
+
+	// Empty desired — prune everything owned by "svc".
+	desired := map[string]struct{}{}
+	deleted, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"mine.example.com"}, deleted)
+
+	// theirs.example.com must still exist — it belongs to a different source.
+	var surviving v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(theirs), &surviving))
+}
+
+func TestPruneOrphanedDNSRecords_EmptyExistingIsNoOp(t *testing.T) {
+	s := pruneScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	desired := map[string]struct{}{"some.example.com": {}}
+	deleted, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
+	require.NoError(t, err)
+	require.Empty(t, deleted)
+}
+
+func TestPruneOrphanedDNSRecords_IgnoresConcurrentlyDeletedRecord(t *testing.T) {
+	s := pruneScheme(t)
+	record := makeEmittedRecord("svc", "race.example.com")
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(record).Build()
+
+	// Simulate an out-of-band deletion racing our prune — delete the target CR
+	// before calling the helper.
+	require.NoError(t, c.Delete(context.Background(), record))
+
+	// Desired set excludes race.example.com — the helper would want to delete it,
+	// but it's already gone. Must not error.
+	desired := map[string]struct{}{}
+	deleted, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
+	require.NoError(t, err, "a racing deletion must not cause an error")
+	// The record is already gone; its hostname may or may not appear in deleted —
+	// we only assert no error and that the client state is consistent.
+	_ = deleted
+}

--- a/internal/controller/tunnel/orphan_prune_test.go
+++ b/internal/controller/tunnel/orphan_prune_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
@@ -147,30 +148,42 @@ func TestPruneOrphanedDNSRecords_EmptyExistingIsNoOp(t *testing.T) {
 	require.Empty(t, deleted)
 }
 
-func TestPruneOrphanedDNSRecords_IgnoresConcurrentlyDeletedRecord(t *testing.T) {
+func TestPruneOrphanedDNSRecords_IgnoresRecordDeletedBetweenListAndDelete(t *testing.T) {
 	s := pruneScheme(t)
+	// racing is present at List time (the helper WILL see it and decide to
+	// delete it), but a concurrent actor removes it in the window between the
+	// helper's List and its Delete. keep proves the iteration over the
+	// remaining records is unaffected by the swallowed NotFound.
 	racing := makeEmittedRecord("svc", "race.example.com")
-	// A desired record that must survive the prune untouched, proving the
-	// racing delete didn't corrupt the rest of the iteration.
 	keep := makeEmittedRecord("svc", "keep.example.com")
 
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(racing, keep).Build()
+	base := fake.NewClientBuilder().WithScheme(s).WithObjects(racing, keep).Build()
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if obj.GetName() == racing.Name {
+				// First delegated Delete actually removes it (the concurrent
+				// actor's deletion taking effect); the second returns the
+				// genuine apierrors NotFound the store now produces — exactly
+				// what the helper's c.Delete observes mid-iteration.
+				_ = cl.Delete(ctx, obj, opts...)
+				return cl.Delete(ctx, obj, opts...)
+			}
+			return cl.Delete(ctx, obj, opts...)
+		},
+	})
 
-	// Simulate an out-of-band deletion racing our prune — delete one target CR
-	// before calling the helper.
-	require.NoError(t, c.Delete(context.Background(), racing))
-
-	// Desired set keeps keep.example.com and excludes race.example.com; the
-	// helper would want to delete the latter, but it's already gone.
+	// Desired excludes race.example.com, so the helper lists it, attempts the
+	// Delete, and must tolerate the NotFound surfaced by the interceptor.
 	desired := map[string]struct{}{"keep.example.com": {}}
 	_, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
-	require.NoError(t, err, "a racing deletion must not cause an error")
+	require.NoError(t, err, "a deletion racing between List and Delete must be swallowed")
 
 	// The desired record was untouched by the prune and is still Gettable.
 	var surviving v1alpha1.CloudflareDNSRecord
 	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(keep), &surviving))
 
-	// The racing record stays gone — the helper did not resurrect it.
+	// The racing record is gone (the concurrent actor removed it; the helper
+	// did not resurrect it).
 	var gone v1alpha1.CloudflareDNSRecord
 	err = c.Get(context.Background(), client.ObjectKeyFromObject(racing), &gone)
 	require.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)

--- a/internal/controller/tunnel/orphan_prune_test.go
+++ b/internal/controller/tunnel/orphan_prune_test.go
@@ -39,6 +39,14 @@ func pruneScheme(t *testing.T) *runtime.Scheme {
 }
 
 func makeEmittedRecord(svcName, hostname string) *v1alpha1.CloudflareDNSRecord {
+	return makeEmittedRecordInSourceNS(svcName, hostname, "ns")
+}
+
+// makeEmittedRecordInSourceNS builds a record whose Kubernetes namespace is
+// always "ns" (so client.InNamespace("ns") never filters it) but whose
+// conventions.LabelSourceNamespace label is sourceNS. This isolates the
+// label-key behaviour of the prune selector from the InNamespace behaviour.
+func makeEmittedRecordInSourceNS(svcName, hostname, sourceNS string) *v1alpha1.CloudflareDNSRecord {
 	return &v1alpha1.CloudflareDNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      emittedDNSRecordName(svcName, hostname),
@@ -46,7 +54,7 @@ func makeEmittedRecord(svcName, hostname string) *v1alpha1.CloudflareDNSRecord {
 			Labels: map[string]string{
 				conventions.LabelSourceKind:      "Service",
 				conventions.LabelSourceName:      svcName,
-				conventions.LabelSourceNamespace: "ns",
+				conventions.LabelSourceNamespace: sourceNS,
 			},
 		},
 		Spec: v1alpha1.CloudflareDNSRecordSpec{
@@ -97,6 +105,38 @@ func TestPruneOrphanedDNSRecords_RespectsLabelScope(t *testing.T) {
 	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(theirs), &surviving))
 }
 
+// TestPruneOrphanedDNSRecords_RespectsNamespaceLabelScope locks in that the
+// conventions.LabelSourceNamespace selector key is load-bearing. Both seeded
+// records live in Kubernetes namespace "ns" (so client.InNamespace("ns") does
+// NOT filter either out); they differ only on the LabelSourceNamespace label
+// value. If a regression dropped that key from the production MatchingLabels
+// selector, the cross-namespace-labelled CR would be wrongly pruned and this
+// test would fail.
+func TestPruneOrphanedDNSRecords_RespectsNamespaceLabelScope(t *testing.T) {
+	s := pruneScheme(t)
+	// Same kind+name (Service/svc), same k8s namespace ("ns"), but the
+	// source-namespace LABEL says it belongs to a source in "other-ns".
+	crossNS := makeEmittedRecordInSourceNS("svc", "cross-ns.example.com", "other-ns")
+	// In-scope record — should be pruned.
+	inScope := makeEmittedRecordInSourceNS("svc", "in-scope.example.com", "ns")
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(crossNS, inScope).Build()
+
+	desired := map[string]struct{}{}
+	deleted, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"in-scope.example.com"}, deleted)
+
+	// The cross-namespace-labelled CR must survive.
+	var surviving v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(crossNS), &surviving))
+
+	// The in-scope CR must be gone.
+	var gone v1alpha1.CloudflareDNSRecord
+	err = c.Get(context.Background(), client.ObjectKeyFromObject(inScope), &gone)
+	require.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
+}
+
 func TestPruneOrphanedDNSRecords_EmptyExistingIsNoOp(t *testing.T) {
 	s := pruneScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).Build()
@@ -109,20 +149,29 @@ func TestPruneOrphanedDNSRecords_EmptyExistingIsNoOp(t *testing.T) {
 
 func TestPruneOrphanedDNSRecords_IgnoresConcurrentlyDeletedRecord(t *testing.T) {
 	s := pruneScheme(t)
-	record := makeEmittedRecord("svc", "race.example.com")
+	racing := makeEmittedRecord("svc", "race.example.com")
+	// A desired record that must survive the prune untouched, proving the
+	// racing delete didn't corrupt the rest of the iteration.
+	keep := makeEmittedRecord("svc", "keep.example.com")
 
-	c := fake.NewClientBuilder().WithScheme(s).WithObjects(record).Build()
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(racing, keep).Build()
 
-	// Simulate an out-of-band deletion racing our prune — delete the target CR
+	// Simulate an out-of-band deletion racing our prune — delete one target CR
 	// before calling the helper.
-	require.NoError(t, c.Delete(context.Background(), record))
+	require.NoError(t, c.Delete(context.Background(), racing))
 
-	// Desired set excludes race.example.com — the helper would want to delete it,
-	// but it's already gone. Must not error.
-	desired := map[string]struct{}{}
-	deleted, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
+	// Desired set keeps keep.example.com and excludes race.example.com; the
+	// helper would want to delete the latter, but it's already gone.
+	desired := map[string]struct{}{"keep.example.com": {}}
+	_, err := pruneOrphanedDNSRecords(context.Background(), c, "Service", "svc", "ns", desired)
 	require.NoError(t, err, "a racing deletion must not cause an error")
-	// The record is already gone; its hostname may or may not appear in deleted —
-	// we only assert no error and that the client state is consistent.
-	_ = deleted
+
+	// The desired record was untouched by the prune and is still Gettable.
+	var surviving v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(keep), &surviving))
+
+	// The racing record stays gone — the helper did not resurrect it.
+	var gone v1alpha1.CloudflareDNSRecord
+	err = c.Get(context.Background(), client.ObjectKeyFromObject(racing), &gone)
+	require.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
 }

--- a/internal/controller/tunnel/service_source_controller.go
+++ b/internal/controller/tunnel/service_source_controller.go
@@ -187,10 +187,26 @@ func (r *ServiceSourceReconciler) Reconcile(ctx context.Context, req reconcile.R
 	}
 
 	// Emit one CloudflareDNSRecord CR per hostname.
+	desired := make(map[string]struct{}, len(contribs))
 	for _, ic := range contribs {
+		desired[ic.Hostname] = struct{}{}
 		if err := r.emitDNSRecord(ctx, &svc, ic.Hostname, tn); err != nil {
 			return reconcile.Result{}, fmt.Errorf("emit dns record for %q: %w", ic.Hostname, err)
 		}
+	}
+
+	// Prune previously-emitted DNSRecord CRs whose hostname is no longer in
+	// the desired set. Best-effort: a prune error logs and continues — the
+	// desired records are already emitted, and any surviving orphan is retried
+	// on the next reconcile. Placed strictly AFTER the emit loop on the
+	// post-emit path; never reached on the deferred-emission early-return
+	// above (where desired would be empty and would wrongly delete live CRs).
+	pruned, perr := pruneOrphanedDNSRecords(ctx, r.Client, "Service", svc.Name, svc.Namespace, desired)
+	if perr != nil {
+		logger.Error(perr, "orphan-prune failed (continuing)")
+	} else if len(pruned) > 0 {
+		r.dedupe.emit(r.Recorder, &svc, corev1.EventTypeNormal, conventions.ReasonOrphanedDNSRecordPruned,
+			fmt.Sprintf("deleted %d orphaned DNSRecord CR(s) for hostnames no longer in spec", len(pruned)))
 	}
 
 	// Per Correction B: the cache IS the source of truth for

--- a/internal/controller/tunnel/tlsroute_source_controller.go
+++ b/internal/controller/tunnel/tlsroute_source_controller.go
@@ -201,10 +201,26 @@ func (r *TLSRouteSourceReconciler) Reconcile(ctx context.Context, req reconcile.
 	}
 
 	// Emit per-hostname DNSRecord CRs: CNAME <hostname> → <gateway-apex>.
+	desired := make(map[string]struct{}, len(hostnames))
 	for _, h := range hostnames {
+		desired[h] = struct{}{}
 		if err := r.emitChainDNSRecord(ctx, &rt, h, gwApex, gw); err != nil {
 			return reconcile.Result{}, fmt.Errorf("emit dns record for %q: %w", h, err)
 		}
+	}
+
+	// Prune previously-emitted DNSRecord CRs whose hostname is no longer in
+	// the desired set. Best-effort: a prune error logs and continues — the
+	// desired records are already emitted, and any surviving orphan is retried
+	// on the next reconcile. Placed strictly AFTER the emit loop on the
+	// post-emit path; never reached on the deferred-emission early-return
+	// above (where desired would be empty and would wrongly delete live CRs).
+	pruned, perr := pruneOrphanedDNSRecords(ctx, r.Client, "TLSRoute", rt.Name, rt.Namespace, desired)
+	if perr != nil {
+		logger.Error(perr, "orphan-prune failed (continuing)")
+	} else if len(pruned) > 0 {
+		r.dedupe.emit(r.Recorder, &rt, corev1.EventTypeNormal, conventions.ReasonOrphanedDNSRecordPruned,
+			fmt.Sprintf("deleted %d orphaned DNSRecord CR(s) for hostnames no longer in spec", len(pruned)))
 	}
 
 	if err := r.writeParentStatus(ctx, &rt, *parent, warns, len(contribs) > 0); err != nil {

--- a/internal/controller/tunnel/tlsroute_source_controller.go
+++ b/internal/controller/tunnel/tlsroute_source_controller.go
@@ -202,7 +202,7 @@ func (r *TLSRouteSourceReconciler) Reconcile(ctx context.Context, req reconcile.
 
 	// Emit per-hostname DNSRecord CRs: CNAME <hostname> → <gateway-apex>.
 	for _, h := range hostnames {
-		if err := r.emitChainDNSRecord(ctx, &rt, h, gwApex); err != nil {
+		if err := r.emitChainDNSRecord(ctx, &rt, h, gwApex, gw); err != nil {
 			return reconcile.Result{}, fmt.Errorf("emit dns record for %q: %w", h, err)
 		}
 	}
@@ -267,25 +267,26 @@ func (r *TLSRouteSourceReconciler) findTunnelTargetedParent(
 	return nil, nil, nil, nil, 0, nil
 }
 
-// emitChainDNSRecord creates (idempotently) a CloudflareDNSRecord CR for one
-// Route hostname pointing at the Gateway apex (the CNAME chain's middle hop).
-//
-// Per design §4.2 / §4.3: <route-hostname> → <gateway-apex> → <tunnel-CNAME>.
 // emitChainDNSRecord upserts the chain CloudflareDNSRecord CR (route
 // hostname → Gateway apex) for this TLSRoute + hostname pair via the
 // shared SSA-based helper. Annotation drift (cloudflare.io/adopt,
-// cloudflare.io/zone-ref) propagates to the emitted CR because
+// cloudflare.io/zone-ref, etc.) propagates to the emitted CR because
 // EmitDNSRecord uses SSA.
+//
+// cloudflare.io/* annotations are merged via inheritedAnnotations: the
+// route's own value wins when set; missing values fall through to the
+// parent Gateway. This implements the per-route override / per-gateway
+// default pattern from design §5.
 //
 // Operator-edits-win: a user `kubectl edit` on the emitted CR will be
 // reverted on the next reconcile.
-func (r *TLSRouteSourceReconciler) emitChainDNSRecord(ctx context.Context, rt *gwv1a2.TLSRoute, hostname, gwApex string) error {
+func (r *TLSRouteSourceReconciler) emitChainDNSRecord(ctx context.Context, rt *gwv1a2.TLSRoute, hostname, gwApex string, gw *gwv1.Gateway) error {
 	return EmitDNSRecord(ctx, r.Client, r.Scheme, EmitOpts{
 		Owner:       rt,
 		OwnerKind:   "TLSRoute",
 		Hostname:    hostname,
 		Content:     gwApex,
-		Annotations: rt.GetAnnotations(),
+		Annotations: inheritedAnnotations(rt.GetAnnotations(), gw),
 	})
 }
 

--- a/internal/controller/tunnel/tlsroute_source_controller_test.go
+++ b/internal/controller/tunnel/tlsroute_source_controller_test.go
@@ -674,6 +674,87 @@ func TestTLSRouteSource_NoListenerHostname_ZeroContribs_AcceptedFalse(t *testing
 	require.True(t, sawClientSide, "expected PartiallyInvalid=True/ClientSideClientRequired always stamped")
 }
 
+// TestTLSRouteSource_InheritsAdoptFromGateway verifies Design E1 §5: when the
+// TLSRoute omits cloudflare.io/adopt, the value falls through from the parent
+// Gateway's annotation. The emitted CloudflareDNSRecord must carry Spec.Adopt
+// reflecting the Gateway's setting.
+func TestTLSRouteSource_InheritsAdoptFromGateway(t *testing.T) {
+	// Gateway carries adopt=true; TLSRoute has no adopt annotation.
+	gw := mkTLSParentGw("gw", "gw-ns")
+	gw.Annotations[conventions.AnnotationAdopt] = "true"
+
+	tn := &v1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "cf-gw-ns-edge", Namespace: "gw-ns"},
+		Status:     v1alpha1.CloudflareTunnelStatus{TunnelID: "tnl-1", TunnelCNAME: "tnl-1.cfargotunnel.com"},
+	}
+	gwSvc := mkTLSGwSvc("gw-svc", "gw-ns")
+	rt := &gwv1a2.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "r",
+			Namespace: "app",
+			// No adopt annotation — must inherit from Gateway.
+		},
+		Spec: gwv1a2.TLSRouteSpec{
+			Hostnames:       []gwv1.Hostname{"secure.example.com"},
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: tunnelsynth.NewCache()}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
+	require.NoError(t, err)
+
+	// Re-Get the emitted DNSRecord and assert Spec.Adopt reflects the Gateway's annotation.
+	drName := emittedDNSRecordName("r", "secure.example.com")
+	var got v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "app", Name: drName}, &got))
+	require.True(t, got.Spec.Adopt, "Spec.Adopt must be true (inherited from parent Gateway)")
+}
+
+// TestTLSRouteSource_RouteOverridesGatewayAdopt verifies Design E1 §5: when
+// the TLSRoute explicitly sets cloudflare.io/adopt, its value wins over the
+// parent Gateway's value. Route-side annotations have priority.
+func TestTLSRouteSource_RouteOverridesGatewayAdopt(t *testing.T) {
+	// Gateway carries adopt=true; TLSRoute overrides to adopt=false.
+	gw := mkTLSParentGw("gw", "gw-ns")
+	gw.Annotations[conventions.AnnotationAdopt] = "true"
+
+	tn := &v1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "cf-gw-ns-edge", Namespace: "gw-ns"},
+		Status:     v1alpha1.CloudflareTunnelStatus{TunnelID: "tnl-1", TunnelCNAME: "tnl-1.cfargotunnel.com"},
+	}
+	gwSvc := mkTLSGwSvc("gw-svc", "gw-ns")
+	rt := &gwv1a2.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "r",
+			Namespace: "app",
+			Annotations: map[string]string{
+				conventions.AnnotationAdopt: "false",
+			},
+		},
+		Spec: gwv1a2.TLSRouteSpec{
+			Hostnames:       []gwv1.Hostname{"secure.example.com"},
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: ptrNs("gw-ns")}}},
+		},
+	}
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
+		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v1alpha1.CloudflareTunnel{}, &v1alpha1.CloudflareDNSRecord{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	r := &TLSRouteSourceReconciler{Client: c, Scheme: tlsRtScheme(t), Cache: tunnelsynth.NewCache()}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "app", Name: "r"}})
+	require.NoError(t, err)
+
+	// Re-Get the emitted DNSRecord and assert the route's own annotation wins.
+	drName := emittedDNSRecordName("r", "secure.example.com")
+	var got v1alpha1.CloudflareDNSRecord
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "app", Name: drName}, &got))
+	require.False(t, got.Spec.Adopt, "Spec.Adopt must be false (TLSRoute annotation overrides Gateway)")
+}
+
 // TestTLSRouteSource_InheritsListenerHostname_WhenSpecEmpty covers the
 // TLSRoute-specific Gateway-API fallback at tlsroute_source_controller.go
 // lines 162-164: when Spec.Hostnames is empty AND the parent Gateway's

--- a/internal/controller/tunnel/tunnel_controller.go
+++ b/internal/controller/tunnel/tunnel_controller.go
@@ -420,6 +420,14 @@ func (r *CloudflareTunnelReconciler) applyRemoteConfig(
 	// observed config to drift from, and an empty live config vs a nil
 	// ObservedIngress would otherwise reflect.DeepEqual-mismatch and emit a
 	// spurious DriftDetected on the very first reconcile.
+	//
+	// The comparison is order-sensitive by design: it reuses
+	// snapshotFromConfig so it shares the exact basis the PUT-skip below
+	// (line ~435) already trusts — diverging here would make drift and
+	// PUT-skip disagree. This assumes Cloudflare preserves ingress order
+	// (cloudflared ingress is semantically ordered: the catch-all is last).
+	// If DriftDetected ever becomes chronically noisy, server-side ingress
+	// reordering is the first thing to check here.
 	if tn.Status.TunnelID != "" && len(tn.Status.ObservedIngress) > 0 {
 		if live, gerr := tc.GetConfiguration(ctx, accountID, tn.Status.TunnelID); gerr != nil {
 			log.FromContext(ctx).V(1).Info("GetConfiguration drift-check failed (continuing)", "err", gerr.Error())

--- a/internal/controller/tunnel/tunnel_controller.go
+++ b/internal/controller/tunnel/tunnel_controller.go
@@ -364,9 +364,10 @@ func (r *CloudflareTunnelReconciler) ensureDataplane(ctx context.Context, tn *v1
 }
 
 // applyRemoteConfig: compute effective ingress from the shared cache, append
-// the catch-all, drift-check against status.observedIngress, and PUT if
-// different. The PUT is a full replace — Cloudflare has no merge semantics
-// on /configurations.
+// the catch-all, detect out-of-band drift (live config vs observed → a single
+// DriftDetected Warning Event, detection only), then diff against
+// status.observedIngress and PUT if different. The PUT is a full replace —
+// Cloudflare has no merge semantics on /configurations.
 func (r *CloudflareTunnelReconciler) applyRemoteConfig(
 	ctx context.Context,
 	tn *v1alpha1.CloudflareTunnel,
@@ -401,6 +402,31 @@ func (r *CloudflareTunnelReconciler) applyRemoteConfig(
 			// deleted between cache-write and conflict-emit) is swallowed.
 			if err := r.emitDuplicateHostnameEvent(ctx, conflict); err != nil && !apierrors.IsNotFound(err) {
 				logger.V(1).Info("emit DuplicateHostname event failed", "err", err.Error())
+			}
+		}
+	}
+
+	// Out-of-band drift detection (Design E2): ask Cloudflare for the live
+	// tunnel config and compare it to what we last observed/pushed. A
+	// divergence means someone edited the config via the dashboard or
+	// another tool between reconciles. We surface this as a single
+	// DriftDetected Warning Event for operator visibility — detection only;
+	// the operator does NOT force a re-push here (the existing PUT path
+	// below already restores operator-desired config whenever the
+	// operator's own inputs changed). Best-effort: a GetConfiguration error
+	// must not fail the reconcile.
+	//
+	// Guarded on a populated baseline: before the first PUT there is no
+	// observed config to drift from, and an empty live config vs a nil
+	// ObservedIngress would otherwise reflect.DeepEqual-mismatch and emit a
+	// spurious DriftDetected on the very first reconcile.
+	if tn.Status.TunnelID != "" && len(tn.Status.ObservedIngress) > 0 {
+		if live, gerr := tc.GetConfiguration(ctx, accountID, tn.Status.TunnelID); gerr != nil {
+			log.FromContext(ctx).V(1).Info("GetConfiguration drift-check failed (continuing)", "err", gerr.Error())
+		} else if live != nil && !reflect.DeepEqual(snapshotFromConfig(live.Config), tn.Status.ObservedIngress) {
+			if r.Recorder != nil {
+				r.Recorder.Eventf(tn, corev1.EventTypeWarning, conventions.ReasonDriftDetected,
+					"live tunnel configuration differs from operator-observed config (out-of-band edit detected)")
 			}
 		}
 	}

--- a/internal/controller/tunnel/tunnel_controller_test.go
+++ b/internal/controller/tunnel/tunnel_controller_test.go
@@ -469,6 +469,164 @@ func TestTunnelReconciler_DuplicateHostname_EmitsEventOnLoser(t *testing.T) {
 	require.True(t, sawDuplicate, "lex-loser Service must receive DuplicateHostname Event")
 }
 
+func TestApplyRemoteConfig_EmitsDriftDetectedWhenLiveDiffersFromObserved(t *testing.T) {
+	// Out-of-band drift (Design E2): the live Cloudflare config differs from
+	// what the operator last observed. applyRemoteConfig must emit a single
+	// DriftDetected Warning Event for operator visibility.
+	setEnvCreds(t)
+	s := tunnelScheme(t)
+	m := mockcf.New()
+
+	created, err := m.Tunnel.CreateTunnel(context.Background(), "acct-1",
+		cloudflare.CreateTunnelParams{Name: "cf-ns"})
+	require.NoError(t, err)
+	// Live config has a real ingress entry someone added via the dashboard.
+	_, err = m.Tunnel.PutConfiguration(context.Background(), "acct-1", created.ID,
+		cloudflare.TunnelConfig{Ingress: []cloudflare.IngressEntry{
+			{Hostname: "rogue.example.com", Service: "http://rogue.ns.svc:80"},
+		}})
+	require.NoError(t, err)
+
+	tn := &v1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "tnl", Namespace: "ns", Finalizers: []string{conventions.FinalizerName}},
+		Spec: v1alpha1.CloudflareTunnelSpec{
+			Name:      "cf-ns",
+			Connector: v1alpha1.ConnectorSpec{Replicas: 2, Protocol: "auto", LogLevel: "info", GracePeriodSeconds: 30},
+		},
+		Status: v1alpha1.CloudflareTunnelStatus{
+			TunnelID:        created.ID,
+			ObservedIngress: []v1alpha1.IngressEntrySnapshot{{Service: "http_status:404"}},
+		},
+	}
+	base := fake.NewClientBuilder().
+		WithScheme(s).WithObjects(tn).
+		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	rec := record.NewFakeRecorder(16)
+	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
+	r.Recorder = rec
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "tnl", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	var sawDrift bool
+	close(rec.Events)
+	for ev := range rec.Events {
+		if containsAll(ev, conventions.ReasonDriftDetected) {
+			sawDrift = true
+		}
+	}
+	require.True(t, sawDrift, "live config differs from observed → DriftDetected Warning Event expected")
+}
+
+func TestApplyRemoteConfig_NoDriftWhenLiveMatchesObserved(t *testing.T) {
+	// When the live Cloudflare config matches Status.ObservedIngress (built
+	// from the same projection that produced the PUT), no DriftDetected
+	// Event must fire.
+	setEnvCreds(t)
+	s := tunnelScheme(t)
+	m := mockcf.New()
+
+	created, err := m.Tunnel.CreateTunnel(context.Background(), "acct-1",
+		cloudflare.CreateTunnelParams{Name: "cf-ns"})
+	require.NoError(t, err)
+	liveCfg := cloudflare.TunnelConfig{Ingress: []cloudflare.IngressEntry{{Service: "http_status:404"}}}
+	_, err = m.Tunnel.PutConfiguration(context.Background(), "acct-1", created.ID, liveCfg)
+	require.NoError(t, err)
+
+	tn := &v1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "tnl", Namespace: "ns", Finalizers: []string{conventions.FinalizerName}},
+		Spec: v1alpha1.CloudflareTunnelSpec{
+			Name:      "cf-ns",
+			Connector: v1alpha1.ConnectorSpec{Replicas: 2, Protocol: "auto", LogLevel: "info", GracePeriodSeconds: 30},
+		},
+		Status: v1alpha1.CloudflareTunnelStatus{
+			TunnelID: created.ID,
+			// Built via the same projection the production code compares against,
+			// so live and observed are byte-equal — no drift.
+			ObservedIngress: snapshotFromConfig(liveCfg),
+		},
+	}
+	base := fake.NewClientBuilder().
+		WithScheme(s).WithObjects(tn).
+		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	rec := record.NewFakeRecorder(16)
+	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
+	r.Recorder = rec
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "tnl", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	var sawDrift bool
+	close(rec.Events)
+	for ev := range rec.Events {
+		if containsAll(ev, conventions.ReasonDriftDetected) {
+			sawDrift = true
+		}
+	}
+	require.False(t, sawDrift, "live config matches observed → no DriftDetected Event")
+}
+
+func TestApplyRemoteConfig_NoDriftWhenObservedEmpty(t *testing.T) {
+	// First-reconcile guard: with Status.ObservedIngress empty/nil there is
+	// no baseline to drift from. Even with a non-empty live config, no
+	// DriftDetected Event must fire (otherwise every fresh tunnel would emit
+	// a spurious drift on first reconcile).
+	setEnvCreds(t)
+	s := tunnelScheme(t)
+	m := mockcf.New()
+
+	created, err := m.Tunnel.CreateTunnel(context.Background(), "acct-1",
+		cloudflare.CreateTunnelParams{Name: "cf-ns"})
+	require.NoError(t, err)
+	_, err = m.Tunnel.PutConfiguration(context.Background(), "acct-1", created.ID,
+		cloudflare.TunnelConfig{Ingress: []cloudflare.IngressEntry{
+			{Hostname: "live.example.com", Service: "http://live.ns.svc:80"},
+		}})
+	require.NoError(t, err)
+
+	tn := &v1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{Name: "tnl", Namespace: "ns", Finalizers: []string{conventions.FinalizerName}},
+		Spec: v1alpha1.CloudflareTunnelSpec{
+			Name:      "cf-ns",
+			Connector: v1alpha1.ConnectorSpec{Replicas: 2, Protocol: "auto", LogLevel: "info", GracePeriodSeconds: 30},
+		},
+		Status: v1alpha1.CloudflareTunnelStatus{
+			TunnelID: created.ID,
+			// ObservedIngress intentionally nil — no baseline yet.
+		},
+	}
+	base := fake.NewClientBuilder().
+		WithScheme(s).WithObjects(tn).
+		WithStatusSubresource(&v1alpha1.CloudflareTunnel{}).Build()
+	c := reconcilelib.SSATranslatingClient(t, base)
+
+	rec := record.NewFakeRecorder(16)
+	r := newTunnelReconciler(t, c, s, m, tunnelsynth.NewCache())
+	r.Recorder = rec
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "tnl", Namespace: "ns"},
+	})
+	require.NoError(t, err)
+
+	var sawDrift bool
+	close(rec.Events)
+	for ev := range rec.Events {
+		if containsAll(ev, conventions.ReasonDriftDetected) {
+			sawDrift = true
+		}
+	}
+	require.False(t, sawDrift, "empty ObservedIngress → first-reconcile guard suppresses DriftDetected")
+}
+
 // containsAll returns true when s contains every substring.
 func containsAll(s string, subs ...string) bool {
 	for _, sub := range subs {

--- a/internal/controller/tunnel/tunnel_controller_test.go
+++ b/internal/controller/tunnel/tunnel_controller_test.go
@@ -494,7 +494,12 @@ func TestApplyRemoteConfig_EmitsDriftDetectedWhenLiveDiffersFromObserved(t *test
 			Connector: v1alpha1.ConnectorSpec{Replicas: 2, Protocol: "auto", LogLevel: "info", GracePeriodSeconds: 30},
 		},
 		Status: v1alpha1.CloudflareTunnelStatus{
-			TunnelID:        created.ID,
+			TunnelID: created.ID,
+			// Deliberately equal to the resolved catch-all snapshot (empty
+			// cache → http_status:404), so wantSnap == ObservedIngress and
+			// the existing early-return fires. This isolates the assertion to
+			// pure drift detection: no PUT mutates the mock before we check
+			// for the DriftDetected event.
 			ObservedIngress: []v1alpha1.IngressEntrySnapshot{{Service: "http_status:404"}},
 		},
 	}

--- a/internal/conventions/conditions.go
+++ b/internal/conventions/conditions.go
@@ -144,6 +144,7 @@ const (
 	// cannot write Status on user-owned Gateway/HTTPRoute objects).
 	ReasonGatewayServiceUnresolved = "GatewayServiceUnresolved" // annotation present but Service Get/parse failed
 	ReasonUnsupportedProtocol      = "UnsupportedProtocol"      // listener protocol cloudflared cannot serve
+	ReasonOrphanedDNSRecordPruned  = "OrphanedDNSRecordPruned"  // emitted DNSRecord CR pruned: its hostname left the source's desired set
 )
 
 // TunnelReasons returns the reason vocabulary appended by spec 3 for the
@@ -170,5 +171,6 @@ func TunnelReasons() []string {
 		ReasonGatewayServiceUnspecified,
 		ReasonGatewayServiceUnresolved,
 		ReasonUnsupportedProtocol,
+		ReasonOrphanedDNSRecordPruned,
 	}
 }

--- a/internal/conventions/conditions_tunnel_test.go
+++ b/internal/conventions/conditions_tunnel_test.go
@@ -35,6 +35,7 @@ func TestTunnelReasons_AllDefined(t *testing.T) {
 		ReasonNameTooLong, ReasonInvalidName,
 		ReasonGatewayServiceUnspecified,
 		ReasonGatewayServiceUnresolved, ReasonUnsupportedProtocol,
+		ReasonOrphanedDNSRecordPruned,
 	}
 	for _, r := range want {
 		require.NotEmpty(t, r)
@@ -55,6 +56,7 @@ func TestTunnelReasons_NoDuplicatesWithBase(t *testing.T) {
 		ReasonNoListenerHostname, ReasonClientSideClientRequired, ReasonNameTooLong, ReasonInvalidName,
 		ReasonGatewayServiceUnspecified,
 		ReasonGatewayServiceUnresolved, ReasonUnsupportedProtocol,
+		ReasonOrphanedDNSRecordPruned,
 	}
 	for _, r := range tunnel {
 		_, dup := base[r]

--- a/test/envtest/tunnel_annotation_inheritance_test.go
+++ b/test/envtest/tunnel_annotation_inheritance_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+)
+
+// TestEnvtest_HTTPRoute_InheritsAdoptFromGateway pins Design E1 §5 against a
+// real apiserver: when an HTTPRoute omits cloudflare.io/adopt but the parent
+// Gateway carries it, the emitted CloudflareDNSRecord must reflect the
+// Gateway's value.
+//
+// Gotchas pre-empted (per project Phase 3 execution lessons):
+//  - DNSRecord admission has CEL "has(zoneID) || has(zoneRef)": the fixture
+//    creates a CloudflareZone CR and sets cloudflare.io/zone-ref on the Gateway
+//    so every emitted DNSRecord carries a valid zoneRef. Routes omit zone-ref
+//    deliberately — they must inherit it from the Gateway.
+//  - Tunnel Status.TunnelCNAME must populate before the HTTPRoute is created
+//    so the HTTPRoute reconciler's deferred-emission guard never fires. The
+//    fixture waits for this before creating the route (mirrors
+//    createGatewayForRouteTest in httproute_source_envtest_test.go).
+//  - setupHTTPRouteEnv is reused without modification — all reconcilers
+//    (Gateway, Tunnel, HTTPRoute sources) are wired and share one
+//    tunnelsynth.Cache, identical to the existing HTTPRoute envtests.
+func TestEnvtest_HTTPRoute_InheritsAdoptFromGateway(t *testing.T) {
+	if sharedConfig == nil {
+		t.Skip("envtest not initialized (KUBEBUILDER_ASSETS unset)")
+	}
+	f := setupHTTPRouteEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Zone CR — admission requires has(zoneRef); the Gateway carries zone-ref,
+	// so the emitted DNSRecord inherits it and passes CEL validation.
+	zone := &v1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: f.ns},
+		Spec: v1alpha1.CloudflareZoneSpec{
+			Name:           "example.com",
+			Type:           "full",
+			DeletionPolicy: "Retain",
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, zone))
+
+	// Backing Service for the Gateway.
+	gwSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-svc", Namespace: f.ns},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, gwSvc))
+
+	// Tunnel-targeted Gateway with adopt=true AND zone-ref so inheritance
+	// propagates both to the emitted DNSRecord.
+	gwHostname := gwv1.Hostname("ext.example.com")
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gw", Namespace: f.ns,
+			Annotations: map[string]string{
+				conventions.AnnotationTunnel:         "true",
+				conventions.AnnotationTunnelName:     "edge",
+				conventions.AnnotationGatewayService: f.ns + "/gw-svc",
+				conventions.AnnotationAdopt:          "true",
+				conventions.AnnotationZoneRef:        "example-com",
+			},
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "any-class",
+			Listeners: []gwv1.Listener{{
+				Name: "h", Hostname: &gwHostname, Port: 80, Protocol: gwv1.HTTPProtocolType,
+			}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, gw))
+
+	// Wait for Status.TunnelCNAME so the HTTPRoute reconciler advances past the
+	// deferred-emission guard on the first reconcile pass.
+	expectedTunnel := "cf-" + f.ns + "-edge"
+	require.Eventually(t, func() bool {
+		var tn v1alpha1.CloudflareTunnel
+		if err := f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: expectedTunnel}, &tn); err != nil {
+			return false
+		}
+		return tn.Status.TunnelCNAME != ""
+	}, 30*time.Second, 250*time.Millisecond, "parent Gateway's tunnel %q must reach Status.TunnelCNAME", expectedTunnel)
+
+	// HTTPRoute deliberately omits adopt and zone-ref — must inherit both from
+	// the parent Gateway.
+	nsRef := gwv1.Namespace(f.ns)
+	rt := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "r",
+			Namespace: f.ns,
+			// No annotations — adopt + zone-ref must fall through from Gateway.
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			Hostnames: []gwv1.Hostname{"notes.example.com"},
+			CommonRouteSpec: gwv1.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: &nsRef}},
+			},
+			Rules: []gwv1.HTTPRouteRule{{}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, rt))
+
+	// The emitted CloudflareDNSRecord must carry Spec.Adopt=true (inherited
+	// from the Gateway's cloudflare.io/adopt annotation).
+	require.Eventually(t, func() bool {
+		var list v1alpha1.CloudflareDNSRecordList
+		if err := f.c.List(ctx, &list, client.InNamespace(f.ns)); err != nil {
+			return false
+		}
+		for _, dr := range list.Items {
+			if dr.Spec.Name == "notes.example.com" && dr.Spec.Type == "CNAME" {
+				return dr.Spec.Adopt
+			}
+		}
+		return false
+	}, 20*time.Second, 250*time.Millisecond,
+		"emitted DNSRecord for notes.example.com must carry Spec.Adopt=true (inherited from Gateway)")
+}
+
+// TestEnvtest_TLSRoute_InheritsAdoptFromGateway is the TLSRoute counterpart
+// to TestEnvtest_HTTPRoute_InheritsAdoptFromGateway. TLSRoute annotation
+// inheritance is wired in P3 Task 3; this test is structurally complete and
+// will be activated once that task lands.
+func TestEnvtest_TLSRoute_InheritsAdoptFromGateway(t *testing.T) {
+	t.Skip("TLSRoute annotation inheritance lands in P3 Task 3")
+}

--- a/test/envtest/tunnel_annotation_inheritance_test.go
+++ b/test/envtest/tunnel_annotation_inheritance_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/conventions"
@@ -150,9 +151,117 @@ func TestEnvtest_HTTPRoute_InheritsAdoptFromGateway(t *testing.T) {
 }
 
 // TestEnvtest_TLSRoute_InheritsAdoptFromGateway is the TLSRoute counterpart
-// to TestEnvtest_HTTPRoute_InheritsAdoptFromGateway. TLSRoute annotation
-// inheritance is wired in P3 Task 3; this test is structurally complete and
-// will be activated once that task lands.
+// to TestEnvtest_HTTPRoute_InheritsAdoptFromGateway. Pins Design E1 §5 against
+// a real apiserver: when a TLSRoute omits cloudflare.io/adopt but the parent
+// Gateway carries it, the emitted CloudflareDNSRecord must reflect the
+// Gateway's value.
+//
+// Gotchas pre-empted (per project Phase 3 execution lessons):
+//   - DNSRecord admission has CEL "has(zoneID) || has(zoneRef)": the fixture
+//     creates a CloudflareZone CR and sets cloudflare.io/zone-ref on the Gateway
+//     so every emitted DNSRecord carries a valid zoneRef. The TLSRoute omits
+//     zone-ref deliberately — it must inherit it from the Gateway.
+//   - Tunnel Status.TunnelCNAME must populate before the TLSRoute is created
+//     so the TLSRoute reconciler's deferred-emission guard never fires.
+//   - setupTLSRouteEnv is reused without modification — all reconcilers
+//     (Gateway, Tunnel, TLSRoute sources) are wired and share one cache.
 func TestEnvtest_TLSRoute_InheritsAdoptFromGateway(t *testing.T) {
-	t.Skip("TLSRoute annotation inheritance lands in P3 Task 3")
+	if sharedConfig == nil {
+		t.Skip("envtest not initialized (KUBEBUILDER_ASSETS unset)")
+	}
+	f := setupTLSRouteEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Zone CR — admission requires has(zoneRef); the Gateway carries zone-ref,
+	// so the emitted DNSRecord inherits it and passes CEL validation.
+	zone := &v1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: f.ns},
+		Spec: v1alpha1.CloudflareZoneSpec{
+			Name:           "example.com",
+			Type:           "full",
+			DeletionPolicy: "Retain",
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, zone))
+
+	// Backing Service for the Gateway.
+	gwSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-svc", Namespace: f.ns},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 443}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, gwSvc))
+
+	// Tunnel-targeted Gateway with adopt=true AND zone-ref so inheritance
+	// propagates both to the emitted DNSRecord.
+	gwHostname := gwv1.Hostname("ext.example.com")
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gw", Namespace: f.ns,
+			Annotations: map[string]string{
+				conventions.AnnotationTunnel:         "true",
+				conventions.AnnotationTunnelName:     "edge",
+				conventions.AnnotationGatewayService: f.ns + "/gw-svc",
+				conventions.AnnotationAdopt:          "true",
+				conventions.AnnotationZoneRef:        "example-com",
+			},
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: "any-class",
+			Listeners: []gwv1.Listener{{
+				Name: "tls", Hostname: &gwHostname, Port: 443, Protocol: gwv1.TLSProtocolType,
+			}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, gw))
+
+	// Wait for Status.TunnelCNAME so the TLSRoute reconciler advances past the
+	// deferred-emission guard on the first reconcile pass.
+	expectedTunnel := "cf-" + f.ns + "-edge"
+	require.Eventually(t, func() bool {
+		var tn v1alpha1.CloudflareTunnel
+		if err := f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: expectedTunnel}, &tn); err != nil {
+			return false
+		}
+		return tn.Status.TunnelCNAME != ""
+	}, 30*time.Second, 250*time.Millisecond, "parent Gateway's tunnel %q must reach Status.TunnelCNAME", expectedTunnel)
+
+	// TLSRoute deliberately omits adopt and zone-ref — must inherit both from
+	// the parent Gateway.
+	nsRef := gwv1.Namespace(f.ns)
+	rt := &gwv1a2.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "r",
+			Namespace: f.ns,
+			// No annotations — adopt + zone-ref must fall through from Gateway.
+		},
+		Spec: gwv1a2.TLSRouteSpec{
+			Hostnames: []gwv1.Hostname{"tls.example.com"},
+			CommonRouteSpec: gwv1.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{{Name: "gw", Namespace: &nsRef}},
+			},
+			// TLSRoute CRD admission requires spec.rules to be present.
+			Rules: []gwv1a2.TLSRouteRule{{}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, rt))
+
+	// The emitted CloudflareDNSRecord must carry Spec.Adopt=true (inherited
+	// from the Gateway's cloudflare.io/adopt annotation).
+	require.Eventually(t, func() bool {
+		var list v1alpha1.CloudflareDNSRecordList
+		if err := f.c.List(ctx, &list, client.InNamespace(f.ns)); err != nil {
+			return false
+		}
+		for _, dr := range list.Items {
+			if dr.Spec.Name == "tls.example.com" && dr.Spec.Type == "CNAME" {
+				return dr.Spec.Adopt
+			}
+		}
+		return false
+	}, 20*time.Second, 250*time.Millisecond,
+		"emitted DNSRecord for tls.example.com must carry Spec.Adopt=true (inherited from Gateway)")
 }

--- a/test/envtest/tunnel_drift_detection_test.go
+++ b/test/envtest/tunnel_drift_detection_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/cloudflare"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+)
+
+// TestEnvtest_TunnelDriftDetection pins the Design-E2 out-of-band drift
+// detection against a real apiserver. The CloudflareTunnel reconciler's
+// applyRemoteConfig asks Cloudflare for the live tunnel config and, when it
+// diverges from Status.ObservedIngress, emits a single DriftDetected Warning
+// Event. This is detection only — no forced re-push.
+//
+// Scenario: a tunnel CR settles with a populated Status (TunnelID +
+// non-empty ObservedIngress). We then mutate the mock's live config out of
+// band (simulating a dashboard edit) and trigger a fresh reconcile. The
+// reconciler must record a DriftDetected Event on the tunnel CR, observed
+// via the apiserver Events API (the manager's EventRecorder writes Events to
+// the real API server in envtest).
+func TestEnvtest_TunnelDriftDetection(t *testing.T) {
+	if sharedConfig == nil {
+		t.Skip("envtest not initialized (KUBEBUILDER_ASSETS unset)")
+	}
+	f := setupTunnelEnv(t)
+	ctx := context.Background()
+
+	tn := makeTunnel("tnl", f.ns)
+	require.NoError(t, f.c.Create(ctx, tn))
+
+	// Wait for the first reconcile to populate TunnelID + ObservedIngress —
+	// the populated baseline the drift guard requires before it engages.
+	require.Eventually(t, func() bool {
+		var got v1alpha1.CloudflareTunnel
+		if err := f.c.Get(ctx, types.NamespacedName{Name: "tnl", Namespace: f.ns}, &got); err != nil {
+			return false
+		}
+		return got.Status.TunnelID != "" && len(got.Status.ObservedIngress) > 0
+	}, 15*time.Second, 250*time.Millisecond, "first reconcile populates TunnelID + ObservedIngress")
+
+	var got v1alpha1.CloudflareTunnel
+	require.NoError(t, f.c.Get(ctx, types.NamespacedName{Name: "tnl", Namespace: f.ns}, &got))
+	tunnelID := got.Status.TunnelID
+
+	// Out-of-band edit: replace the live config with an ingress entry the
+	// operator never pushed (simulating a dashboard / external-tool change).
+	// snapshotFromConfig(live) will now differ from Status.ObservedIngress.
+	_, err := f.mock.Tunnel.PutConfiguration(ctx, "acct-1", tunnelID,
+		cloudflare.TunnelConfig{Ingress: []cloudflare.IngressEntry{
+			{Hostname: "rogue.example.com", Service: "http://rogue.svc:80"},
+			{Service: "http_status:404"},
+		}})
+	require.NoError(t, err)
+
+	// Trigger a fresh reconcile via an annotation touch (no spec change).
+	require.NoError(t, f.c.Get(ctx, types.NamespacedName{Name: "tnl", Namespace: f.ns}, &got))
+	if got.Annotations == nil {
+		got.Annotations = map[string]string{}
+	}
+	got.Annotations["trigger"] = "drift"
+	require.NoError(t, f.c.Update(ctx, &got))
+
+	// The reconcile must record a DriftDetected Warning Event on the tunnel
+	// CR. The manager's EventRecorder persists Events to the apiserver, so we
+	// observe them by listing core/v1 Events in the test namespace and
+	// matching on Reason + InvolvedObject.
+	require.Eventually(t, func() bool {
+		var events corev1.EventList
+		if err := f.c.List(ctx, &events, client.InNamespace(f.ns)); err != nil {
+			return false
+		}
+		for i := range events.Items {
+			ev := &events.Items[i]
+			if ev.Reason == conventions.ReasonDriftDetected &&
+				ev.InvolvedObject.Kind == "CloudflareTunnel" &&
+				ev.InvolvedObject.Name == "tnl" &&
+				ev.Type == corev1.EventTypeWarning {
+				return true
+			}
+		}
+		return false
+	}, 20*time.Second, 250*time.Millisecond,
+		"out-of-band live-config edit must produce a DriftDetected Warning Event on the tunnel CR")
+}

--- a/test/envtest/tunnel_orphan_prune_test.go
+++ b/test/envtest/tunnel_orphan_prune_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
+	"github.com/jacaudi/cloudflare-operator/internal/conventions"
+)
+
+// TestEnvtest_OrphanPrune_RemovesDNSRecordWhenHostnameDropped pins Design E3
+// (orphan prune) against a real apiserver. A Service emitting two
+// CloudflareDNSRecord CRs (a.example.com, b.example.com) has its hostnames
+// annotation narrowed to just a.example.com; the next source-reconcile pass
+// must prune the now-orphaned b.example.com CR while leaving a.example.com
+// untouched.
+//
+// Gotchas pre-empted (per project Phase 3 execution lessons):
+//   - DNSRecord admission has CEL "has(zoneID) || has(zoneRef)": the fixture
+//     creates a CloudflareZone CR and sets cloudflare.io/zone-ref on the
+//     Service so every emitted DNSRecord carries a valid zoneRef.
+//   - Tunnel Status.TunnelCNAME must populate before emission can advance past
+//     the source reconciler's deferred-emission guard; the fixture waits on it.
+//   - setupServiceEnv is reused without modification — Service + Tunnel
+//     reconcilers share one tunnelsynth.Cache, identical to the sibling
+//     Service envtests.
+func TestEnvtest_OrphanPrune_RemovesDNSRecordWhenHostnameDropped(t *testing.T) {
+	if sharedConfig == nil {
+		t.Skip("envtest not initialized (KUBEBUILDER_ASSETS unset)")
+	}
+	f := setupServiceEnv(t, "")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Zone CR — admission requires has(zoneRef); the Service carries zone-ref,
+	// so every emitted DNSRecord inherits it and passes CEL validation.
+	zone := &v1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: f.ns},
+		Spec: v1alpha1.CloudflareZoneSpec{
+			Name:           "example.com",
+			Type:           "full",
+			DeletionPolicy: "Retain",
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, zone))
+
+	// Annotated Service emitting TWO hostnames.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc", Namespace: f.ns,
+			Annotations: map[string]string{
+				conventions.AnnotationTunnel:     "true",
+				conventions.AnnotationTunnelName: "payments",
+				conventions.AnnotationHostnames:  "a.example.com,b.example.com",
+				conventions.AnnotationZoneRef:    "example-com",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, svc))
+
+	// Wait for the tunnel CR + Status.TunnelCNAME (deferred-emission flow).
+	expectedTunnel := "cf-" + f.ns + "-payments"
+	require.Eventually(t, func() bool {
+		var tn v1alpha1.CloudflareTunnel
+		if err := f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: expectedTunnel}, &tn); err != nil {
+			return false
+		}
+		return tn.Status.TunnelCNAME != ""
+	}, 30*time.Second, 250*time.Millisecond, "tunnel Status.TunnelCNAME populated")
+
+	// Both DNSRecord CRs must be emitted before we narrow the annotation.
+	require.Eventually(t, func() bool {
+		return dnsRecordExists(ctx, t, f.c, f.ns, "a.example.com") &&
+			dnsRecordExists(ctx, t, f.c, f.ns, "b.example.com")
+	}, 30*time.Second, 250*time.Millisecond, "both a.example.com and b.example.com DNSRecord CRs emitted")
+
+	// Narrow the hostnames annotation: drop b.example.com.
+	require.NoError(t, f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: "svc"}, svc))
+	svc.Annotations[conventions.AnnotationHostnames] = "a.example.com"
+	require.NoError(t, f.c.Update(ctx, svc))
+
+	// The next reconcile pass must prune the orphaned b.example.com CR while
+	// keeping a.example.com. Before the orphan-prune wiring this assertion
+	// fails: the b.example.com CR persists because nothing deletes it.
+	require.Eventually(t, func() bool {
+		return !dnsRecordExists(ctx, t, f.c, f.ns, "b.example.com")
+	}, 30*time.Second, 250*time.Millisecond,
+		"orphaned DNSRecord for b.example.com must be pruned after it leaves the hostnames annotation")
+
+	// a.example.com must survive — it's still in the desired set.
+	require.True(t, dnsRecordExists(ctx, t, f.c, f.ns, "a.example.com"),
+		"DNSRecord for a.example.com must survive (still in the desired set)")
+}
+
+// TestEnvtest_OrphanPrune_RespectsLabelScope pins the label-scope contract of
+// pruneOrphanedDNSRecords against a real apiserver: pruning triggered by one
+// Service (which lists CRs by its own three source-identity labels) must NEVER
+// touch a CR owned by a different Service, even when both live in the same
+// namespace and reference the same zone.
+func TestEnvtest_OrphanPrune_RespectsLabelScope(t *testing.T) {
+	if sharedConfig == nil {
+		t.Skip("envtest not initialized (KUBEBUILDER_ASSETS unset)")
+	}
+	f := setupServiceEnv(t, "")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	zone := &v1alpha1.CloudflareZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-com", Namespace: f.ns},
+		Spec: v1alpha1.CloudflareZoneSpec{
+			Name:           "example.com",
+			Type:           "full",
+			DeletionPolicy: "Retain",
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, zone))
+
+	// Service ONE emits one.example.com.
+	svc1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-one", Namespace: f.ns,
+			Annotations: map[string]string{
+				conventions.AnnotationTunnel:     "true",
+				conventions.AnnotationTunnelName: "payments",
+				conventions.AnnotationHostnames:  "one.example.com",
+				conventions.AnnotationZoneRef:    "example-com",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, svc1))
+
+	// Service TWO emits two.example.com (same tunnel, same zone, same ns).
+	svc2 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-two", Namespace: f.ns,
+			Annotations: map[string]string{
+				conventions.AnnotationTunnel:     "true",
+				conventions.AnnotationTunnelName: "payments",
+				conventions.AnnotationHostnames:  "two.example.com",
+				conventions.AnnotationZoneRef:    "example-com",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	require.NoError(t, f.c.Create(ctx, svc2))
+
+	expectedTunnel := "cf-" + f.ns + "-payments"
+	require.Eventually(t, func() bool {
+		var tn v1alpha1.CloudflareTunnel
+		if err := f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: expectedTunnel}, &tn); err != nil {
+			return false
+		}
+		return tn.Status.TunnelCNAME != ""
+	}, 30*time.Second, 250*time.Millisecond, "tunnel Status.TunnelCNAME populated")
+
+	// Both CRs emitted.
+	require.Eventually(t, func() bool {
+		return dnsRecordExists(ctx, t, f.c, f.ns, "one.example.com") &&
+			dnsRecordExists(ctx, t, f.c, f.ns, "two.example.com")
+	}, 30*time.Second, 250*time.Millisecond, "both Services' DNSRecord CRs emitted")
+
+	// Opt svc-one OUT entirely (tunnel=false). Its reconcile path no longer
+	// emits and is not the prune path; but more importantly, mutate svc-two so
+	// IT prunes — drop its only hostname so svc-two's prune pass runs with an
+	// empty desired set. svc-one's CR must survive: it carries svc-one's
+	// source labels, invisible to svc-two's label-scoped prune.
+	require.NoError(t, f.c.Get(ctx, types.NamespacedName{Namespace: f.ns, Name: "svc-two"}, svc2))
+	svc2.Annotations[conventions.AnnotationHostnames] = "two-renamed.example.com"
+	require.NoError(t, f.c.Update(ctx, svc2))
+
+	// svc-two's old CR (two.example.com) is pruned; the new one
+	// (two-renamed.example.com) is emitted.
+	require.Eventually(t, func() bool {
+		return !dnsRecordExists(ctx, t, f.c, f.ns, "two.example.com") &&
+			dnsRecordExists(ctx, t, f.c, f.ns, "two-renamed.example.com")
+	}, 30*time.Second, 250*time.Millisecond,
+		"svc-two's old hostname CR pruned and renamed CR emitted")
+
+	// svc-one's CR MUST survive the svc-two prune — label scope isolates them.
+	require.True(t, dnsRecordExists(ctx, t, f.c, f.ns, "one.example.com"),
+		"svc-one's DNSRecord must survive svc-two's prune (label-scoped, not cross-source)")
+}
+
+// dnsRecordExists reports whether a CloudflareDNSRecord with the given
+// Spec.Name currently exists in the namespace. A record mid-deletion (non-nil
+// DeletionTimestamp) is treated as already gone so the prune assertions don't
+// race the finalizer/GC.
+func dnsRecordExists(ctx context.Context, t *testing.T, c client.Client, ns, hostname string) bool {
+	t.Helper()
+	var list v1alpha1.CloudflareDNSRecordList
+	if err := c.List(ctx, &list, client.InNamespace(ns)); err != nil {
+		return false
+	}
+	for i := range list.Items {
+		dr := &list.Items[i]
+		if dr.Spec.Name == hostname && dr.DeletionTimestamp == nil {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Post-refactor follow-up phase **P3** — three independent tunnel-controller items, all envtested:

- **E1 — annotation inheritance.** New shared in-package helper (`inheritAnnotation` / `inheritedAnnotations`) so HTTPRoute and TLSRoute source reconcilers inherit `cloudflare.io/*` annotations from the parent Gateway when the route omits them (route value wins when set non-empty). One helper, reused by both route reconcilers — no per-route duplication.
- **E2 — out-of-band drift detection.** The previously-defined-but-unconsumed `TunnelClient.GetConfiguration` is now wired into `applyRemoteConfig`: it compares the live tunnel config to the operator's last-observed snapshot and emits a single `DriftDetected` warning Event on divergence (dashboard / external-tool edits). **Detection only** — the existing PUT / early-return path is unchanged; no auto-revert. Guarded against a spurious first-reconcile event.
- **E3 — orphan cleanup.** New shared `pruneOrphanedDNSRecords` helper, wired into all four source reconcilers (Service / Gateway / HTTPRoute / TLSRoute) strictly on the post-emit path: when a source's hostname set shrinks, the now-orphaned operator-emitted `CloudflareDNSRecord` CRs are deleted (label-scoped to the owning source; best-effort; concurrent-deletion-safe). Emits `OrphanedDNSRecordPruned` via the existing event-dedupe layer.

10 commits; helpers + per-reconciler wiring + 3 new envtest suites + unit tests + the `ReasonOrphanedDNSRecordPruned` constant registration. Every task passed an independent per-task review and the whole branch passed a final independent comprehensive review (0 critical / 0 important).

Base is `refactor/total` (same flow as the P1 / P2 phases); this does not target `main`.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test -count=1 ./...` — full unit suite green (no regressions across all packages)
- [x] Full envtest suite green, incl. the 3 new suites: HTTPRoute+TLSRoute annotation inheritance, tunnel drift detection, orphan-prune (dropped-hostname + label-scope)
- [x] Per-task independent reviews + final comprehensive review — no critical/important findings
- [ ] Reviewer sanity-check of the E2 detection-only invariant and the E3 post-emit-path placement across all 4 reconcilers

🤖 Generated with [Claude Code](https://claude.com/claude-code)