### PR TITLE
chore(deps): remove orphaned cloudflare-go/v7 from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.2
 
 require (
 	github.com/cloudflare/cloudflare-go/v6 v6.10.0
-	github.com/cloudflare/cloudflare-go/v7 v7.3.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -106,7 +106,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/cloudflare-go/v6 v6.10.0 h1:tm+YwMDAdxxy2eIAlLH9Wu8JWSMg6fE3j3ydZbMG6co=
 github.com/cloudflare/cloudflare-go/v6 v6.10.0/go.mod h1:Lj3MUqjvKctXRpdRhLQxZYRrNZHuRs0XYuH8JtQGyoI=
-github.com/cloudflare/cloudflare-go/v7 v7.3.0/go.mod h1:9zcoIAtu6cmcoPszCNISvqYMXs8wObtVGXE1qGFMrNU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+fbBAhrQPs=
 github.com/curioswitch/go-reassign v0.3.0/go.mod h1:nApPCCTtqLJN/s8HfItCcKV0jIPwluBOvZP+dsJGA88=


### PR DESCRIPTION
## Summary
- Removes the orphan `github.com/cloudflare/cloudflare-go/v7 v7.3.0` require entry from `go.mod` (and corresponding `go.sum` line) via `go mod tidy`.
- Commit 5551e67 added v7 to `go.mod` but migrated zero code — every `internal/cloudflare/*.go` still imports `cloudflare-go/v6`. The v7 entry was a stale leftover from an incomplete migration.

## Context
PR #140 (Renovate: v6 → v7) tries to replace v6 with v7 by string substitution, which would (a) leave duplicate `v7 v7.3.0` lines in `go.mod` and (b) break the build because v6 is still imported. This PR doesn't migrate the code — it just clears the orphan so the half-migration trap is gone. A real v6→v7 code migration remains separate work; PR #140 cannot merge until that's done.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] CI green