### PR TITLE
fix: tunnel source-controller reconciliation loop

### DIFF
--- a/internal/controller/tunnel/httproute_source_controller.go
+++ b/internal/controller/tunnel/httproute_source_controller.go
@@ -10,6 +10,7 @@ package tunnel
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -443,10 +444,9 @@ func hostnameMatchesListener(listenerHost, routeHost string) bool {
 // arbitrarily-old copy). This is the "merge-in-memory then full Update"
 // approach — preferred over SSA here for testability with the fake client.
 //
-// Identity match for parent entries: same Name AND same Namespace pointer
-// content (both nil, or both non-nil with equal strings). Section / Port
-// are ignored — a Route may pin one parent ref per controller without
-// ambiguity in practice.
+// Identity match for parent entries includes the controller name. Gateway API
+// permits multiple controllers to report status for the same parent reference;
+// each controller owns only its own RouteParentStatus entry.
 //
 // Returns any error from the final Status().Update so the caller can log it.
 func (r *HTTPRouteSourceReconciler) writeParentStatus(
@@ -463,10 +463,13 @@ func (r *HTTPRouteSourceReconciler) writeParentStatus(
 		return fmt.Errorf("re-fetch httproute for status write: %w", err)
 	}
 
-	// Find our existing entry (by parent identity) or append a new one.
+	// Find our existing entry (by parent identity and controller name) or
+	// append a new one. Other Gateway API controllers can report the same
+	// parent reference, so matching ParentRef alone would overwrite them.
 	idx := -1
 	for i := range live.Status.Parents {
-		if parentRefEquals(live.Status.Parents[i].ParentRef, parent) {
+		if live.Status.Parents[i].ControllerName == tunnelControllerName &&
+			parentRefEquals(live.Status.Parents[i].ParentRef, parent) {
 			idx = i
 			break
 		}
@@ -557,22 +560,11 @@ func (r *HTTPRouteSourceReconciler) writeParentStatus(
 	return r.Status().Update(ctx, &live)
 }
 
-// parentRefEquals matches two ParentReferences on Name + Namespace. Section
-// / Port are intentionally ignored — for the tunnel controller's purposes a
-// (Gateway, listener) pair is identified by (name, namespace) alone; the
-// design doesn't address per-section attachment.
+// parentRefEquals matches complete ParentReferences. A Route may attach to
+// multiple sections of the same Gateway, each of which has a distinct status
+// entry under Gateway API.
 func parentRefEquals(a, b gwv1.ParentReference) bool {
-	if a.Name != b.Name {
-		return false
-	}
-	switch {
-	case a.Namespace == nil && b.Namespace == nil:
-		return true
-	case a.Namespace != nil && b.Namespace != nil:
-		return *a.Namespace == *b.Namespace
-	default:
-		return false
-	}
+	return reflect.DeepEqual(a, b)
 }
 
 var _ reconcile.Reconciler = (*HTTPRouteSourceReconciler)(nil)

--- a/internal/controller/tunnel/httproute_source_controller_test.go
+++ b/internal/controller/tunnel/httproute_source_controller_test.go
@@ -203,34 +203,28 @@ func TestHTTPRouteSource_MultiParent_OnlyTunnelTargetedTouched(t *testing.T) {
 }
 
 // TestHTTPRouteSource_PreservesOtherParentStatusEntry verifies that when
-// another controller has already written a status entry for a NON-tunnel
-// parent, our reconcile does NOT clobber it. This is the production-shape
-// contract — multi-parent Routes accumulate status entries from each parent's
-// owning controller, and we touch only the tunnel-targeted parent's entry.
+// another controller has already reported the SAME tunnel-targeted parent,
+// our reconcile adds its own entry instead of clobbering the other controller.
 func TestHTTPRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 	gw := mkParentGw("gw", "gw-ns")
 	tn := &v2alpha1.CloudflareTunnel{
 		ObjectMeta: metav1.ObjectMeta{Name: "gw-ns-edge", Namespace: "gw-ns"},
 		Status:     v2alpha1.CloudflareTunnelStatus{TunnelID: "tnl-1", TunnelCNAME: "tnl-1.cfargotunnel.com"},
 	}
-	otherGw := &gwv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "other-gw", Namespace: "other-ns"},
-	}
 	gwSvc := mkGwSvc("gw-svc", "gw-ns")
 	rt := &gwv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "app"},
 		Spec: gwv1.HTTPRouteSpec{
 			Hostnames: []gwv1.Hostname{"x.example.com"},
-			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{
-				{Name: "other-gw", Namespace: ptrNs("other-ns")},
-				{Name: "gw", Namespace: ptrNs("gw-ns")},
-			}},
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{
+				Name: "gw", Namespace: ptrNs("gw-ns"),
+			}}},
 			Rules: []gwv1.HTTPRouteRule{{}},
 		},
 		Status: gwv1.HTTPRouteStatus{
 			RouteStatus: gwv1.RouteStatus{
 				Parents: []gwv1.RouteParentStatus{{
-					ParentRef:      gwv1.ParentReference{Name: "other-gw", Namespace: ptrNs("other-ns")},
+					ParentRef:      gwv1.ParentReference{Name: "gw", Namespace: ptrNs("gw-ns")},
 					ControllerName: gwv1.GatewayController("other.io/other-controller"),
 					Conditions: []metav1.Condition{{
 						Type:               "Accepted",
@@ -242,7 +236,7 @@ func TestHTTPRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 			},
 		},
 	}
-	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
+	base := fake.NewClientBuilder().WithScheme(rtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
 		WithStatusSubresource(&gwv1.HTTPRoute{}, &v2alpha1.CloudflareDNSRecord{}).Build()
 	c := reconcilelib.SSATranslatingClient(t, base)
 
@@ -252,20 +246,20 @@ func TestHTTPRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 
 	var got gwv1.HTTPRoute
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "app", Name: "r"}, &got))
-	// Both entries present: the pre-existing other-controller's entry AND our new entry.
+	// Both entries have the same parent reference but distinct owning controllers.
 	require.Len(t, got.Status.Parents, 2)
 
 	var foundOther, foundOurs bool
 	for _, ps := range got.Status.Parents {
-		if ps.ParentRef.Name == "other-gw" {
+		if ps.ControllerName == "other.io/other-controller" {
 			foundOther = true
-			require.Equal(t, gwv1.GatewayController("other.io/other-controller"), ps.ControllerName)
+			require.Equal(t, gwv1.ObjectName("gw"), ps.ParentRef.Name)
 			require.NotEmpty(t, ps.Conditions)
 			require.Equal(t, "OtherReason", ps.Conditions[0].Reason, "other-controller's reason preserved")
 		}
-		if ps.ParentRef.Name == "gw" {
+		if ps.ControllerName == tunnelControllerName {
 			foundOurs = true
-			require.Equal(t, gwv1.GatewayController("cloudflare.io/tunnel-controller"), ps.ControllerName)
+			require.Equal(t, gwv1.ObjectName("gw"), ps.ParentRef.Name)
 		}
 	}
 	require.True(t, foundOther, "other-controller parent entry must be preserved")

--- a/internal/controller/tunnel/setup.go
+++ b/internal/controller/tunnel/setup.go
@@ -22,9 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -55,6 +57,10 @@ type Options struct {
 	// CRs by the source reconcilers. Empty fields fall back to internal
 	// defaults (Replicas=2, Protocol="auto", LogLevel="info", GracePeriod=30s).
 	DefaultConnector v2alpha1.ConnectorSpec
+}
+
+func sourceDNSRecordPredicate() predicate.Predicate {
+	return predicate.GenerationChangedPredicate{}
 }
 
 // tlsRouteSupported reports whether the gateway-api TLSRoute kind is served
@@ -180,7 +186,7 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named("service-source").
 		For(&corev1.Service{}).
-		Owns(&v2alpha1.CloudflareDNSRecord{}).
+		Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
 		Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToServices(mgr))).
 		Complete(svcR); err != nil {
 		return fmt.Errorf("setup ServiceSource: %w", err)
@@ -204,7 +210,7 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named("gateway-source").
 		For(&gwv1.Gateway{}).
-		Owns(&v2alpha1.CloudflareDNSRecord{}).
+		Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
 		Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToGateways(mgr))).
 		Complete(gwR); err != nil {
 		return fmt.Errorf("setup GatewaySource: %w", err)
@@ -224,7 +230,7 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named("httproute-source").
 		For(&gwv1.HTTPRoute{}).
-		Owns(&v2alpha1.CloudflareDNSRecord{}).
+		Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
 		Watches(&gwv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToHTTPRoutes(mgr))).
 		Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToHTTPRoutes(mgr))).
 		Complete(httpR); err != nil {
@@ -246,7 +252,7 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 		if err := ctrl.NewControllerManagedBy(mgr).
 			Named("tlsroute-source").
 			For(&gwv1a2.TLSRoute{}).
-			Owns(&v2alpha1.CloudflareDNSRecord{}).
+			Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
 			Watches(&gwv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToTLSRoutes(mgr))).
 			Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToTLSRoutes(mgr))).
 			Complete(tlsR); err != nil {

--- a/internal/controller/tunnel/setup.go
+++ b/internal/controller/tunnel/setup.go
@@ -63,6 +63,13 @@ func sourceDNSRecordPredicate() predicate.Predicate {
 	return predicate.GenerationChangedPredicate{}
 }
 
+func sourceObjectPredicate() predicate.Predicate {
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.AnnotationChangedPredicate{},
+	)
+}
+
 // tlsRouteSupported reports whether the gateway-api TLSRoute kind is served
 // by the cluster (it lives only in the gateway-api EXPERIMENTAL channel).
 // (false, nil) => CRD genuinely absent (degrade gracefully). (false, err)
