### PR TITLE
test(envtest): fix the two intermittent CI flakes at the harness layer

### DIFF
--- a/test/envtest/dnsrecord_txt_registry_test.go
+++ b/test/envtest/dnsrecord_txt_registry_test.go
@@ -150,7 +150,7 @@ func newTxtRegistryHarness(t *testing.T) (context.Context, *mock.Mock, client.Cl
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/dnsrecord_txt_registry_test.go
+++ b/test/envtest/dnsrecord_txt_registry_test.go
@@ -81,6 +81,10 @@ func newTxtRegistryHarness(t *testing.T) (context.Context, *mock.Mock, client.Cl
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/gateway_source_envtest_test.go
+++ b/test/envtest/gateway_source_envtest_test.go
@@ -110,7 +110,7 @@ func setupGatewayEnv(t *testing.T, nsName string) *gatewayEnvFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/gateway_source_envtest_test.go
+++ b/test/envtest/gateway_source_envtest_test.go
@@ -58,6 +58,10 @@ func setupGatewayEnv(t *testing.T, nsName string) *gatewayEnvFixture {
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 	utilruntime.Must(gwv1.Install(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/httproute_source_envtest_test.go
+++ b/test/envtest/httproute_source_envtest_test.go
@@ -57,6 +57,10 @@ func setupHTTPRouteEnv(t *testing.T) *httpRouteEnvFixture {
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 	utilruntime.Must(gwv1.Install(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/httproute_source_envtest_test.go
+++ b/test/envtest/httproute_source_envtest_test.go
@@ -129,7 +129,7 @@ func setupHTTPRouteEnv(t *testing.T) *httpRouteEnvFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/service_source_envtest_test.go
+++ b/test/envtest/service_source_envtest_test.go
@@ -122,7 +122,7 @@ func setupServiceEnv(t *testing.T, nsName string) *serviceEnvFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/service_source_envtest_test.go
+++ b/test/envtest/service_source_envtest_test.go
@@ -62,6 +62,10 @@ func setupServiceEnv(t *testing.T, nsName string) *serviceEnvFixture {
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/source_status_gate_test.go
+++ b/test/envtest/source_status_gate_test.go
@@ -136,6 +136,10 @@ func setupStatusGateHTTPEnv(t *testing.T) *statusGateFixture {
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 	utilruntime.Must(gwv1.Install(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},
@@ -221,6 +225,10 @@ func setupStatusGateTLSEnv(t *testing.T) *statusGateFixture {
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 	utilruntime.Must(gwv1.Install(sch))
 	utilruntime.Must(gwv1a2.Install(sch))
+
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
 
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,

--- a/test/envtest/source_status_gate_test.go
+++ b/test/envtest/source_status_gate_test.go
@@ -199,7 +199,7 @@ func setupStatusGateHTTPEnv(t *testing.T) *statusGateFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()
@@ -289,7 +289,7 @@ func setupStatusGateTLSEnv(t *testing.T) *statusGateFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()
@@ -368,7 +368,7 @@ func createGatewayForGateTest(t *testing.T, f *statusGateFixture, listenerProto 
 		},
 		Spec: gwv1.GatewaySpec{
 			GatewayClassName: "any-class",
-			Listeners: []gwv1.Listener{listenerForProto(&h, port, listenerProto)},
+			Listeners:        []gwv1.Listener{listenerForProto(&h, port, listenerProto)},
 		},
 	}
 	require.NoError(t, f.c.Create(ctx, gw))

--- a/test/envtest/suite_test.go
+++ b/test/envtest/suite_test.go
@@ -24,6 +24,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -160,6 +161,29 @@ func purgeCloudflareCRs(t *testing.T) {
 		}
 		return true
 	}, 30*time.Second, 50*time.Millisecond, "cloudflare.io CRs from an earlier test never cleared")
+}
+
+// startManager runs mgr and blocks the test's cleanup until it has fully
+// stopped. Use it instead of a bare `go mgr.Start(ctx)`.
+//
+// Cancelling a manager's context does not stop it synchronously — Start returns
+// only once its workers have drained. A test that does not wait therefore leaves
+// controllers reconciling after it has returned, and the source controllers emit
+// CloudflareDNSRecord CRs, so a straggler can repopulate the cluster that the
+// next test just purged. Owning the cancel here keeps this independent of the
+// caller's other t.Cleanup ordering.
+func startManager(t *testing.T, parent context.Context, mgr ctrl.Manager) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = mgr.Start(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 }
 
 func TestMain(m *testing.M) {

--- a/test/envtest/suite_test.go
+++ b/test/envtest/suite_test.go
@@ -8,14 +8,18 @@ full license text.
 package envtest_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -40,7 +44,7 @@ var sharedScheme *runtime.Scheme
 // build their own managers (e.g. zone bundle wiring with mock-backed clients).
 var sharedConfig *rest.Config
 
-// resolveGatewayAPICRDPaths returns the gateway-api CRD directories from the
+// resolveGatewayAPICRDPaths returns the gateway-api CRD directory from the
 // local Go module cache, keyed by the sigs.k8s.io/gateway-api version pinned
 // in this repo's go.mod. Returns an error if `go list -m` fails — a hard
 // prerequisite that we surface clearly rather than silently skipping the
@@ -54,14 +58,20 @@ var sharedConfig *rest.Config
 // versions (observed empty under this repo's `make test` invocation, even
 // though the build resolved the gateway-api dependency cleanly).
 //
-// The Standard channel ships Gateway, HTTPRoute, GatewayClass, GRPCRoute, and
-// ReferenceGrant. TLSRoute (v1alpha2) lives only in the experimental channel,
-// so we install BOTH directories. The experimental channel is a superset of
-// Standard for the CRDs we install — envtest tolerates duplicate CRD declarations
-// across paths because each CRD's Kubernetes object is name-keyed and applied
-// idempotently. The experimental directory also ships TCPRoute / UDPRoute /
-// GRPCRoute / ReferenceGrant / BackendLBPolicy / BackendTLSPolicy — none of
-// which the reconcilers touch, but installing them is harmless.
+// We install ONLY the Experimental channel, never Standard alongside it.
+// Experimental is a strict superset: it ships every CRD Standard does (same
+// names) and serves a superset of their versions, plus TCPRoute / UDPRoute and
+// the x-k8s.io CRDs. Installing both directories is actively unsafe, because
+// the two channels declare the SAME CRD names with different served versions
+// (Standard's tlsroutes serves v1 only; Experimental's serves v1 + v1alpha2 +
+// v1alpha3). envtest resolves such duplicates as "last path wins", and
+// envtest.Environment.Start pushes CRDDirectoryPaths through mergePaths, which
+// launders them through a Go map and so randomizes their order on every run.
+// Passing both channels therefore installed the Standard tlsroutes — with
+// v1alpha2 NOT served — in a random ~1-in-4 of runs, permanently removing the
+// gateway.networking.k8s.io/v1alpha2 group-version and failing every TLSRoute
+// test with `no matches for kind "TLSRoute"`. One directory, no duplicate
+// names, no order dependence.
 func resolveGatewayAPICRDPaths() ([]string, error) {
 	listOut, err := exec.Command("go", "list", "-m", "-json", "sigs.k8s.io/gateway-api").Output()
 	if err != nil {
@@ -88,11 +98,68 @@ func resolveGatewayAPICRDPaths() ([]string, error) {
 		return nil, fmt.Errorf("sigs.k8s.io/gateway-api module Dir empty (cache hydrated?)")
 	}
 
-	base := filepath.Join(dir, "config", "crd")
-	return []string{
-		filepath.Join(base, "standard"),
-		filepath.Join(base, "experimental"),
-	}, nil
+	return []string{filepath.Join(dir, "config", "crd", "experimental")}, nil
+}
+
+// purgeCloudflareCRs deletes every cloudflare.io CR in the shared apiserver and
+// blocks until they are gone. Call it before building a test's manager, so each
+// test starts against an empty cluster.
+//
+// The whole package shares ONE envtest apiserver, and envtest runs no namespace
+// GC — so a test's CRs outlive it. Every test manager watches cluster-wide, so
+// without this a later test's controllers pick up earlier tests' abandoned CRs
+// and reconcile them against the later test's mock, creating and deleting
+// records in it. That is how the zone bundle's §10.4 lost the TXT companion it
+// had just seeded: adoption is then refused permanently by design (never
+// backfill a TXT for a pre-existing record), so Status.RecordID stays empty and
+// the assertion can never pass — no matter how long it waits.
+//
+// Finalizers are stripped first: the manager that owned these CRs is gone, so
+// nothing is left to remove them and Delete would block forever.
+func purgeCloudflareCRs(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Fresh list objects per pass — List does not clear a previous result.
+	lists := func() []client.ObjectList {
+		return []client.ObjectList{
+			&v2alpha1.CloudflareDNSRecordList{},
+			&v2alpha1.CloudflareTunnelList{},
+			&v2alpha1.CloudflareZoneList{},
+			&v2alpha1.CloudflareZoneConfigList{},
+			&v2alpha1.CloudflareRulesetList{},
+		}
+	}
+
+	for _, l := range lists() {
+		require.NoError(t, sharedClient.List(ctx, l))
+		objs, err := apimeta.ExtractList(l)
+		require.NoError(t, err)
+		for _, o := range objs {
+			obj, ok := o.(client.Object)
+			if !ok {
+				continue
+			}
+			if len(obj.GetFinalizers()) > 0 {
+				obj.SetFinalizers(nil)
+				_ = sharedClient.Update(ctx, obj)
+			}
+			_ = sharedClient.Delete(ctx, obj)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		for _, l := range lists() {
+			if err := sharedClient.List(ctx, l); err != nil {
+				return false
+			}
+			objs, err := apimeta.ExtractList(l)
+			if err != nil || len(objs) > 0 {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 50*time.Millisecond, "cloudflare.io CRs from an earlier test never cleared")
 }
 
 func TestMain(m *testing.M) {
@@ -103,16 +170,11 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	// Resolve the gateway-api CRD paths from the Go module cache so the envtest
-	// API server can install Gateway / HTTPRoute / TLSRoute CRDs without
-	// vendoring them into the repo. The Standard channel ships Gateway +
-	// HTTPRoute; the Experimental channel ships TLSRoute (v1alpha2). Both
-	// directories are installed — see resolveGatewayAPICRDPaths. Resolution
-	// sources:
-	//   - $GOMODCACHE (via `go env GOMODCACHE`) — the local module cache root.
-	//   - sigs.k8s.io/gateway-api version (via runtime/debug.ReadBuildInfo) —
-	//     the version actually compiled into the test binary, so the CRDs on
-	//     disk match the Go types in scope. No risk of skew with go.mod.
+	// Resolve the gateway-api CRD directory from the Go module cache so the
+	// envtest API server can install Gateway / HTTPRoute / TLSRoute CRDs without
+	// vendoring them into the repo. Only the Experimental channel is installed —
+	// see resolveGatewayAPICRDPaths for why installing Standard alongside it is
+	// unsafe.
 	gwCRDPaths, err := resolveGatewayAPICRDPaths()
 	if err != nil {
 		panic("resolve gateway-api CRD paths: " + err.Error())

--- a/test/envtest/tlsroute_source_envtest_test.go
+++ b/test/envtest/tlsroute_source_envtest_test.go
@@ -131,7 +131,7 @@ func setupTLSRouteEnv(t *testing.T) *tlsRouteEnvFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/tlsroute_source_envtest_test.go
+++ b/test/envtest/tlsroute_source_envtest_test.go
@@ -61,6 +61,10 @@ func setupTLSRouteEnv(t *testing.T) *tlsRouteEnvFixture {
 	utilruntime.Must(gwv1.Install(sch))
 	utilruntime.Must(gwv1a2.Install(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/tunnel_concurrency_envtest_test.go
+++ b/test/envtest/tunnel_concurrency_envtest_test.go
@@ -35,6 +35,10 @@ func TestEnvtest_AddToManager_AppliesConcurrency(t *testing.T) {
 	utilruntime.Must(gwv1.Install(sch))
 	utilruntime.Must(gwv1a2.Install(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/tunnel_dataplane_hash_test.go
+++ b/test/envtest/tunnel_dataplane_hash_test.go
@@ -128,7 +128,7 @@ func setupDataplaneHashEnv(t *testing.T) (client.Client, *dataplaneCountingClien
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/tunnel_dataplane_hash_test.go
+++ b/test/envtest/tunnel_dataplane_hash_test.go
@@ -98,6 +98,10 @@ func setupDataplaneHashEnv(t *testing.T) (client.Client, *dataplaneCountingClien
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/tunnel_envtest_test.go
+++ b/test/envtest/tunnel_envtest_test.go
@@ -98,7 +98,7 @@ func setupTunnelEnv(t *testing.T) *tunnelEnvFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/tunnel_envtest_test.go
+++ b/test/envtest/tunnel_envtest_test.go
@@ -66,6 +66,10 @@ func setupTunnelEnv(t *testing.T) *tunnelEnvFixture {
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/tunnel_route_enqueue_test.go
+++ b/test/envtest/tunnel_route_enqueue_test.go
@@ -76,6 +76,10 @@ func setupTunnelRouteHTTPEnv(t *testing.T) *tunnelRouteEnqueueFixture {
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 	utilruntime.Must(gwv1.Install(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},
@@ -133,6 +137,10 @@ func setupTunnelRouteTLSEnv(t *testing.T) *tunnelRouteEnqueueFixture {
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 	utilruntime.Must(gwv1.Install(sch))
 	utilruntime.Must(gwv1a2.Install(sch))
+
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
 
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,

--- a/test/envtest/tunnel_route_enqueue_test.go
+++ b/test/envtest/tunnel_route_enqueue_test.go
@@ -111,7 +111,7 @@ func setupTunnelRouteHTTPEnv(t *testing.T) *tunnelRouteEnqueueFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()
@@ -169,7 +169,7 @@ func setupTunnelRouteTLSEnv(t *testing.T) *tunnelRouteEnqueueFixture {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	syncCtx, syncCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer syncCancel()

--- a/test/envtest/zone_test.go
+++ b/test/envtest/zone_test.go
@@ -46,6 +46,10 @@ func TestZoneBundle_EnvtestAcceptance(t *testing.T) {
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(v2alpha1.AddToScheme(sch))
 
+	// Start from an empty cluster: earlier tests' CRs outlive them in the
+	// shared apiserver and every manager watches cluster-wide.
+	purgeCloudflareCRs(t)
+
 	mgr, err := ctrl.NewManager(sharedConfig, ctrl.Options{
 		Scheme:  sch,
 		Metrics: metricsserver.Options{BindAddress: "0"},

--- a/test/envtest/zone_test.go
+++ b/test/envtest/zone_test.go
@@ -107,7 +107,7 @@ func TestZoneBundle_EnvtestAcceptance(t *testing.T) {
 		Complete(rsR))
 
 	ctx := t.Context()
-	go func() { _ = mgr.Start(ctx) }()
+	startManager(t, ctx, mgr)
 
 	// Block until the manager's informer cache is populated; mgr.GetClient()
 	// returns a cached reader and `the cache is not started` errors until


### PR DESCRIPTION
Fixes both envtest flakes that have been making CI close to a coin-flip. **Both were harness bugs — no test assertion, timeout, or skip was changed.**

## Flake 1 — TLSRoute `no matches for kind` (~1 run in 8)

`envtest.Environment.Start` passes `CRDDirectoryPaths` through `mergePaths`, which launders them through a Go map — its own doc comment says it *"makes no guarantees about order of the merged slice"*. `renderCRDs` then resolves same-named CRDs as *"the definition that we found last"*.

gateway-api ships `tlsroutes.gateway.networking.k8s.io` in **both** channels with different served versions:

| channel | served |
|---|---|
| `config/crd/standard` | `v1` only — **v1alpha2 served=false** |
| `config/crd/experimental` | `v1`, `v1alpha2`, `v1alpha3` |

So the winner was decided by random map-iteration order. When Standard landed last, the `gateway.networking.k8s.io/v1alpha2` group-version never existed at all and every TLSRoute test failed — for the whole run, which is why all five failed together.

**Fix:** install only the Experimental channel. It is a strict superset of Standard (verified for both v1.5.1 and v1.6.0: identical CRD name set, superset of served versions), so nothing is lost — and with one directory there are no duplicate names left to race.

This was never Linux-specific; it reproduces on darwin at the same rate. The bad draw happens once per process at `TestMain`, so `-count=N` can't re-draw it — you have to re-exec the binary.

## Flake 2 — §10.4 TXT-adoption `Condition never satisfied`

The package shares **one** apiserver and envtest runs no namespace GC, so every CR outlives the test that created it. Every test builds its own manager with a **cluster-wide** watch. `TestZoneBundle_EnvtestAcceptance` runs last, so its controllers picked up dozens of abandoned CRs from earlier tests and reconciled them against **its own mock** — controller logs show the zone test's `cloudflarednsrecord` controller doing `deleted DNS record on Cloudflare {txtr-obs-to-mgd-rec}` and `created DNS record {ext-example-com-…}`.

That clobbers the TXT companion §10.4 seeds. Adoption is then refused *permanently* by design (never backfill a TXT for a pre-existing record — the load-bearing safety property), so `Status.RecordID` stays empty forever. **That is why bumping the timeout 30s → 120s never helped: the condition can never become true, no matter how long you wait.**

**Fix (2 parts):**
1. `purgeCloudflareCRs` — drop all `cloudflare.io` CRs before each test builds its manager, so every test starts against an empty cluster.
2. `startManager` — actually wait for a test's manager to stop before the next test runs. Cancelling a manager's context does not stop it synchronously, and no fixture waited. Since the source controllers *emit* `CloudflareDNSRecord` CRs, a still-draining manager could repopulate the cluster right after the next test purged it, reviving the same bug.

## Evidence

Reproduced locally and measured — a single green run proves nothing here, since the suite already passed most of the time.

| | before | after |
|---|---|---|
| Flake 1 — 28 separate processes | 3 failed | **0 failed** |
| Flake 2 — `GOMAXPROCS=4 go test -race` (the condition that reproduces it) | 2 of 3 failed | **6 of 6 passed** |
| full `make test` | — | green |

Reproduction recipe for Flake 2, for the record: `GOMAXPROCS=4 go test ./test/envtest/ -race`. It does *not* reproduce with free CPU, and it does *not* reproduce running the zone test alone — the whole suite has to run first to accumulate the orphaned CRs.

Side benefit: the envtest suite got ~2x faster (**~230s → ~124s**) since it no longer churns through orphaned CRs on every manager start.

## Known gap (not addressed here)

`test/envtest` never calls `logf.SetLogger`, so controller-runtime discards **all** controller logs — which is why these CI failures carried zero diagnostics. Temporarily adding it is what made Flake 2's cause visible. Worth adding as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)