### PR TITLE
docs: drop cloudflare-go version pin from doc comments and roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ to capture the open design questions before any of them turn into a plan.
 Each section lists what the API looks like today, the rough shape a controller
 might take, and the open questions that need answering before design work
 starts. CRD sketches were cross-checked against the Cloudflare Go SDK
-(`github.com/cloudflare/cloudflare-go/v6`) and the public API reference; API
+(`github.com/cloudflare/cloudflare-go`) and the public API reference; API
 paths quoted below come from those sources.
 
 ## Contents
@@ -152,7 +152,7 @@ KV namespaces are a separate top-level resource at
 and so do container bindings (`[[containers]]` block — image ref,
 `default_port`, `sleep_after`, `enable_internet`, `entrypoint`, allowed/
 denied hosts). The Cloudflare Containers Go management API isn't yet
-surfaced in cloudflare-go v6's typed client; the management surface today
+surfaced in cloudflare-go's typed client; the management surface today
 is the Worker upload itself.
 
 ### Workers — static assets (the Pages replacement)
@@ -273,7 +273,7 @@ operator's scope.
   Do we expose them raw in `Worker.spec.containers[]`, or wrap them in a
   higher-level "egress profile" sub-CRD that can be shared across
   Workers?
-- Container management API: as of cloudflare-go v6 there's no typed
+- Container management API: cloudflare-go has no typed
   client for container-level operations beyond the Worker upload itself.
   If a standalone management API (`/accounts/{account_id}/containers/`
   or `/cloudchamber/`) lands later, we may want a `ContainerInstance`

--- a/internal/cloudflare/dns.go
+++ b/internal/cloudflare/dns.go
@@ -33,7 +33,7 @@ func classifyDNSAPIErr(err error) error {
 	return err
 }
 
-// dnsClient wraps the cloudflare-go v6 SDK to implement DNSClient.
+// dnsClient wraps the cloudflare-go SDK to implement DNSClient.
 type dnsClient struct {
 	cf *cfgo.Client
 }

--- a/internal/cloudflare/ruleset.go
+++ b/internal/cloudflare/ruleset.go
@@ -23,7 +23,7 @@ import (
 // should treat this as "start from scratch" and proceed to UpsertPhaseEntrypoint.
 var ErrPhaseEntrypointNotFound = errors.New("phase entrypoint not found")
 
-// rulesetClient wraps the cloudflare-go v6 SDK to implement RulesetClient.
+// rulesetClient wraps the cloudflare-go SDK to implement RulesetClient.
 type rulesetClient struct {
 	cf *cfgo.Client
 }

--- a/internal/cloudflare/zone.go
+++ b/internal/cloudflare/zone.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7/zones"
 )
 
-// zoneClient wraps the cloudflare-go v6 SDK to implement ZoneClient.
+// zoneClient wraps the cloudflare-go SDK to implement ZoneClient.
 type zoneClient struct {
 	cf *cfgo.Client
 }

--- a/internal/cloudflare/zoneconfig.go
+++ b/internal/cloudflare/zoneconfig.go
@@ -28,7 +28,7 @@ import (
 // transient error. Match with errors.Is.
 var ErrPlanTierInsufficient = errors.New("cloudflare plan tier does not support this setting")
 
-// zoneConfigClient wraps the cloudflare-go v6 SDK to implement ZoneConfigClient.
+// zoneConfigClient wraps the cloudflare-go SDK to implement ZoneConfigClient.
 // It covers zone-level settings (PUT /zones/{id}/settings/{setting_id}) and
 // the bot-management resource (GET/PUT /zones/{id}/bot_management).
 type zoneConfigClient struct {


### PR DESCRIPTION
## Summary

Follow-up cleanup to #142. Four wrapper-client docstrings under `internal/cloudflare/` still said `cloudflare-go v6 SDK` by version number, and `docs/roadmap.md` hard-coded `/v6` in the module path plus two "as of v6" statements about API surface availability. After the v6→v7 migration in #142, those references are stale; swapping to `v7` would just go stale again at v8.

Making them version-agnostic instead — the wrappers wrap "the cloudflare-go SDK" regardless of major; the roadmap discusses cloudflare-go's typed-client surface in general, not a specific release.

## Files

- `internal/cloudflare/dns.go:36` — docstring
- `internal/cloudflare/ruleset.go:26` — docstring
- `internal/cloudflare/zone.go:18` — docstring
- `internal/cloudflare/zoneconfig.go:31` — docstring
- `docs/roadmap.md` — 3 lines (module path mention + 2 "as of v6" statements)

7 insertions / 7 deletions. No code changes.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)