@@ -185,7 +192,7 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 	}
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named("service-source").
-		For(&corev1.Service{}).
+		For(&corev1.Service{}, builder.WithPredicates(sourceObjectPredicate())).
 		Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
 		Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToServices(mgr))).
 		Complete(svcR); err != nil {
@@ -209,7 +216,7 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 	}
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named("gateway-source").
-		For(&gwv1.Gateway{}).
+		For(&gwv1.Gateway{}, builder.WithPredicates(sourceObjectPredicate())).
 		Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
 		Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToGateways(mgr))).
 		Complete(gwR); err != nil {
@@ -229,9 +236,9 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 	}
 	if err := ctrl.NewControllerManagedBy(mgr).
 		Named("httproute-source").
-		For(&gwv1.HTTPRoute{}).
+		For(&gwv1.HTTPRoute{}, builder.WithPredicates(sourceObjectPredicate())).
 		Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
-		Watches(&gwv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToHTTPRoutes(mgr))).
+		Watches(&gwv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToHTTPRoutes(mgr)), builder.WithPredicates(sourceObjectPredicate())).
 		Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToHTTPRoutes(mgr))).
 		Complete(httpR); err != nil {
 		return fmt.Errorf("setup HTTPRouteSource: %w", err)
@@ -251,9 +258,9 @@ func AddToManager(mgr ctrl.Manager, opts Options) error {
 		}
 		if err := ctrl.NewControllerManagedBy(mgr).
 			Named("tlsroute-source").
-			For(&gwv1a2.TLSRoute{}).
+			For(&gwv1a2.TLSRoute{}, builder.WithPredicates(sourceObjectPredicate())).
 			Owns(&v2alpha1.CloudflareDNSRecord{}, builder.WithPredicates(sourceDNSRecordPredicate())).
-			Watches(&gwv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToTLSRoutes(mgr))).
+			Watches(&gwv1.Gateway{}, handler.EnqueueRequestsFromMapFunc(gatewayToTLSRoutes(mgr)), builder.WithPredicates(sourceObjectPredicate())).
 			Watches(&v2alpha1.CloudflareTunnel{}, handler.EnqueueRequestsFromMapFunc(tunnelToTLSRoutes(mgr))).
 			Complete(tlsR); err != nil {
 			return fmt.Errorf("setup TLSRouteSource: %w", err)

--- a/internal/controller/tunnel/setup_test.go
+++ b/internal/controller/tunnel/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -49,6 +50,19 @@ func TestAddToManager_DefaultConnectorResourcesPassthrough(t *testing.T) {
 	applyOptionDefaults(&opts)
 	require.Equal(t, want, opts.DefaultConnector.Resources)
 	require.Equal(t, int32(2), opts.DefaultConnector.Replicas) // scalar defaulting still applies
+}
+
+func TestSourceDNSRecordPredicate(t *testing.T) {
+	predicate := sourceDNSRecordPredicate()
+	record := &v2alpha1.CloudflareDNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}}
+
+	require.True(t, predicate.Create(event.CreateEvent{Object: record}))
+	require.True(t, predicate.Delete(event.DeleteEvent{Object: record}))
+	require.False(t, predicate.Update(event.UpdateEvent{ObjectOld: record, ObjectNew: record.DeepCopy()}))
+
+	updated := record.DeepCopy()
+	updated.Generation = 2
+	require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: record, ObjectNew: updated}))
 }
 
 // mapFuncScheme registers the types needed by the tunnelTo* MapFuncs in unit

