### PR TITLE
ci: restore .releaserc.json (unblocks main's CI/CD release)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,53 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "breaking": true, "release": "minor" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "release": false }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "refactor", "section": "Refactors" },
+            { "type": "chore", "scope": "deps", "section": "Dependencies" }
+          ]
+        },
+        "writerOpts": {
+          "headerPartial": "## {{#if @root.linkCompare~}}[{{version}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{~else}}{{~version}}{{~/if}} ({{date}})"
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "if [ -f chart/Chart.yaml ]; then sed -i 's/^version:.*/version: ${nextRelease.version}/' chart/Chart.yaml && sed -i 's/^appVersion:.*/appVersion: \"${nextRelease.version}\"/' chart/Chart.yaml; fi"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "chart/Chart.yaml"],
+        "message": "release: v${nextRelease.version} [skip ci]"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

- Restores `.releaserc.json` to its pre-refactor content. The refactor's clean-slate sweep (`bf522b4`) deleted it; without it, semantic-release defaults to a plugin set that includes `@semantic-release/npm`, which aborts on the missing `package.json`. The reusable release workflow's own docstring requires this config.
- File restored verbatim from `372dcf3:.releaserc.json` (the last working main tip). Plugin list explicitly excludes npm; preserves the project's release-rule policy (breaking→minor, refactor→patch, chore→false) and the chart-version bump via `@semantic-release/exec`.

## Why the release failed on main

The post-`9c705de` `CI/CD` run (`26269647417`) showed:

```
release / Semantic Release: Failed step "verifyConditions" of plugin "@semantic-release/npm"
SemanticReleaseError: Missing \`package.json\` file.
```

All other jobs (test, envtest, lint, build metadata) were green; `container` and `helm` were skipped because they `needs: [release]`. Once this file is restored, the next push to `main` (the merge of this PR itself) re-runs the release pipeline, which should publish v0.19.0 (driven by the refactor's `feat!:` / `refactor:` commits since `v0.18.3`).

## Heads-up — separate decision

The restored `breaking → minor` rule is unusual; the standard convention is `breaking → major`. Given v2alpha1 is a full API break, v1.0.0 would be the more honest version. If you want that instead of v0.19.0, this PR also needs `breaking: true` → `"major"` AND the `9c705de` merge commit body would need a `BREAKING CHANGE:` footer (or a follow-up commit with one) so semantic-release picks it up. Not changed here — flagging only.

## Test plan

- [ ] Merge this PR
- [ ] Watch the resulting CI/CD run on `main` — `release / Semantic Release` should now succeed
- [ ] Confirm v0.19.0 tag + GitHub Release are published
- [ ] Confirm `container` + `helm` jobs run and publish to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)