### PR TITLE
chore: gofmt the 6 pre-existing unformatted files on refactor/total

### DIFF
--- a/api/v1alpha1/cloudflareoperator_types_test.go
+++ b/api/v1alpha1/cloudflareoperator_types_test.go
@@ -30,4 +30,3 @@ func TestControllerSpec_DefaultReplicas(t *testing.T) {
 	s := ControllerSpec{}
 	require.Equal(t, int32(0), s.Replicas, "replicas should default to zero so CEL/defaulting can fill it")
 }
-

--- a/internal/controller/tunnel/setup_indexers_test.go
+++ b/internal/controller/tunnel/setup_indexers_test.go
@@ -35,9 +35,9 @@ func TestIndexHTTPRouteByGatewayParent_MultiParent(t *testing.T) {
 		Spec: gwv1.HTTPRouteSpec{
 			CommonRouteSpec: gwv1.CommonRouteSpec{
 				ParentRefs: []gwv1.ParentReference{
-					{Name: "gw1"},                                   // implicit Gateway kind, same ns
-					{Name: "gw2", Namespace: gwv1NS("ns-b")},        // explicit cross-ns
-					{Name: "svc", Kind: gwv1Kind("Service")},        // non-Gateway → skipped
+					{Name: "gw1"},                            // implicit Gateway kind, same ns
+					{Name: "gw2", Namespace: gwv1NS("ns-b")}, // explicit cross-ns
+					{Name: "svc", Kind: gwv1Kind("Service")}, // non-Gateway → skipped
 				},
 			},
 		},

--- a/internal/controller/zone/zone_controller_test.go
+++ b/internal/controller/zone/zone_controller_test.go
@@ -190,8 +190,8 @@ func TestZone_DeleteWithDelete_CallsDrainHoldFn(t *testing.T) {
 
 	var drainCalls []string
 	r := &CloudflareZoneReconciler{
-		Client: c,
-		Scheme: s,
+		Client:       c,
+		Scheme:       s,
 		ZoneClientFn: func(_ cloudflare.Credentials) (cloudflare.ZoneClient, error) { return m.Zone, nil },
 		DrainHoldFn: func(_ context.Context, zoneID string) error {
 			drainCalls = append(drainCalls, zoneID)
@@ -241,8 +241,8 @@ func TestZone_DeleteWithDelete_DrainHoldFnErrorIsLogged(t *testing.T) {
 
 	drainErr := errors.New("hold drain failed")
 	r := &CloudflareZoneReconciler{
-		Client: c,
-		Scheme: s,
+		Client:       c,
+		Scheme:       s,
 		ZoneClientFn: func(_ cloudflare.Credentials) (cloudflare.ZoneClient, error) { return m.Zone, nil },
 		DrainHoldFn: func(_ context.Context, _ string) error {
 			return drainErr

--- a/internal/controller/zone/zoneconfig_controller.go
+++ b/internal/controller/zone/zoneconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +34,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"golang.org/x/sync/errgroup"
 
 	v1alpha1 "github.com/jacaudi/cloudflare-operator/api/v1alpha1"
 	"github.com/jacaudi/cloudflare-operator/internal/cloudflare"

--- a/internal/reconcile/owner.go
+++ b/internal/reconcile/owner.go
@@ -27,4 +27,3 @@ import (
 func SetControllerOwner(owner, child client.Object, scheme *runtime.Scheme) error {
 	return controllerutil.SetControllerReference(owner, child, scheme)
 }
-

--- a/test/envtest/tunnel_annotation_inheritance_test.go
+++ b/test/envtest/tunnel_annotation_inheritance_test.go
@@ -39,17 +39,17 @@ import (
 // Gateway's value.
 //
 // Gotchas pre-empted (per project Phase 3 execution lessons):
-//  - DNSRecord admission has CEL "has(zoneID) || has(zoneRef)": the fixture
-//    creates a CloudflareZone CR and sets cloudflare.io/zone-ref on the Gateway
-//    so every emitted DNSRecord carries a valid zoneRef. Routes omit zone-ref
-//    deliberately — they must inherit it from the Gateway.
-//  - Tunnel Status.TunnelCNAME must populate before the HTTPRoute is created
-//    so the HTTPRoute reconciler's deferred-emission guard never fires. The
-//    fixture waits for this before creating the route (mirrors
-//    createGatewayForRouteTest in httproute_source_envtest_test.go).
-//  - setupHTTPRouteEnv is reused without modification — all reconcilers
-//    (Gateway, Tunnel, HTTPRoute sources) are wired and share one
-//    tunnelsynth.Cache, identical to the existing HTTPRoute envtests.
+//   - DNSRecord admission has CEL "has(zoneID) || has(zoneRef)": the fixture
+//     creates a CloudflareZone CR and sets cloudflare.io/zone-ref on the Gateway
+//     so every emitted DNSRecord carries a valid zoneRef. Routes omit zone-ref
+//     deliberately — they must inherit it from the Gateway.
+//   - Tunnel Status.TunnelCNAME must populate before the HTTPRoute is created
+//     so the HTTPRoute reconciler's deferred-emission guard never fires. The
+//     fixture waits for this before creating the route (mirrors
+//     createGatewayForRouteTest in httproute_source_envtest_test.go).
+//   - setupHTTPRouteEnv is reused without modification — all reconcilers
+//     (Gateway, Tunnel, HTTPRoute sources) are wired and share one
+//     tunnelsynth.Cache, identical to the existing HTTPRoute envtests.
 func TestEnvtest_HTTPRoute_InheritsAdoptFromGateway(t *testing.T) {
 	if sharedConfig == nil {
 		t.Skip("envtest not initialized (KUBEBUILDER_ASSETS unset)")


### PR DESCRIPTION
## Summary

`make lint` runs `gofmt -l . | tee /dev/stderr | (! read)` — it fails repo-wide if **any** Go file is unformatted. Six files have accumulated gofmt drift across the prior squash-merges onto `refactor/total` and are dirty on the base branch itself:

- `api/v1alpha1/cloudflareoperator_types_test.go` — trailing blank line
- `internal/reconcile/owner.go` — trailing blank line
- `internal/controller/tunnel/setup_indexers_test.go` — comment-column re-alignment
- `internal/controller/zone/zone_controller_test.go` — struct-literal field alignment
- `internal/controller/zone/zoneconfig_controller.go` — one import moved into its correct group
- `test/envtest/tunnel_annotation_inheritance_test.go` — whitespace

These predate and are unrelated to any in-flight feature branch, but they make `make lint` fail for **every branch cut from `refactor/total`** (incl. the open P4 and P5 PRs) for a base-branch reason. Pure `gofmt -w`; **zero behavior change**.

## Test Plan

- [x] `gofmt -l .` now reports nothing (whole repo clean)
- [x] Exactly the 6 files changed (19 insertions / 21 deletions, all whitespace/import-group)
- [x] `go build ./...` clean · `go vet ./...` clean
- [x] `go test -count=1 ./...` — all packages pass (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)