### PR TITLE
fix(tunnel): distinguish transient Get errors from "no tunnel-targeted parent"

### DIFF
--- a/internal/controller/tunnel/attach.go
+++ b/internal/controller/tunnel/attach.go
@@ -510,9 +510,12 @@ func handleDeriveTunnelNameErr(
 // findTunnelTargetedParentRef scans parentRefs for the first parent Gateway
 // that opts into tunnel attachment (cloudflare.io/tunnel truthy), has a
 // derivable tunnel name, an existing CloudflareTunnel, and a resolvable
-// Gateway Service. Returns all-nil when none qualifies. Get failures on a
-// candidate are treated as "not this parent" (skip, don't fail). Shared by
-// the HTTPRoute and TLSRoute source reconcilers.
+// Gateway Service. Returns all-nil when none qualifies. A NotFound on a
+// candidate's Gateway or CloudflareTunnel is treated as "not this parent"
+// (skip); any other (transient) Get failure is returned so the caller can
+// requeue instead of mis-reporting "no tunnel-targeted parent" and tripping
+// the deactivation prune (issue #146). Shared by the HTTPRoute and TLSRoute
+// source reconcilers.
 func findTunnelTargetedParentRef(
 	ctx context.Context,
 	c client.Client,
@@ -527,7 +530,15 @@ func findTunnelTargetedParentRef(
 		}
 		var gw gwv1.Gateway
 		if err := c.Get(ctx, types.NamespacedName{Namespace: gwNS, Name: string(pr.Name)}, &gw); err != nil {
-			continue
+			// A definitively-missing parent (NotFound) is "not this parent" —
+			// skip it. Any other Get failure (apiserver glitch, cache resync
+			// hole) is transient: surface it so the reconcile requeues and
+			// retries, rather than mis-reporting "no tunnel-targeted parent"
+			// and tripping the #145 deactivation prune (issue #146).
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, nil, nil, nil, 0, err
 		}
 		enabled, _ := conventions.ParseTruthy(gw.Annotations[conventions.AnnotationTunnel])
 		if !enabled {
@@ -539,7 +550,15 @@ func findTunnelTargetedParentRef(
 		}
 		var tn v2alpha1.CloudflareTunnel
 		if err := c.Get(ctx, types.NamespacedName{Namespace: gwNS, Name: derived}, &tn); err != nil {
-			continue
+			// Same distinction as the Gateway Get above: a missing
+			// CloudflareTunnel (NotFound) means this parent doesn't yet opt
+			// into tunnelling — skip it. A transient Get failure is surfaced
+			// so the reconcile requeues instead of spuriously deactivating
+			// (issue #146).
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, nil, nil, nil, 0, err
 		}
 		gwSvc, port, err := resolveGatewayService(ctx, c, &gw)
 		if err != nil {

--- a/internal/controller/tunnel/attach_test.go
+++ b/internal/controller/tunnel/attach_test.go
@@ -692,6 +692,21 @@ func TestHandleDeriveTunnelNameErr_NoTrackerEntry(t *testing.T) {
 //
 // Negative case: a plain Gateway without the cloudflare.io/tunnel annotation
 // yields all-nil/zero returns (no match, no error).
+//
+// Test-category coverage for the issue #146 fix (Get-error distinction):
+//   1. Happy path         — "positive: tunnel-targeted gateway resolves all fields"
+//   2. Negative/no-match   — "negative: plain gateway ...", "... missing CloudflareTunnel CR ..."
+//   3. Error handling      — "transient Gateway Get error propagates",
+//                            "transient CloudflareTunnel Get error propagates"
+//   4. Edge/boundary       — "NotFound on Gateway still skips (not an error)" — the
+//                            precise NotFound-vs-other boundary the fix branches on
+//   5. Concurrency         — N/A: findTunnelTargetedParentRef is a pure per-call read
+//                            with no shared mutable state; controller-runtime already
+//                            serializes reconciles per object via the workqueue.
+//   6. Security            — N/A: this path performs no auth/secret/tenant-boundary
+//                            handling; it only reads Gateway/CloudflareTunnel/Service.
+//   7. Regression          — the two "transient ... Get error propagates" subtests are
+//                            the direct regression guard for issue #146.
 func TestFindTunnelTargetedParentRef(t *testing.T) {
 	t.Run("positive: tunnel-targeted gateway resolves all fields", func(t *testing.T) {
 		// Build the tunnel-targeted Gateway (mirrors mkParentGw("gw","ns1")).
@@ -773,6 +788,115 @@ func TestFindTunnelTargetedParentRef(t *testing.T) {
 			WithScheme(rtScheme(t)).
 			WithObjects(gw, gwSvc). // deliberately NO CloudflareTunnel
 			Build()
+
+		pr, foundGw, foundTn, svc, port, err := findTunnelTargetedParentRef(
+			context.Background(), c, "ns1",
+			[]gwv1.ParentReference{{Name: gwv1.ObjectName("gw")}},
+		)
+
+		require.NoError(t, err)
+		require.Nil(t, pr)
+		require.Nil(t, foundGw)
+		require.Nil(t, foundTn)
+		require.Nil(t, svc)
+		require.Equal(t, int32(0), port)
+	})
+
+	// Regression for issue #146: a transient (non-NotFound) Get failure on the
+	// Gateway must be surfaced as an error so the reconcile requeues, rather
+	// than returning all-nil (which the #145 deactivation-prune branch would
+	// misread as "no tunnel-targeted parent" and spuriously delete emitted CRs).
+	t.Run("transient Gateway Get error propagates (issue #146)", func(t *testing.T) {
+		gw := mkParentGw("gw", "ns1")
+		gwSvc := mkGwSvc("gw-svc", "ns1")
+		tnName, derr := DeriveTunnelName("ns1", "edge")
+		require.NoError(t, derr)
+		tn := &v2alpha1.CloudflareTunnel{
+			ObjectMeta: metav1.ObjectMeta{Name: tnName, Namespace: "ns1"},
+		}
+
+		boom := errors.New("etcdserver: request timed out")
+		base := fake.NewClientBuilder().
+			WithScheme(rtScheme(t)).
+			WithObjects(gw, tn, gwSvc).
+			Build()
+		c := interceptor.NewClient(base, interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*gwv1.Gateway); ok {
+					return boom
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		})
+
+		pr, foundGw, foundTn, svc, port, err := findTunnelTargetedParentRef(
+			context.Background(), c, "ns1",
+			[]gwv1.ParentReference{{Name: gwv1.ObjectName("gw")}},
+		)
+
+		require.ErrorIs(t, err, boom)
+		require.Nil(t, pr)
+		require.Nil(t, foundGw)
+		require.Nil(t, foundTn)
+		require.Nil(t, svc)
+		require.Equal(t, int32(0), port)
+	})
+
+	// Same distinction for the CloudflareTunnel Get: the Gateway resolves fine,
+	// but a transient failure fetching the derived CloudflareTunnel must be
+	// surfaced rather than swallowed into an all-nil "no parent" result.
+	t.Run("transient CloudflareTunnel Get error propagates (issue #146)", func(t *testing.T) {
+		gw := mkParentGw("gw", "ns1")
+		gwSvc := mkGwSvc("gw-svc", "ns1")
+		tnName, derr := DeriveTunnelName("ns1", "edge")
+		require.NoError(t, derr)
+		tn := &v2alpha1.CloudflareTunnel{
+			ObjectMeta: metav1.ObjectMeta{Name: tnName, Namespace: "ns1"},
+		}
+
+		boom := errors.New("connection reset by peer")
+		base := fake.NewClientBuilder().
+			WithScheme(rtScheme(t)).
+			WithObjects(gw, tn, gwSvc).
+			Build()
+		c := interceptor.NewClient(base, interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v2alpha1.CloudflareTunnel); ok {
+					return boom
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		})
+
+		pr, foundGw, foundTn, svc, port, err := findTunnelTargetedParentRef(
+			context.Background(), c, "ns1",
+			[]gwv1.ParentReference{{Name: gwv1.ObjectName("gw")}},
+		)
+
+		require.ErrorIs(t, err, boom)
+		require.Nil(t, pr)
+		require.Nil(t, foundGw)
+		require.Nil(t, foundTn)
+		require.Nil(t, svc)
+		require.Equal(t, int32(0), port)
+	})
+
+	// Edge/boundary: the other side of the #146 branch. A NotFound Get (the
+	// definitively-missing case) must STILL skip the parent and return
+	// all-nil with NO error — only non-NotFound errors are surfaced. Injecting
+	// a synthetic NotFound (rather than just omitting the object) proves the
+	// branch keys on apierrors.IsNotFound, not on the fake client's behavior.
+	t.Run("NotFound on Gateway still skips (not an error)", func(t *testing.T) {
+		notFound := apierrors.NewNotFound(schema.GroupResource{Group: gwv1.GroupName, Resource: "gateways"}, "gw")
+		base := fake.NewClientBuilder().WithScheme(rtScheme(t)).Build()
+		c := interceptor.NewClient(base, interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*gwv1.Gateway); ok {
+					return notFound
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		})
 
 		pr, foundGw, foundTn, svc, port, err := findTunnelTargetedParentRef(
 			context.Background(), c, "ns1",


### PR DESCRIPTION
## Summary

`findTunnelTargetedParentRef` (`internal/controller/tunnel/attach.go`) `continue`d past a candidate parent on **any** Get failure — a single `continue` handled both `apierrors.IsNotFound` (parent definitively absent) and transient errors (apiserver glitch, cache resync hole, timeout). When every candidate parent fails to Get, the function returns `(nil parent, nil err)`, which the reconcile reads as "no tunnel-targeted parent."

Before #145 this was harmless. After #145 added deactivation pruning at the HTTPRoute/TLSRoute `parent == nil` branch, a **transient** Get error on the parent Gateway (or its `CloudflareTunnel`) can spuriously delete every `CloudflareDNSRecord` CR the source ever emitted, triggering a delete-and-reemit churn that briefly tears down the Cloudflare-side DNS + TXT records (issue #146).

## Fix

Branch on the error type at the two Get sites in `findTunnelTargetedParentRef` (the Gateway Get and the `CloudflareTunnel` Get):

- `apierrors.IsNotFound(err)` → `continue` (parent definitively doesn't exist).
- any other error → return it, so the caller can requeue.

The HTTPRoute and TLSRoute reconcile paths already surface a non-nil error from `findTunnelTargetedParent` as `return reconcile.Result{}, err`, so returning the transient error here is sufficient to convert it into a requeue instead of falling into the deactivation prune. No change to the reconcile paths was required.

## Root cause (from the issue)

Per the issue's field-evidence note: an operator reports a CR briefly disappearing without a deliberate annotation change; logs at the time would show the `orphan-prune failed during deactivation sweep` message **absent** (the prune call succeeded) followed by re-emission a moment later. The risk is observability churn (events, briefly-missing Cloudflare-side records), not data loss — but this fix removes the spurious-prune path entirely for transient errors.

## Tests

Extended `TestFindTunnelTargetedParentRef` (fake-client unit tests, `sigs.k8s.io/controller-runtime/pkg/client/fake` + `interceptor`). Category coverage:

1. **Happy path** — tunnel-targeted Gateway resolves all fields (existing).
2. **Negative / no-match** — plain Gateway without the tunnel annotation; tunnel-annotated Gateway with a missing `CloudflareTunnel` CR (existing).
3. **Error handling** — transient (non-NotFound) Get error on the Gateway propagates; same for the `CloudflareTunnel` Get (new, `interceptor.Funcs`).
4. **Edge / boundary** — an injected synthetic `NotFound` on the Gateway still skips (returns all-nil, no error), proving the branch keys on `apierrors.IsNotFound` (new).
5. **Concurrency** — N/A (placeholder comment): `findTunnelTargetedParentRef` is a pure per-call read with no shared mutable state; controller-runtime serializes reconciles per object via the workqueue.
6. **Security** — N/A (placeholder comment): this path performs no auth/secret/tenant-boundary handling.
7. **Regression** — the two "transient ... Get error propagates" subtests are the direct guard for #146.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass locally (Go 1.26). The `test/envtest` integration suite passed in this environment; maintainer CI should of course re-run it.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)