--- a/internal/controller/tunnel/setup_test.go
+++ b/internal/controller/tunnel/setup_test.go
@@ -65,6 +65,23 @@ func TestSourceDNSRecordPredicate(t *testing.T) {
 	require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: record, ObjectNew: updated}))
 }
 
+func TestSourceObjectPredicate(t *testing.T) {
+	predicate := sourceObjectPredicate()
+	object := &v2alpha1.CloudflareDNSRecord{ObjectMeta: metav1.ObjectMeta{Generation: 1}}
+
+	require.True(t, predicate.Create(event.CreateEvent{Object: object}))
+	require.True(t, predicate.Delete(event.DeleteEvent{Object: object}))
+	require.False(t, predicate.Update(event.UpdateEvent{ObjectOld: object, ObjectNew: object.DeepCopy()}))
+
+	annotationChanged := object.DeepCopy()
+	annotationChanged.Annotations = map[string]string{"cloudflare.io/tunnel": "true"}
+	require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: object, ObjectNew: annotationChanged}))
+
+	specChanged := object.DeepCopy()
+	specChanged.Generation = 2
+	require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: object, ObjectNew: specChanged}))
+}
+
 // mapFuncScheme registers the types needed by the tunnelTo* MapFuncs in unit
 // tests: CloudflareTunnel (the obj arg), HTTPRoute, and TLSRoute (the listed
 // types).

--- a/internal/controller/tunnel/tlsroute_source_controller.go
+++ b/internal/controller/tunnel/tlsroute_source_controller.go
@@ -315,10 +315,13 @@ func (r *TLSRouteSourceReconciler) writeParentStatus(
 		return fmt.Errorf("re-fetch tlsroute for status write: %w", err)
 	}
 
-	// Find our existing entry (by parent identity) or append a new one.
+	// Find our existing entry (by parent identity and controller name) or
+	// append a new one. Other Gateway API controllers can report the same
+	// parent reference, so matching ParentRef alone would overwrite them.
 	idx := -1
 	for i := range live.Status.Parents {
-		if parentRefEquals(live.Status.Parents[i].ParentRef, parent) {
+		if live.Status.Parents[i].ControllerName == tunnelControllerName &&
+			parentRefEquals(live.Status.Parents[i].ParentRef, parent) {
 			idx = i
 			break
 		}

--- a/internal/controller/tunnel/tlsroute_source_controller_test.go
+++ b/internal/controller/tunnel/tlsroute_source_controller_test.go
@@ -243,32 +243,27 @@ func TestTLSRouteSource_MultiParent_OnlyTunnelTargetedTouched(t *testing.T) {
 }
 
 // TestTLSRouteSource_PreservesOtherParentStatusEntry verifies that when
-// another controller has already written a status entry for a NON-tunnel
-// parent, our reconcile does NOT clobber it. Mirror of T12's regression test
-// against the parent-only-status-write contract (§4.2 / Q3 lock).
+// another controller has already reported the SAME tunnel-targeted parent,
+// our reconcile adds its own entry instead of clobbering the other controller.
 func TestTLSRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 	gw := mkTLSParentGw("gw", "gw-ns")
 	tn := &v2alpha1.CloudflareTunnel{
 		ObjectMeta: metav1.ObjectMeta{Name: "gw-ns-edge", Namespace: "gw-ns"},
 		Status:     v2alpha1.CloudflareTunnelStatus{TunnelID: "tnl-1", TunnelCNAME: "tnl-1.cfargotunnel.com"},
 	}
-	otherGw := &gwv1.Gateway{
-		ObjectMeta: metav1.ObjectMeta{Name: "other-gw", Namespace: "other-ns"},
-	}
 	gwSvc := mkTLSGwSvc("gw-svc", "gw-ns")
 	rt := &gwv1a2.TLSRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "app"},
 		Spec: gwv1a2.TLSRouteSpec{
 			Hostnames: []gwv1.Hostname{"x.example.com"},
-			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{
-				{Name: "other-gw", Namespace: ptrNs("other-ns")},
-				{Name: "gw", Namespace: ptrNs("gw-ns")},
-			}},
+			CommonRouteSpec: gwv1.CommonRouteSpec{ParentRefs: []gwv1.ParentReference{{
+				Name: "gw", Namespace: ptrNs("gw-ns"),
+			}}},
 		},
 		Status: gwv1a2.TLSRouteStatus{
 			RouteStatus: gwv1.RouteStatus{
 				Parents: []gwv1.RouteParentStatus{{
-					ParentRef:      gwv1.ParentReference{Name: "other-gw", Namespace: ptrNs("other-ns")},
+					ParentRef:      gwv1.ParentReference{Name: "gw", Namespace: ptrNs("gw-ns")},
 					ControllerName: gwv1.GatewayController("other.io/other-controller"),
 					Conditions: []metav1.Condition{{
 						Type:               "Accepted",
@@ -280,7 +275,7 @@ func TestTLSRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 			},
 		},
 	}
-	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, otherGw, tn, gwSvc, rt).
+	base := fake.NewClientBuilder().WithScheme(tlsRtScheme(t)).WithObjects(gw, tn, gwSvc, rt).
 		WithStatusSubresource(&gwv1a2.TLSRoute{}, &v2alpha1.CloudflareDNSRecord{}).Build()
 	c := reconcilelib.SSATranslatingClient(t, base)
 
@@ -294,15 +289,15 @@ func TestTLSRouteSource_PreservesOtherParentStatusEntry(t *testing.T) {
 
 	var foundOther, foundOurs bool
 	for _, ps := range got.Status.Parents {
-		if ps.ParentRef.Name == "other-gw" {
+		if ps.ControllerName == "other.io/other-controller" {
 			foundOther = true
-			require.Equal(t, gwv1.GatewayController("other.io/other-controller"), ps.ControllerName)
+			require.Equal(t, gwv1.ObjectName("gw"), ps.ParentRef.Name)
 			require.NotEmpty(t, ps.Conditions)
 			require.Equal(t, "OtherReason", ps.Conditions[0].Reason)
 		}
-		if ps.ParentRef.Name == "gw" {
+		if ps.ControllerName == tunnelControllerName {
 			foundOurs = true
-			require.Equal(t, gwv1.GatewayController("cloudflare.io/tunnel-controller"), ps.ControllerName)
+			require.Equal(t, gwv1.ObjectName("gw"), ps.ParentRef.Name)
 		}
 	}
 	require.True(t, foundOther, "other-controller parent entry must be preserved")


### PR DESCRIPTION
Fixes #156

The tunnel source controllers could form a feedback loop with Gateway API controllers:

- Generated `CloudflareDNSRecord` status updates re-enqueued their source and caused another SSA apply.
- `HTTPRoute` and `TLSRoute` parent status entries were matched only by `ParentRef`, allowing the tunnel controller to overwrite another controller's status for the same parent.
- Status-only updates to source Routes and Gateways still re-enqueued the source controllers, which reapplied generated DNS records.

This change:

- Filters status-only updates on generated DNSRecord ownership watches.
- Preserves a distinct `RouteParentStatus` entry per complete `ParentRef` and `ControllerName`.
- Filters status-only updates on source-object and Gateway fan-out watches while retaining create/delete, spec, annotation, and CloudflareTunnel status triggers.

Validation:

- `go test ./internal/controller/tunnel` (314 tests)
- Broader Go test selection for `./api/v2alpha1`, `./cmd/manager`, and `./internal`
- Live cluster validation with the test image: stable HTTPRoute resource versions, zero Cilium route enqueues over 30 seconds, zero previously hot API write series, and kube-apiserver CPU returned to baseline.